### PR TITLE
Make local seed idempotent and keep database data between restarts

### DIFF
--- a/ticketing-backend/SEED_Y_PERSISTENCIA.md
+++ b/ticketing-backend/SEED_Y_PERSISTENCIA.md
@@ -1,0 +1,48 @@
+# Seed local y persistencia de datos
+
+## Objetivo
+Tener datos base al arrancar en local (usuario, agente y categoría), pero que **los datos persistan** entre reinicios.
+
+## Cómo funciona ahora
+- `LocalSeedRunner` solo se ejecuta en perfil `local`.
+- Inserta datos base **solo si no existen**:
+  - categoría `General`
+  - usuario `user@local.test`
+  - agente `agent@local.test`
+- La comprobación de usuarios se hace por email (`findByEmailIgnoreCase`) para no chocar con el índice único de email.
+
+## Persistencia entre reinicios
+`docker-compose.yml` ya monta un volumen nombrado (`ticketing_pgdata`) para PostgreSQL.
+Si no eliminas ese volumen, los datos permanecen.
+
+## Script `run.ps1`
+El script ahora conserva la base de datos por defecto.
+
+- Arranque normal (conserva datos):
+  ```powershell
+  .\run.ps1
+  ```
+
+- Arranque con limpieza total de base de datos:
+  ```powershell
+  .\run.ps1 -ResetDatabase
+  ```
+
+## Insertar usuarios manualmente y poder hacer login
+Para que un usuario creado manualmente pueda iniciar sesión, su `password_hash` debe ser BCrypt.
+
+Ejemplo SQL (password en claro: `secret123`):
+
+```sql
+INSERT INTO users (id, email, display_name, role, is_active, password_hash)
+VALUES (
+  gen_random_uuid(),
+  'nuevo@local.test',
+  'Nuevo Usuario',
+  'USER',
+  true,
+  '$2a$10$8E7Mzy8M2Q0dQkN4kD7a3eN9WQfN3st9sSk6cZy4xkS9t2C5K8E4i'
+);
+```
+
+> Nota: el hash de ejemplo es ilustrativo. Genera un hash BCrypt real para la contraseña que quieras usar.

--- a/ticketing-backend/run.ps1
+++ b/ticketing-backend/run.ps1
@@ -1,9 +1,18 @@
-# Script para reiniciar la aplicación con base de datos limpia
-Write-Host "=== Reiniciando Ticketing Backend ===" -ForegroundColor Cyan
+param(
+    [switch]$ResetDatabase
+)
 
-# 1. Detener contenedores y limpiar volúmenes
+# Script para iniciar la aplicación. La base de datos se conserva por defecto.
+Write-Host "=== Iniciando Ticketing Backend ===" -ForegroundColor Cyan
+
+# 1. Detener contenedores (sin borrar volumen por defecto)
 Write-Host "`n[1/5] Deteniendo contenedores Docker..." -ForegroundColor Yellow
-docker compose down -v 2>$null
+if ($ResetDatabase) {
+    Write-Host "    ResetDatabase activado: se eliminará el volumen de PostgreSQL" -ForegroundColor DarkYellow
+    docker compose down -v 2>$null
+} else {
+    docker compose down 2>$null
+}
 
 # 2. Iniciar PostgreSQL
 Write-Host "[2/5] Iniciando PostgreSQL..." -ForegroundColor Yellow
@@ -39,4 +48,3 @@ Write-Host "Presiona Ctrl+C para detener la aplicación`n" -ForegroundColor Gray
 
 $env:SPRING_PROFILES_ACTIVE = "local"
 .\mvnw.cmd spring-boot:run
-

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/seed/LocalSeedRunner.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/seed/LocalSeedRunner.java
@@ -36,7 +36,7 @@ public class LocalSeedRunner implements CommandLineRunner {
             categoryRepo.save(new CategoryJpaEntity(CATEGORY_ID, "General", true));
         }
 
-        if (userRepo.findById(USER_ID).isEmpty()) {
+        if (userRepo.findByEmailIgnoreCase("user@local.test").isEmpty()) {
             userRepo.save(new UserJpaEntity(
                     USER_ID,
                     "user@local.test",
@@ -47,7 +47,7 @@ public class LocalSeedRunner implements CommandLineRunner {
             ));
         }
 
-        if (userRepo.findById(AGENT_ID).isEmpty()) {
+        if (userRepo.findByEmailIgnoreCase("agent@local.test").isEmpty()) {
             userRepo.save(new UserJpaEntity(
                     AGENT_ID,
                     "agent@local.test",


### PR DESCRIPTION

### Description

- `LocalSeedRunner` ahora comprueba la existencia de los usuarios por email usando `findByEmailIgnoreCase(...)` antes de insertar los usuarios `user@local.test` y `agent@local.test`, haciendo el seed idempotente.
- `run.ps1` se modificó para preservar la base de datos por defecto y añadir el switch opcional `-ResetDatabase` que elimina el volumen de PostgreSQL cuando se requiere un reinicio limpio.
- Se añadió `ticketing-backend/SEED_Y_PERSISTENCIA.md` con instrucciones sobre el comportamiento del seed, cómo mantener persistencia y un ejemplo SQL para insertar usuarios manualmente (nota sobre usar hashes BCrypt para las contraseñas).
