### PR TITLE
Add user tickets pages, routing and API client; improve UI test stubs

### DIFF
--- a/docs/tickets-endpoints-proposal.md
+++ b/docs/tickets-endpoints-proposal.md
@@ -1,0 +1,158 @@
+# Propuesta de endpoints para páginas de Tickets (USER / AGENT / ADMIN)
+
+> Objetivo: habilitar completamente las páginas implementadas en frontend con filtros, paginación y acciones operativas.
+
+## 1) Listado de tickets del usuario autenticado (USER)
+
+### `GET /api/tickets/me`
+Lista los tickets creados por el usuario logado.
+
+**Query params (opcionales)**
+- `status`: `OPEN|IN_PROGRESS|RESOLVED`
+- `q`: texto libre (id/título)
+- `page`: número de página (base 0)
+- `size`: tamaño de página
+- `sort`: ejemplo `createdAt,desc`
+
+**200 Response**
+```json
+{
+  "items": [
+    {
+      "id": "uuid",
+      "title": "No puedo acceder",
+      "status": "OPEN",
+      "priority": "MEDIUM",
+      "createdAt": "2026-01-02T10:15:30Z",
+      "updatedAt": "2026-01-02T10:16:12Z",
+      "category": { "id": "uuid", "name": "Accesos" }
+    }
+  ],
+  "page": 0,
+  "size": 20,
+  "total": 148
+}
+```
+
+---
+
+## 2) Cola operativa para AGENT/ADMIN
+
+### `GET /api/tickets`
+Listado global para soporte con filtros avanzados.
+
+**Query params (opcionales)**
+- `scope`: `UNASSIGNED|MINE|ALL`  
+- `status`: lista CSV (`OPEN,IN_PROGRESS`)
+- `priority`: lista CSV (`LOW,MEDIUM,HIGH,URGENT`)
+- `categoryId`: UUID
+- `createdFrom`, `createdTo`: ISO datetime
+- `updatedFrom`, `updatedTo`: ISO datetime
+- `slaState`: `ON_TRACK|AT_RISK|BREACHED`
+- `assignedTo`: UUID (solo ADMIN)
+- `q`: texto libre
+- `page`, `size`, `sort`
+
+**200 Response**
+```json
+{
+  "items": [
+    {
+      "id": "uuid",
+      "title": "Error en facturación",
+      "status": "IN_PROGRESS",
+      "priority": "HIGH",
+      "createdAt": "2026-01-02T10:15:30Z",
+      "updatedAt": "2026-01-02T11:45:00Z",
+      "createdBy": { "id": "uuid", "displayName": "Juan" },
+      "assignedTo": { "id": "uuid", "displayName": "Agente 1" },
+      "category": { "id": "uuid", "name": "Facturación" },
+      "slaState": "AT_RISK"
+    }
+  ],
+  "page": 0,
+  "size": 20,
+  "total": 523
+}
+```
+
+---
+
+## 3) Métricas para cards de dashboard/tickets operativos
+
+### `GET /api/tickets/metrics`
+
+**Query params (opcionales)**
+- `scope`: `MINE|TEAM|ALL`
+- `categoryId`
+
+**200 Response**
+```json
+{
+  "unassigned": 24,
+  "assignedToMe": 17,
+  "inProgress": 31,
+  "awaitingCustomer": 9,
+  "slaAtRisk": 12,
+  "slaBreached": 3
+}
+```
+
+---
+
+## 4) Detalle de ticket
+
+### `GET /api/tickets/{id}`
+
+**200 Response**
+```json
+{
+  "id": "uuid",
+  "title": "No puedo acceder",
+  "description": "...",
+  "status": "OPEN",
+  "priority": "MEDIUM",
+  "createdAt": "2026-01-02T10:15:30Z",
+  "updatedAt": "2026-01-02T10:16:12Z",
+  "createdBy": { "id": "uuid", "displayName": "Juan" },
+  "assignedTo": { "id": "uuid", "displayName": "Agente 1" },
+  "category": { "id": "uuid", "name": "Accesos" }
+}
+```
+
+---
+
+## 5) Asignación y acciones operativas
+
+### `PATCH /api/tickets/{id}/assign`
+Body:
+```json
+{ "assignedToUserId": "uuid" }
+```
+
+### `PATCH /api/tickets/{id}/priority`
+Body:
+```json
+{ "priority": "LOW|MEDIUM|HIGH|URGENT" }
+```
+
+> Nota: el backend ya tiene `PATCH /api/tickets/{id}/status`; este endpoint encaja con esta propuesta.
+
+---
+
+## 6) Comentarios (detalle / colaboración)
+
+### `GET /api/tickets/{id}/comments`
+### `POST /api/tickets/{id}/comments`
+Body:
+```json
+{ "body": "mensaje" }
+```
+
+---
+
+## 7) Contratos recomendados
+
+- Añadir `priority` y `slaState` al modelo de ticket para la vista AGENT/ADMIN.
+- Respuesta paginada uniforme (`items/page/size/total`) para listados.
+- Filtros por query params, evitando endpoints duplicados por cada vista.

--- a/docs/tickets-endpoints-proposal.md
+++ b/docs/tickets-endpoints-proposal.md
@@ -1,158 +1,69 @@
-# Propuesta de endpoints para páginas de Tickets (USER / AGENT / ADMIN)
+# Tickets API - estado actual y próximos pasos
 
-> Objetivo: habilitar completamente las páginas implementadas en frontend con filtros, paginación y acciones operativas.
+Este documento queda actualizado tras implementar los endpoints de tickets del MVP sin `slaState`.
 
-## 1) Listado de tickets del usuario autenticado (USER)
+## Endpoints implementados
 
 ### `GET /api/tickets/me`
-Lista los tickets creados por el usuario logado.
+Listado paginado de tickets creados por el usuario autenticado (`USER`, `AGENT`, `ADMIN`).
 
-**Query params (opcionales)**
-- `status`: `OPEN|IN_PROGRESS|RESOLVED`
-- `q`: texto libre (id/título)
-- `page`: número de página (base 0)
-- `size`: tamaño de página
-- `sort`: ejemplo `createdAt,desc`
-
-**200 Response**
-```json
-{
-  "items": [
-    {
-      "id": "uuid",
-      "title": "No puedo acceder",
-      "status": "OPEN",
-      "priority": "MEDIUM",
-      "createdAt": "2026-01-02T10:15:30Z",
-      "updatedAt": "2026-01-02T10:16:12Z",
-      "category": { "id": "uuid", "name": "Accesos" }
-    }
-  ],
-  "page": 0,
-  "size": 20,
-  "total": 148
-}
-```
-
----
-
-## 2) Cola operativa para AGENT/ADMIN
+Query params:
+- `status`: `OPEN|IN_PROGRESS|RESOLVED` (opcional)
+- `q`: búsqueda por título (opcional)
+- `page`: base 0 (default `0`)
+- `size`: tamaño página (default `20`, max `100`)
 
 ### `GET /api/tickets`
-Listado global para soporte con filtros avanzados.
+Listado paginado de cola operativa para `AGENT/ADMIN`.
 
-**Query params (opcionales)**
-- `scope`: `UNASSIGNED|MINE|ALL`  
-- `status`: lista CSV (`OPEN,IN_PROGRESS`)
-- `priority`: lista CSV (`LOW,MEDIUM,HIGH,URGENT`)
-- `categoryId`: UUID
-- `createdFrom`, `createdTo`: ISO datetime
-- `updatedFrom`, `updatedTo`: ISO datetime
-- `slaState`: `ON_TRACK|AT_RISK|BREACHED`
-- `assignedTo`: UUID (solo ADMIN)
-- `q`: texto libre
-- `page`, `size`, `sort`
+Query params:
+- `scope`: `UNASSIGNED|MINE|OTHERS|ALL` (default `MINE`)
+- `status`: `OPEN|IN_PROGRESS|RESOLVED` (opcional)
+- `q`: búsqueda por título (opcional)
+- `page`, `size`
 
-**200 Response**
-```json
-{
-  "items": [
-    {
-      "id": "uuid",
-      "title": "Error en facturación",
-      "status": "IN_PROGRESS",
-      "priority": "HIGH",
-      "createdAt": "2026-01-02T10:15:30Z",
-      "updatedAt": "2026-01-02T11:45:00Z",
-      "createdBy": { "id": "uuid", "displayName": "Juan" },
-      "assignedTo": { "id": "uuid", "displayName": "Agente 1" },
-      "category": { "id": "uuid", "name": "Facturación" },
-      "slaState": "AT_RISK"
-    }
-  ],
-  "page": 0,
-  "size": 20,
-  "total": 523
-}
-```
-
----
-
-## 3) Métricas para cards de dashboard/tickets operativos
-
-### `GET /api/tickets/metrics`
-
-**Query params (opcionales)**
-- `scope`: `MINE|TEAM|ALL`
-- `categoryId`
-
-**200 Response**
-```json
-{
-  "unassigned": 24,
-  "assignedToMe": 17,
-  "inProgress": 31,
-  "awaitingCustomer": 9,
-  "slaAtRisk": 12,
-  "slaBreached": 3
-}
-```
-
----
-
-## 4) Detalle de ticket
+Semántica de `scope`:
+- `UNASSIGNED`: tickets sin agente asignado
+- `MINE`: tickets asignados al agente autenticado
+- `OTHERS`: tickets asignados a otros agentes
+- `ALL`: todos
 
 ### `GET /api/tickets/{id}`
+Detalle de ticket.
+- `USER`: solo sus propios tickets (createdBy)
+- `AGENT/ADMIN`: acceso completo
 
-**200 Response**
+### Ya existentes
+- `POST /api/tickets`
+- `PATCH /api/tickets/{id}/status`
+
+## Modelo de paginación usado
+
+Se usa respuesta uniforme:
+
 ```json
 {
-  "id": "uuid",
-  "title": "No puedo acceder",
-  "description": "...",
-  "status": "OPEN",
-  "priority": "MEDIUM",
-  "createdAt": "2026-01-02T10:15:30Z",
-  "updatedAt": "2026-01-02T10:16:12Z",
-  "createdBy": { "id": "uuid", "displayName": "Juan" },
-  "assignedTo": { "id": "uuid", "displayName": "Agente 1" },
-  "category": { "id": "uuid", "name": "Accesos" }
+  "items": [],
+  "page": 0,
+  "size": 20,
+  "total": 0
 }
 ```
 
----
+Este formato es simple, estable para frontend y fácil de testear en el contexto del TFG.
 
-## 5) Asignación y acciones operativas
+## Cambios de dominio aplicados
 
-### `PATCH /api/tickets/{id}/assign`
-Body:
-```json
-{ "assignedToUserId": "uuid" }
-```
+- Añadido `priority` en `Ticket` con enum:
+  - `LOW`, `MEDIUM`, `HIGH`
+- Se inicializa por defecto en creación como `MEDIUM`.
+- Se persiste en base de datos (`tickets.priority`).
 
-### `PATCH /api/tickets/{id}/priority`
-Body:
-```json
-{ "priority": "LOW|MEDIUM|HIGH|URGENT" }
-```
+## Próximos endpoints sugeridos (no implementados aún)
 
-> Nota: el backend ya tiene `PATCH /api/tickets/{id}/status`; este endpoint encaja con esta propuesta.
+- `PATCH /api/tickets/{id}/assign`
+- `PATCH /api/tickets/{id}/priority`
+- `GET /api/tickets/{id}/comments`
+- `POST /api/tickets/{id}/comments`
 
----
-
-## 6) Comentarios (detalle / colaboración)
-
-### `GET /api/tickets/{id}/comments`
-### `POST /api/tickets/{id}/comments`
-Body:
-```json
-{ "body": "mensaje" }
-```
-
----
-
-## 7) Contratos recomendados
-
-- Añadir `priority` y `slaState` al modelo de ticket para la vista AGENT/ADMIN.
-- Respuesta paginada uniforme (`items/page/size/total`) para listados.
-- Filtros por query params, evitando endpoints duplicados por cada vista.
+> `slaState` queda fuera por ahora para evitar complejidad innecesaria en el MVP.

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/shared/pagination/PageResponse.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/shared/pagination/PageResponse.java
@@ -1,0 +1,21 @@
+package com.aperdigon.ticketing_backend.api.shared.pagination;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> items,
+        int page,
+        int size,
+        long total
+) {
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements()
+        );
+    }
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/TicketController.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/TicketController.java
@@ -1,22 +1,33 @@
 package com.aperdigon.ticketing_backend.api.tickets;
 
-import java.net.URI;
-import java.util.UUID;
-
 import com.aperdigon.ticketing_backend.api.shared.currentuser.CurrentUserProvider;
+import com.aperdigon.ticketing_backend.api.shared.pagination.PageResponse;
 import com.aperdigon.ticketing_backend.api.tickets.change_status.ChangeTicketStatusRequest;
 import com.aperdigon.ticketing_backend.api.tickets.create.CreateTicketRequest;
 import com.aperdigon.ticketing_backend.api.tickets.create.CreateTicketResponse;
+import com.aperdigon.ticketing_backend.api.tickets.detail.TicketDetailResponse;
+import com.aperdigon.ticketing_backend.api.tickets.list.TicketSummaryResponse;
 import com.aperdigon.ticketing_backend.application.tickets.change_status.ChangeTicketStatusCommand;
 import com.aperdigon.ticketing_backend.application.tickets.change_status.ChangeTicketStatusUseCase;
 import com.aperdigon.ticketing_backend.application.tickets.create.CreateTicketCommand;
 import com.aperdigon.ticketing_backend.application.tickets.create.CreateTicketUseCase;
+import com.aperdigon.ticketing_backend.application.tickets.get.GetTicketUseCase;
+import com.aperdigon.ticketing_backend.application.tickets.list.ListMyTicketsQuery;
+import com.aperdigon.ticketing_backend.application.tickets.list.ListMyTicketsUseCase;
+import com.aperdigon.ticketing_backend.application.tickets.list.ListTicketsQuery;
+import com.aperdigon.ticketing_backend.application.tickets.list.ListTicketsUseCase;
+import com.aperdigon.ticketing_backend.application.tickets.list.TicketQueueScope;
 import com.aperdigon.ticketing_backend.domain.category.CategoryId;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/tickets")
@@ -24,19 +35,27 @@ public class TicketController {
 
     private final CreateTicketUseCase createTicketUseCase;
     private final ChangeTicketStatusUseCase changeTicketStatusUseCase;
+    private final ListMyTicketsUseCase listMyTicketsUseCase;
+    private final ListTicketsUseCase listTicketsUseCase;
+    private final GetTicketUseCase getTicketUseCase;
     private final CurrentUserProvider currentUserProvider;
 
     public TicketController(
             CreateTicketUseCase createTicketUseCase,
             ChangeTicketStatusUseCase changeTicketStatusUseCase,
+            ListMyTicketsUseCase listMyTicketsUseCase,
+            ListTicketsUseCase listTicketsUseCase,
+            GetTicketUseCase getTicketUseCase,
             CurrentUserProvider currentUserProvider
     ) {
         this.createTicketUseCase = createTicketUseCase;
         this.changeTicketStatusUseCase = changeTicketStatusUseCase;
+        this.listMyTicketsUseCase = listMyTicketsUseCase;
+        this.listTicketsUseCase = listTicketsUseCase;
+        this.getTicketUseCase = getTicketUseCase;
         this.currentUserProvider = currentUserProvider;
     }
 
-    // UC1: Crear ticket (USER también puede, AGENT/ADMIN también si quieres)
     @PostMapping
     public ResponseEntity<CreateTicketResponse> create(@Valid @RequestBody CreateTicketRequest request) {
         var actor = currentUserProvider.getCurrentUser();
@@ -53,7 +72,42 @@ public class TicketController {
                 .body(new CreateTicketResponse(id));
     }
 
-    // UC4: Cambiar estado (AGENT/ADMIN está protegido ya por SecurityConfig)
+    @GetMapping("/me")
+    public PageResponse<TicketSummaryResponse> listMine(
+            @RequestParam(required = false) TicketStatus status,
+            @RequestParam(required = false) String q,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        var actor = currentUserProvider.getCurrentUser();
+        var pageable = PageRequest.of(page, Math.min(Math.max(size, 1), 100), Sort.by(Sort.Direction.DESC, "updatedAt"));
+
+        var result = listMyTicketsUseCase.execute(new ListMyTicketsQuery(actor, status, q, pageable));
+        return PageResponse.from(result.map(TicketSummaryResponse::from));
+    }
+
+    @GetMapping
+    public PageResponse<TicketSummaryResponse> listQueue(
+            @RequestParam(defaultValue = "MINE") TicketQueueScope scope,
+            @RequestParam(required = false) TicketStatus status,
+            @RequestParam(required = false) String q,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        var actor = currentUserProvider.getCurrentUser();
+        var pageable = PageRequest.of(page, Math.min(Math.max(size, 1), 100), Sort.by(Sort.Direction.DESC, "updatedAt"));
+
+        var result = listTicketsUseCase.execute(new ListTicketsQuery(actor, scope, status, q, pageable));
+        return PageResponse.from(result.map(TicketSummaryResponse::from));
+    }
+
+    @GetMapping("/{id}")
+    public TicketDetailResponse getById(@PathVariable UUID id) {
+        var actor = currentUserProvider.getCurrentUser();
+        var ticket = getTicketUseCase.execute(new TicketId(id), actor);
+        return TicketDetailResponse.from(ticket);
+    }
+
     @PatchMapping("/{id}/status")
     public ResponseEntity<Void> changeStatus(@PathVariable UUID id, @Valid @RequestBody ChangeTicketStatusRequest request) {
         var actor = currentUserProvider.getCurrentUser();

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/detail/TicketDetailResponse.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/detail/TicketDetailResponse.java
@@ -1,0 +1,36 @@
+package com.aperdigon.ticketing_backend.api.tickets.detail;
+
+import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketPriority;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record TicketDetailResponse(
+        UUID id,
+        String title,
+        String description,
+        TicketStatus status,
+        TicketPriority priority,
+        Instant createdAt,
+        Instant updatedAt,
+        UUID createdByUserId,
+        UUID assignedToUserId,
+        UUID categoryId
+) {
+    public static TicketDetailResponse from(Ticket ticket) {
+        return new TicketDetailResponse(
+                ticket.id().value(),
+                ticket.title(),
+                ticket.description(),
+                ticket.status(),
+                ticket.priority(),
+                ticket.createdAt(),
+                ticket.updatedAt(),
+                ticket.createdBy().value(),
+                ticket.assignedTo() == null ? null : ticket.assignedTo().value(),
+                ticket.categoryId().value()
+        );
+    }
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/list/TicketSummaryResponse.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/list/TicketSummaryResponse.java
@@ -1,0 +1,32 @@
+package com.aperdigon.ticketing_backend.api.tickets.list;
+
+import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketPriority;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record TicketSummaryResponse(
+        UUID id,
+        String title,
+        TicketStatus status,
+        TicketPriority priority,
+        Instant createdAt,
+        Instant updatedAt,
+        UUID createdByUserId,
+        UUID assignedToUserId
+) {
+    public static TicketSummaryResponse from(Ticket ticket) {
+        return new TicketSummaryResponse(
+                ticket.id().value(),
+                ticket.title(),
+                ticket.status(),
+                ticket.priority(),
+                ticket.createdAt(),
+                ticket.updatedAt(),
+                ticket.createdBy().value(),
+                ticket.assignedTo() == null ? null : ticket.assignedTo().value()
+        );
+    }
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/ports/TicketRepository.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/ports/TicketRepository.java
@@ -1,11 +1,20 @@
 package com.aperdigon.ticketing_backend.application.ports;
 
+import com.aperdigon.ticketing_backend.application.tickets.list.TicketQueueScope;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+import com.aperdigon.ticketing_backend.domain.user.UserId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
 public interface TicketRepository {
     Ticket save(Ticket ticket);
     Optional<Ticket> findById(TicketId id);
+
+    Page<Ticket> findMyTickets(UserId createdBy, TicketStatus status, String q, Pageable pageable);
+
+    Page<Ticket> findAgentTickets(UserId actorId, TicketQueueScope scope, TicketStatus status, String q, Pageable pageable);
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/get/GetTicketUseCase.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/get/GetTicketUseCase.java
@@ -1,0 +1,34 @@
+package com.aperdigon.ticketing_backend.application.tickets.get;
+
+import com.aperdigon.ticketing_backend.application.ports.TicketRepository;
+import com.aperdigon.ticketing_backend.application.shared.CurrentUser;
+import com.aperdigon.ticketing_backend.application.shared.exception.ForbiddenException;
+import com.aperdigon.ticketing_backend.application.shared.exception.NotFoundException;
+import com.aperdigon.ticketing_backend.domain.shared.validation.Guard;
+import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GetTicketUseCase {
+
+    private final TicketRepository ticketRepository;
+
+    public GetTicketUseCase(TicketRepository ticketRepository) {
+        this.ticketRepository = Guard.notNull(ticketRepository, "ticketRepository");
+    }
+
+    public Ticket execute(TicketId ticketId, CurrentUser actor) {
+        Guard.notNull(ticketId, "ticketId");
+        Guard.notNull(actor, "actor");
+
+        Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(() -> new NotFoundException("Ticket not found: " + ticketId.value()));
+
+        if (!actor.isAgentOrAdmin() && !ticket.createdBy().equals(actor.id())) {
+            throw new ForbiddenException("You cannot access this ticket");
+        }
+
+        return ticket;
+    }
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/list/ListMyTicketsQuery.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/list/ListMyTicketsQuery.java
@@ -1,0 +1,12 @@
+package com.aperdigon.ticketing_backend.application.tickets.list;
+
+import com.aperdigon.ticketing_backend.application.shared.CurrentUser;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+import org.springframework.data.domain.Pageable;
+
+public record ListMyTicketsQuery(
+        CurrentUser actor,
+        TicketStatus status,
+        String q,
+        Pageable pageable
+) {}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/list/ListMyTicketsUseCase.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/list/ListMyTicketsUseCase.java
@@ -1,0 +1,27 @@
+package com.aperdigon.ticketing_backend.application.tickets.list;
+
+import com.aperdigon.ticketing_backend.application.ports.TicketRepository;
+import com.aperdigon.ticketing_backend.domain.shared.validation.Guard;
+import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ListMyTicketsUseCase {
+
+    private final TicketRepository ticketRepository;
+
+    public ListMyTicketsUseCase(TicketRepository ticketRepository) {
+        this.ticketRepository = Guard.notNull(ticketRepository, "ticketRepository");
+    }
+
+    public Page<Ticket> execute(ListMyTicketsQuery query) {
+        Guard.notNull(query, "query");
+        return ticketRepository.findMyTickets(
+                query.actor().id(),
+                query.status(),
+                query.q(),
+                query.pageable()
+        );
+    }
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/list/ListTicketsQuery.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/list/ListTicketsQuery.java
@@ -1,0 +1,13 @@
+package com.aperdigon.ticketing_backend.application.tickets.list;
+
+import com.aperdigon.ticketing_backend.application.shared.CurrentUser;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+import org.springframework.data.domain.Pageable;
+
+public record ListTicketsQuery(
+        CurrentUser actor,
+        TicketQueueScope scope,
+        TicketStatus status,
+        String q,
+        Pageable pageable
+) {}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/list/ListTicketsUseCase.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/list/ListTicketsUseCase.java
@@ -1,0 +1,34 @@
+package com.aperdigon.ticketing_backend.application.tickets.list;
+
+import com.aperdigon.ticketing_backend.application.ports.TicketRepository;
+import com.aperdigon.ticketing_backend.application.shared.exception.ForbiddenException;
+import com.aperdigon.ticketing_backend.domain.shared.validation.Guard;
+import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ListTicketsUseCase {
+
+    private final TicketRepository ticketRepository;
+
+    public ListTicketsUseCase(TicketRepository ticketRepository) {
+        this.ticketRepository = Guard.notNull(ticketRepository, "ticketRepository");
+    }
+
+    public Page<Ticket> execute(ListTicketsQuery query) {
+        Guard.notNull(query, "query");
+
+        if (!query.actor().isAgentOrAdmin()) {
+            throw new ForbiddenException("Only AGENT/ADMIN can list operational queues");
+        }
+
+        return ticketRepository.findAgentTickets(
+                query.actor().id(),
+                query.scope(),
+                query.status(),
+                query.q(),
+                query.pageable()
+        );
+    }
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/list/TicketQueueScope.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/list/TicketQueueScope.java
@@ -1,0 +1,8 @@
+package com.aperdigon.ticketing_backend.application.tickets.list;
+
+public enum TicketQueueScope {
+    UNASSIGNED,
+    MINE,
+    OTHERS,
+    ALL
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/domain/ticket/Ticket.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/domain/ticket/Ticket.java
@@ -26,6 +26,7 @@ public final class Ticket {
 
     private UserId assignedTo; // nullable en MVP
     private TicketStatus status;
+    private TicketPriority priority;
 
     private final Instant createdAt;
     private Instant updatedAt;
@@ -39,6 +40,7 @@ public final class Ticket {
             CategoryId categoryId,
             UserId createdBy,
             TicketStatus status,
+            TicketPriority priority,
             Instant createdAt,
             Instant updatedAt,
             UserId assignedTo,
@@ -50,6 +52,7 @@ public final class Ticket {
         this.categoryId = Guard.notNull(categoryId, "categoryId");
         this.createdBy = Guard.notNull(createdBy, "createdBy");
         this.status = Guard.notNull(status, "status");
+        this.priority = Guard.notNull(priority, "priority");
         this.createdAt = Guard.notNull(createdAt, "createdAt");
         this.updatedAt = Guard.notNull(updatedAt, "updatedAt");
         this.assignedTo = assignedTo;
@@ -69,6 +72,7 @@ public final class Ticket {
                 category.id(),
                 creator.id(),
                 TicketStatus.OPEN,
+                TicketPriority.MEDIUM,
                 now,
                 now,
                 null,
@@ -83,6 +87,7 @@ public final class Ticket {
             CategoryId categoryId,
             UserId createdBy,
             TicketStatus status,
+            TicketPriority priority,
             Instant createdAt,
             Instant updatedAt,
             UserId assignedTo,
@@ -96,6 +101,7 @@ public final class Ticket {
                 categoryId,
                 createdBy,
                 status,
+                priority,
                 createdAt,
                 updatedAt,
                 assignedTo,
@@ -164,6 +170,7 @@ public final class Ticket {
     public UserId createdBy() { return createdBy; }
     public UserId assignedTo() { return assignedTo; }
     public TicketStatus status() { return status; }
+    public TicketPriority priority() { return priority; }
     public Instant createdAt() { return createdAt; }
     public Instant updatedAt() { return updatedAt; }
     public List<Comment> comments() { return Collections.unmodifiableList(comments); }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/domain/ticket/TicketPriority.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/domain/ticket/TicketPriority.java
@@ -1,0 +1,7 @@
+package com.aperdigon.ticketing_backend.domain.ticket;
+
+public enum TicketPriority {
+    LOW,
+    MEDIUM,
+    HIGH
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/adapter/JpaTicketRepository.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/adapter/JpaTicketRepository.java
@@ -1,17 +1,26 @@
 package com.aperdigon.ticketing_backend.infrastructure.persistence.adapter;
 
 import com.aperdigon.ticketing_backend.application.ports.TicketRepository;
+import com.aperdigon.ticketing_backend.application.tickets.list.TicketQueueScope;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+import com.aperdigon.ticketing_backend.domain.user.UserId;
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.CommentJpaEntity;
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.TicketJpaEntity;
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.mapper.TicketMapper;
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.CategorySpringDataRepository;
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.TicketSpringDataRepository;
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.UserSpringDataRepository;
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -34,18 +43,17 @@ public class JpaTicketRepository implements TicketRepository {
     @Override
     @Transactional
     public Ticket save(Ticket ticket) {
-        // Cargamos referencias necesarias (createdBy + category + assignedTo) desde DB
         var createdBy = userSpringRepo.getReferenceById(ticket.createdBy().value());
         var category = categorySpringRepo.getReferenceById(ticket.categoryId().value());
         var assignedTo = ticket.assignedTo() == null ? null : userSpringRepo.getReferenceById(ticket.assignedTo().value());
 
-        // Si existe, actualizamos sobre la entidad existente para mantener relaciones y orphanRemoval
         TicketJpaEntity entity = ticketSpringRepo.findById(ticket.id().value())
                 .orElseGet(() -> new TicketJpaEntity(
                         ticket.id().value(),
                         ticket.title(),
                         ticket.description(),
                         ticket.status(),
+                        ticket.priority(),
                         ticket.createdAt(),
                         ticket.updatedAt(),
                         createdBy,
@@ -56,14 +64,13 @@ public class JpaTicketRepository implements TicketRepository {
         entity.setTitle(ticket.title());
         entity.setDescription(ticket.description());
         entity.setStatus(ticket.status());
+        entity.setPriority(ticket.priority());
         entity.setUpdatedAt(ticket.updatedAt());
         entity.setCreatedAt(ticket.createdAt());
         entity.setCreatedBy(createdBy);
         entity.setCategory(category);
         entity.setAssignedTo(assignedTo);
 
-        // Sin UC5 aún no necesitas persistir comments, pero lo dejamos preparado:
-        // sincronizamos comments por id (simple: borrar y recrear)
         entity.getComments().clear();
         for (var c : ticket.comments()) {
             var author = userSpringRepo.getReferenceById(c.authorId().value());
@@ -77,7 +84,6 @@ public class JpaTicketRepository implements TicketRepository {
         }
 
         TicketJpaEntity saved = ticketSpringRepo.save(entity);
-        // leer con details para mapear consistente
         return ticketSpringRepo.findWithDetailsById(saved.getId())
                 .map(TicketMapper::toDomain)
                 .orElseThrow();
@@ -87,5 +93,57 @@ public class JpaTicketRepository implements TicketRepository {
     @Transactional(readOnly = true)
     public Optional<Ticket> findById(TicketId id) {
         return ticketSpringRepo.findWithDetailsById(id.value()).map(TicketMapper::toDomain);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Ticket> findMyTickets(UserId createdBy, TicketStatus status, String q, Pageable pageable) {
+        Specification<TicketJpaEntity> spec = (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            predicates.add(cb.equal(root.get("createdBy").get("id"), createdBy.value()));
+
+            if (status != null) {
+                predicates.add(cb.equal(root.get("status"), status));
+            }
+
+            if (q != null && !q.isBlank()) {
+                String normalized = "%" + q.trim().toLowerCase() + "%";
+                predicates.add(cb.like(cb.lower(root.get("title")), normalized));
+            }
+
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+
+        return ticketSpringRepo.findAll(spec, pageable).map(TicketMapper::toDomain);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Ticket> findAgentTickets(UserId actorId, TicketQueueScope scope, TicketStatus status, String q, Pageable pageable) {
+        Specification<TicketJpaEntity> spec = (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            if (scope == TicketQueueScope.UNASSIGNED) {
+                predicates.add(cb.isNull(root.get("assignedTo")));
+            } else if (scope == TicketQueueScope.MINE) {
+                predicates.add(cb.equal(root.get("assignedTo").get("id"), actorId.value()));
+            } else if (scope == TicketQueueScope.OTHERS) {
+                predicates.add(cb.isNotNull(root.get("assignedTo")));
+                predicates.add(cb.notEqual(root.get("assignedTo").get("id"), actorId.value()));
+            }
+
+            if (status != null) {
+                predicates.add(cb.equal(root.get("status"), status));
+            }
+
+            if (q != null && !q.isBlank()) {
+                String normalized = "%" + q.trim().toLowerCase() + "%";
+                predicates.add(cb.like(cb.lower(root.get("title")), normalized));
+            }
+
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+
+        return ticketSpringRepo.findAll(spec, pageable).map(TicketMapper::toDomain);
     }
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/entity/TicketJpaEntity.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/entity/TicketJpaEntity.java
@@ -1,5 +1,6 @@
 package com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity;
 
+import com.aperdigon.ticketing_backend.domain.ticket.TicketPriority;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
 import jakarta.persistence.*;
 
@@ -25,6 +26,10 @@ public class TicketJpaEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 30)
     private TicketStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "priority", nullable = false, length = 20)
+    private TicketPriority priority;
 
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
@@ -55,6 +60,7 @@ public class TicketJpaEntity {
             String title,
             String description,
             TicketStatus status,
+            TicketPriority priority,
             Instant createdAt,
             Instant updatedAt,
             UserJpaEntity createdBy,
@@ -65,6 +71,7 @@ public class TicketJpaEntity {
         this.title = title;
         this.description = description;
         this.status = status;
+        this.priority = priority;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.createdBy = createdBy;
@@ -77,6 +84,7 @@ public class TicketJpaEntity {
     public String getTitle() { return title; }
     public String getDescription() { return description; }
     public TicketStatus getStatus() { return status; }
+    public TicketPriority getPriority() { return priority; }
     public Instant getCreatedAt() { return createdAt; }
     public Instant getUpdatedAt() { return updatedAt; }
     public UserJpaEntity getCreatedBy() { return createdBy; }
@@ -85,6 +93,7 @@ public class TicketJpaEntity {
     public List<CommentJpaEntity> getComments() { return comments; }
 
     public void setStatus(TicketStatus status) { this.status = status; }
+    public void setPriority(TicketPriority priority) { this.priority = priority; }
     public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
     public void setAssignedTo(UserJpaEntity assignedTo) { this.assignedTo = assignedTo; }
 

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/mapper/TicketMapper.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/mapper/TicketMapper.java
@@ -38,6 +38,7 @@ public final class TicketMapper {
                 category.id(),
                 createdBy.id(),
                 e.getStatus(),
+                e.getPriority(),
                 e.getCreatedAt(),
                 e.getUpdatedAt(),
                 assignedToId,

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/repository/TicketSpringDataRepository.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/repository/TicketSpringDataRepository.java
@@ -3,13 +3,13 @@ package com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repositor
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.TicketJpaEntity;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.Optional;
 import java.util.UUID;
 
-public interface TicketSpringDataRepository extends JpaRepository<TicketJpaEntity, UUID> {
+public interface TicketSpringDataRepository extends JpaRepository<TicketJpaEntity, UUID>, JpaSpecificationExecutor<TicketJpaEntity> {
 
-    // Para evitar LazyInitialization y traer comments/refs cuando se lee un ticket
     @EntityGraph(attributePaths = {"comments", "createdBy", "assignedTo", "category", "comments.author"})
     Optional<TicketJpaEntity> findWithDetailsById(UUID id);
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/security/SecurityConfig.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/security/SecurityConfig.java
@@ -35,10 +35,13 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/auth/**").permitAll()
 
                         //UC1: crear ticket todos
-                        .requestMatchers("/api/tickets").hasAnyRole("USER","AGENT","ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/tickets").hasAnyRole("USER","AGENT","ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/api/tickets/me").hasAnyRole("USER","AGENT","ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/api/tickets").hasAnyRole("AGENT", "ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/api/tickets/*").hasAnyRole("USER", "AGENT", "ADMIN")
 
                         // UC4: cambiar estado solo AGENT/ADMIN
-                        .requestMatchers("/api/tickets/*/status").hasAnyRole("AGENT", "ADMIN")
+                        .requestMatchers(HttpMethod.PATCH, "/api/tickets/*/status").hasAnyRole("AGENT", "ADMIN")
 
                         // resto API: requiere estar autenticado
                         .requestMatchers("/api/**").authenticated()

--- a/ticketing-backend/src/main/resources/db/migration/V3__add_ticket_priority.sql
+++ b/ticketing-backend/src/main/resources/db/migration/V3__add_ticket_priority.sql
@@ -1,0 +1,4 @@
+ALTER TABLE tickets
+    ADD COLUMN priority VARCHAR(20) NOT NULL DEFAULT 'MEDIUM';
+
+CREATE INDEX idx_tickets_priority ON tickets(priority);

--- a/ticketing-frontend/src/app/layout/AppShell.tsx
+++ b/ticketing-frontend/src/app/layout/AppShell.tsx
@@ -10,15 +10,15 @@ type AppMenuItem = Required<NonNullable<MenuProps["items"]>>[number];
 const { Header, Sider, Content } = Layout;
 
 const baseItems: AppMenuItem[] = [
-  { key: "/dashboard", icon: <MdDashboard fontSize={18}/>, label: "Dashboard" },
-  { key: "/tickets", icon: <HiTicket   fontSize={18}/>, label: "Tickets" },
-  { key: "/tickets/new", icon: <MdOutlineAdd fontSize={18}/>, label: "Nuevo ticket" },
-  { key: "/profile", icon: <HiBars3 fontSize={18}/>, label: "Perfil" }
+  { key: "/dashboard", icon: <MdDashboard fontSize={18} />, label: "Dashboard" },
+  { key: "/tickets", icon: <HiTicket fontSize={18} />, label: "Tickets" },
+  { key: "/tickets/new", icon: <MdOutlineAdd fontSize={18} />, label: "Nuevo ticket" },
+  { key: "/profile", icon: <HiBars3 fontSize={18} />, label: "Perfil" },
 ];
 
 function getMenuItems(isAdmin: boolean): AppMenuItem[] {
   if (isAdmin) {
-    return [...baseItems, { key: "/admin", icon: <HiUsers fontSize={18}/>, label: "Administración" }];
+    return [...baseItems, { key: "/admin", icon: <HiUsers fontSize={18} />, label: "Administración" }];
   }
 
   return baseItems;
@@ -27,7 +27,7 @@ function getMenuItems(isAdmin: boolean): AppMenuItem[] {
 function getSelectedKey(pathname: string, items: AppMenuItem[]) {
   const matched = items
     .map((item) => item.key?.toString() ?? "")
-    .sort((a, b) => b.length - a.length) // Sort by length descending
+    .sort((a, b) => b.length - a.length)
     .find((key) => key && pathname.startsWith(key));
 
   return matched ? [matched] : ["/dashboard"];
@@ -58,7 +58,7 @@ export function AppShell() {
         />
       </Sider>
 
-      <Layout style={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
+      <Layout style={{ display: "flex", flexDirection: "column", width: "100%" }}>
         <Header
           style={{
             background: "#fff",

--- a/ticketing-frontend/src/app/pages/RoleLandingRedirect.test.tsx
+++ b/ticketing-frontend/src/app/pages/RoleLandingRedirect.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { vi } from "vitest";
+import { RoleLandingRedirect } from "./RoleLandingRedirect";
+
+const hasAnyRoleMock = vi.fn<(roles: Array<"USER" | "AGENT" | "ADMIN">) => boolean>();
+
+vi.mock("../../features/auth/hooks/useAuth", () => ({
+  useAuth: () => ({
+    hasAnyRole: hasAnyRoleMock,
+  }),
+}));
+
+function renderRoute() {
+  const router = createMemoryRouter(
+    [
+      { path: "/", element: <RoleLandingRedirect /> },
+      { path: "/tickets", element: <h1>Tickets</h1> },
+      { path: "/dashboard", element: <h1>Dashboard</h1> },
+    ],
+    { initialEntries: ["/"] },
+  );
+
+  return render(<RouterProvider router={router} />);
+}
+
+describe("RoleLandingRedirect", () => {
+  beforeEach(() => {
+    hasAnyRoleMock.mockReset();
+  });
+
+  it("redirects USER to /tickets", async () => {
+    hasAnyRoleMock.mockReturnValue(false);
+    renderRoute();
+
+    expect(await screen.findByRole("heading", { name: "Tickets" })).toBeInTheDocument();
+  });
+
+  it("redirects AGENT/ADMIN to /dashboard", async () => {
+    hasAnyRoleMock.mockReturnValue(true);
+    renderRoute();
+
+    expect(await screen.findByRole("heading", { name: "Dashboard" })).toBeInTheDocument();
+  });
+});

--- a/ticketing-frontend/src/app/pages/RoleLandingRedirect.tsx
+++ b/ticketing-frontend/src/app/pages/RoleLandingRedirect.tsx
@@ -1,0 +1,12 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../../features/auth/hooks/useAuth";
+
+export function RoleLandingRedirect() {
+  const { hasAnyRole } = useAuth();
+
+  if (hasAnyRole(["AGENT", "ADMIN"])) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return <Navigate to="/tickets" replace />;
+}

--- a/ticketing-frontend/src/app/pages/TicketsPage.test.tsx
+++ b/ticketing-frontend/src/app/pages/TicketsPage.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { vi } from "vitest";
+import { TicketsPage } from "./TicketsPage";
+
+const hasAnyRoleMock = vi.fn<(roles: Array<"USER" | "AGENT" | "ADMIN">) => boolean>();
+
+vi.mock("../../features/auth/hooks/useAuth", () => ({
+  useAuth: () => ({
+    hasAnyRole: hasAnyRoleMock,
+  }),
+}));
+
+vi.mock("../../features/tickets/ui/UserTicketsHomePage", () => ({
+  UserTicketsHomePage: () => <h1>Mis tickets</h1>,
+}));
+
+describe("TicketsPage", () => {
+  beforeEach(() => {
+    hasAnyRoleMock.mockReset();
+  });
+
+  it("shows USER tickets page for normal users", () => {
+    hasAnyRoleMock.mockReturnValue(false);
+
+    render(
+      <MemoryRouter>
+        <TicketsPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Mis tickets" })).toBeInTheDocument();
+  });
+
+  it("shows generic tickets page for AGENT/ADMIN", () => {
+    hasAnyRoleMock.mockReturnValue(true);
+
+    render(
+      <MemoryRouter>
+        <TicketsPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Tickets" })).toBeInTheDocument();
+  });
+});

--- a/ticketing-frontend/src/app/pages/TicketsPage.test.tsx
+++ b/ticketing-frontend/src/app/pages/TicketsPage.test.tsx
@@ -15,6 +15,10 @@ vi.mock("../../features/tickets/ui/UserTicketsHomePage", () => ({
   UserTicketsHomePage: () => <h1>Mis tickets</h1>,
 }));
 
+vi.mock("../../features/tickets/ui/AgentAdminTicketsPage", () => ({
+  AgentAdminTicketsPage: () => <h1>Gestión de tickets</h1>,
+}));
+
 describe("TicketsPage", () => {
   beforeEach(() => {
     hasAnyRoleMock.mockReset();
@@ -32,7 +36,7 @@ describe("TicketsPage", () => {
     expect(screen.getByRole("heading", { name: "Mis tickets" })).toBeInTheDocument();
   });
 
-  it("shows generic tickets page for AGENT/ADMIN", () => {
+  it("shows AGENT/ADMIN tickets page", () => {
     hasAnyRoleMock.mockReturnValue(true);
 
     render(
@@ -41,6 +45,6 @@ describe("TicketsPage", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole("heading", { name: "Tickets" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Gestión de tickets" })).toBeInTheDocument();
   });
 });

--- a/ticketing-frontend/src/app/pages/TicketsPage.tsx
+++ b/ticketing-frontend/src/app/pages/TicketsPage.tsx
@@ -1,0 +1,13 @@
+import { PlaceholderPage } from "./PlaceholderPage";
+import { useAuth } from "../../features/auth/hooks/useAuth";
+import { UserTicketsHomePage } from "../../features/tickets/ui/UserTicketsHomePage";
+
+export function TicketsPage() {
+  const { hasAnyRole } = useAuth();
+
+  if (hasAnyRole(["AGENT", "ADMIN"])) {
+    return <PlaceholderPage title="Tickets" />;
+  }
+
+  return <UserTicketsHomePage />;
+}

--- a/ticketing-frontend/src/app/pages/TicketsPage.tsx
+++ b/ticketing-frontend/src/app/pages/TicketsPage.tsx
@@ -1,12 +1,12 @@
-import { PlaceholderPage } from "./PlaceholderPage";
 import { useAuth } from "../../features/auth/hooks/useAuth";
 import { UserTicketsHomePage } from "../../features/tickets/ui/UserTicketsHomePage";
+import { AgentAdminTicketsPage } from "../../features/tickets/ui/AgentAdminTicketsPage";
 
 export function TicketsPage() {
   const { hasAnyRole } = useAuth();
 
   if (hasAnyRole(["AGENT", "ADMIN"])) {
-    return <PlaceholderPage title="Tickets" />;
+    return <AgentAdminTicketsPage />;
   }
 
   return <UserTicketsHomePage />;

--- a/ticketing-frontend/src/app/router.tsx
+++ b/ticketing-frontend/src/app/router.tsx
@@ -4,6 +4,8 @@ import { LoginPage } from "../features/auth/ui/LoginPage";
 import { AppShell } from "./layout/AppShell";
 import { NotFoundPage } from "./pages/NotFoundPage";
 import { PlaceholderPage } from "./pages/PlaceholderPage";
+import { RoleLandingRedirect } from "./pages/RoleLandingRedirect";
+import { TicketsPage } from "./pages/TicketsPage";
 
 function ForbiddenPage() {
   return <PlaceholderPage title="403 — Forbidden" />;
@@ -18,9 +20,9 @@ export const router = createBrowserRouter([
       {
         element: <AppShell />,
         children: [
-          { path: "/", element: <PlaceholderPage title="Dashboard" /> },
+          { path: "/", element: <RoleLandingRedirect /> },
           { path: "/dashboard", element: <PlaceholderPage title="Dashboard" /> },
-          { path: "/tickets", element: <PlaceholderPage title="Tickets" /> },
+          { path: "/tickets", element: <TicketsPage /> },
           { path: "/tickets/new", element: <PlaceholderPage title="Nuevo ticket" /> },
           { path: "/profile", element: <PlaceholderPage title="Perfil" /> },
           { path: "/admin", element: <PlaceholderPage title="Administración" /> },

--- a/ticketing-frontend/src/features/auth/ui/LoginPage.tsx
+++ b/ticketing-frontend/src/features/auth/ui/LoginPage.tsx
@@ -38,7 +38,7 @@ export function LoginPage() {
         await register({ email, displayName, password, confirmPassword, remember });
       }
 
-      const from = loc.state?.from ?? "/tickets";
+      const from = loc.state?.from ?? "/";
       nav(from, { replace: true });
     } catch (err) {
       if (err instanceof ApiError) setError(`${err.status} — ${err.message}`);

--- a/ticketing-frontend/src/features/tickets/api/ticketsApi.ts
+++ b/ticketing-frontend/src/features/tickets/api/ticketsApi.ts
@@ -1,5 +1,5 @@
 import { createApiClient } from "../../../shared/api/client";
-import type { TicketSummary } from "../model/types";
+import type { PaginatedResponse, TicketQueueScope, TicketStatus, TicketSummary } from "../model/types";
 
 const AUTH_TOKEN_STORAGE_KEY = "ticketing_access_token";
 
@@ -7,8 +7,23 @@ const authClient = createApiClient({
   getToken: () => localStorage.getItem(AUTH_TOKEN_STORAGE_KEY),
 });
 
+function buildQuery(params: Record<string, string | number | undefined>) {
+  const query = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== "") {
+      query.set(key, String(value));
+    }
+  });
+
+  const asString = query.toString();
+  return asString ? `?${asString}` : "";
+}
+
 export const ticketsApi = {
-  // TODO: Backend currently only documents POST /api/tickets and PATCH /api/tickets/{id}/status.
-  // Keep this GET wired to /api/tickets so the UI can consume it as soon as listing is exposed.
-  getMyTickets: () => authClient.get<TicketSummary[]>("/api/tickets"),
+  getMyTickets: (params?: { page?: number; size?: number; status?: TicketStatus; q?: string }) =>
+    authClient.get<PaginatedResponse<TicketSummary>>(`/api/tickets/me${buildQuery(params ?? {})}`),
+
+  getQueueTickets: (params?: { page?: number; size?: number; status?: TicketStatus; q?: string; scope?: TicketQueueScope }) =>
+    authClient.get<PaginatedResponse<TicketSummary>>(`/api/tickets${buildQuery(params ?? {})}`),
 };

--- a/ticketing-frontend/src/features/tickets/api/ticketsApi.ts
+++ b/ticketing-frontend/src/features/tickets/api/ticketsApi.ts
@@ -1,0 +1,14 @@
+import { createApiClient } from "../../../shared/api/client";
+import type { TicketSummary } from "../model/types";
+
+const AUTH_TOKEN_STORAGE_KEY = "ticketing_access_token";
+
+const authClient = createApiClient({
+  getToken: () => localStorage.getItem(AUTH_TOKEN_STORAGE_KEY),
+});
+
+export const ticketsApi = {
+  // TODO: Backend currently only documents POST /api/tickets and PATCH /api/tickets/{id}/status.
+  // Keep this GET wired to /api/tickets so the UI can consume it as soon as listing is exposed.
+  getMyTickets: () => authClient.get<TicketSummary[]>("/api/tickets"),
+};

--- a/ticketing-frontend/src/features/tickets/model/types.ts
+++ b/ticketing-frontend/src/features/tickets/model/types.ts
@@ -1,8 +1,21 @@
 export type TicketStatus = "OPEN" | "IN_PROGRESS" | "RESOLVED";
+export type TicketPriority = "LOW" | "MEDIUM" | "HIGH";
+export type TicketQueueScope = "UNASSIGNED" | "MINE" | "OTHERS" | "ALL";
 
 export type TicketSummary = {
   id: string;
   title: string;
   status: TicketStatus;
+  priority: TicketPriority;
   createdAt: string;
+  updatedAt: string;
+  createdByUserId: string;
+  assignedToUserId: string | null;
+};
+
+export type PaginatedResponse<T> = {
+  items: T[];
+  page: number;
+  size: number;
+  total: number;
 };

--- a/ticketing-frontend/src/features/tickets/model/types.ts
+++ b/ticketing-frontend/src/features/tickets/model/types.ts
@@ -1,0 +1,8 @@
+export type TicketStatus = "OPEN" | "IN_PROGRESS" | "RESOLVED";
+
+export type TicketSummary = {
+  id: string;
+  title: string;
+  status: TicketStatus;
+  createdAt: string;
+};

--- a/ticketing-frontend/src/features/tickets/ui/AgentAdminTicketsPage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/AgentAdminTicketsPage.test.tsx
@@ -1,9 +1,20 @@
 import { render, screen } from "@testing-library/react";
 import { ConfigProvider } from "antd";
+import { vi } from "vitest";
 import { AgentAdminTicketsPage } from "./AgentAdminTicketsPage";
 
+const getQueueTicketsMock = vi.fn();
+
+vi.mock("../api/ticketsApi", () => ({
+  ticketsApi: {
+    getQueueTickets: () => getQueueTicketsMock(),
+  },
+}));
+
 describe("AgentAdminTicketsPage", () => {
-  it("renders queue controls and backend notice", () => {
+  it("renders queue controls and loaded table state", async () => {
+    getQueueTicketsMock.mockResolvedValueOnce({ items: [], page: 0, size: 20, total: 0 });
+
     render(
       <ConfigProvider>
         <AgentAdminTicketsPage />
@@ -12,6 +23,6 @@ describe("AgentAdminTicketsPage", () => {
 
     expect(screen.getByRole("heading", { name: "Gestión de tickets" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Sin asignar" })).toBeInTheDocument();
-    expect(screen.getByText("Panel AGENT/ADMIN preparado")).toBeInTheDocument();
+    expect(await screen.findByText("No hay tickets para mostrar con los filtros actuales")).toBeInTheDocument();
   });
 });

--- a/ticketing-frontend/src/features/tickets/ui/AgentAdminTicketsPage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/AgentAdminTicketsPage.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { ConfigProvider } from "antd";
+import { AgentAdminTicketsPage } from "./AgentAdminTicketsPage";
+
+describe("AgentAdminTicketsPage", () => {
+  it("renders queue controls and backend notice", () => {
+    render(
+      <ConfigProvider>
+        <AgentAdminTicketsPage />
+      </ConfigProvider>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Gestión de tickets" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sin asignar" })).toBeInTheDocument();
+    expect(screen.getByText("Panel AGENT/ADMIN preparado")).toBeInTheDocument();
+  });
+});

--- a/ticketing-frontend/src/features/tickets/ui/AgentAdminTicketsPage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/AgentAdminTicketsPage.tsx
@@ -1,39 +1,23 @@
-import { Alert, Button, Card, Empty, Space, Table, Tag, Typography } from "antd";
+import { Alert, Button, Card, Empty, Skeleton, Space, Table, Tag, Typography } from "antd";
 import type { TableProps } from "antd";
-import { useMemo, useState } from "react";
-
-type AgentTicketQueueItem = {
-  id: string;
-  title: string;
-  status: "OPEN" | "IN_PROGRESS" | "RESOLVED";
-  priority: "LOW" | "MEDIUM" | "HIGH" | "URGENT";
-  assignee: string | null;
-  updatedAt: string;
-};
+import { useEffect, useMemo, useState } from "react";
+import { ticketsApi } from "../api/ticketsApi";
+import type { TicketPriority, TicketQueueScope, TicketStatus, TicketSummary } from "../model/types";
 
 type QueueView = "unassigned" | "mine" | "all";
+type LoadState = "loading" | "ready" | "error";
 
-const STATUS_LABEL: Record<AgentTicketQueueItem["status"], string> = {
+const STATUS_LABEL: Record<TicketStatus, string> = {
   OPEN: "Abierto",
   IN_PROGRESS: "En progreso",
   RESOLVED: "Resuelto",
 };
 
-const PRIORITY_LABEL: Record<AgentTicketQueueItem["priority"], string> = {
+const PRIORITY_LABEL: Record<TicketPriority, string> = {
   LOW: "Baja",
   MEDIUM: "Media",
   HIGH: "Alta",
-  URGENT: "Urgente",
 };
-
-const METRICS = [
-  { title: "Sin asignar", value: "--" },
-  { title: "Asignados a mí", value: "--" },
-  { title: "En progreso", value: "--" },
-  { title: "SLA en riesgo", value: "--" },
-] as const;
-
-const EMPTY_QUEUE: AgentTicketQueueItem[] = [];
 
 function formatDate(isoDate: string) {
   return new Intl.DateTimeFormat("es-ES", {
@@ -42,10 +26,50 @@ function formatDate(isoDate: string) {
   }).format(new Date(isoDate));
 }
 
+function queueScopeFromView(view: QueueView): TicketQueueScope {
+  if (view === "unassigned") return "UNASSIGNED";
+  if (view === "mine") return "MINE";
+  return "ALL";
+}
+
 export function AgentAdminTicketsPage() {
   const [view, setView] = useState<QueueView>("unassigned");
+  const [loadState, setLoadState] = useState<LoadState>("loading");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [tickets, setTickets] = useState<TicketSummary[]>([]);
+  const [total, setTotal] = useState(0);
 
-  const columns: TableProps<AgentTicketQueueItem>["columns"] = useMemo(
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadQueue = async () => {
+      setLoadState("loading");
+      setErrorMessage(null);
+
+      try {
+        const response = await ticketsApi.getQueueTickets({ scope: queueScopeFromView(view), page: 0, size: 20 });
+
+        if (!isMounted) return;
+
+        setTickets(response.items);
+        setTotal(response.total);
+        setLoadState("ready");
+      } catch (error) {
+        if (!isMounted) return;
+
+        setLoadState("error");
+        setErrorMessage(error instanceof Error ? error.message : "No se pudo cargar la cola de tickets.");
+      }
+    };
+
+    void loadQueue();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [view]);
+
+  const columns: TableProps<TicketSummary>["columns"] = useMemo(
     () => [
       { title: "ID", dataIndex: "id", key: "id", width: 180 },
       { title: "Título", dataIndex: "title", key: "title" },
@@ -54,20 +78,20 @@ export function AgentAdminTicketsPage() {
         dataIndex: "status",
         key: "status",
         width: 140,
-        render: (statusValue: unknown) => <Tag>{STATUS_LABEL[statusValue as AgentTicketQueueItem["status"]]}</Tag>,
+        render: (statusValue: unknown) => <Tag>{STATUS_LABEL[statusValue as TicketStatus]}</Tag>,
       },
       {
         title: "Prioridad",
         dataIndex: "priority",
         key: "priority",
-        width: 140,
-        render: (priorityValue: unknown) => <Tag>{PRIORITY_LABEL[priorityValue as AgentTicketQueueItem["priority"]]}</Tag>,
+        width: 120,
+        render: (priorityValue: unknown) => <Tag>{PRIORITY_LABEL[priorityValue as TicketPriority]}</Tag>,
       },
       {
         title: "Asignado",
-        dataIndex: "assignee",
-        key: "assignee",
-        width: 160,
+        dataIndex: "assignedToUserId",
+        key: "assignedToUserId",
+        width: 180,
         render: (assigneeValue: unknown) => (assigneeValue ? String(assigneeValue) : "Sin asignar"),
       },
       {
@@ -88,6 +112,9 @@ export function AgentAdminTicketsPage() {
         ? "Tickets asignados a mí"
         : "Todos los tickets";
 
+  const unassignedCount = tickets.filter((ticket) => ticket.assignedToUserId === null).length;
+  const inProgressCount = tickets.filter((ticket) => ticket.status === "IN_PROGRESS").length;
+
   return (
     <Space direction="vertical" size={16} style={{ width: "100%" }}>
       <Typography.Title level={3} style={{ margin: 0 }}>
@@ -95,22 +122,23 @@ export function AgentAdminTicketsPage() {
       </Typography.Title>
 
       <Space style={{ display: "grid", gridTemplateColumns: "repeat(4, minmax(0, 1fr))" }}>
-        {METRICS.map((metric) => (
-          <Card key={metric.title}>
-            <Typography.Text type="secondary">{metric.title}</Typography.Text>
-            <Typography.Title level={3} style={{ margin: "8px 0 0" }}>
-              {metric.value}
-            </Typography.Title>
-          </Card>
-        ))}
+        <Card>
+          <Typography.Text type="secondary">Sin asignar (vista)</Typography.Text>
+          <Typography.Title level={3} style={{ margin: "8px 0 0" }}>{unassignedCount}</Typography.Title>
+        </Card>
+        <Card>
+          <Typography.Text type="secondary">Total (vista)</Typography.Text>
+          <Typography.Title level={3} style={{ margin: "8px 0 0" }}>{total}</Typography.Title>
+        </Card>
+        <Card>
+          <Typography.Text type="secondary">En progreso (vista)</Typography.Text>
+          <Typography.Title level={3} style={{ margin: "8px 0 0" }}>{inProgressCount}</Typography.Title>
+        </Card>
+        <Card>
+          <Typography.Text type="secondary">Scope actual</Typography.Text>
+          <Typography.Title level={3} style={{ margin: "8px 0 0" }}>{queueScopeFromView(view)}</Typography.Title>
+        </Card>
       </Space>
-
-      <Alert
-        type="info"
-        showIcon
-        message="Panel AGENT/ADMIN preparado"
-        description="La estructura de cola, métricas y tabla ya está lista. En cuanto estén los endpoints de listado/filtros se conectará con datos reales."
-      />
 
       <Space>
         <Button type={view === "unassigned" ? "primary" : "default"} onClick={() => setView("unassigned")}>Sin asignar</Button>
@@ -124,10 +152,23 @@ export function AgentAdminTicketsPage() {
             {viewLabel}
           </Typography.Title>
 
-          {EMPTY_QUEUE.length === 0 ? (
+          {loadState === "loading" && <Skeleton active paragraph={{ rows: 6 }} />}
+
+          {loadState === "error" && (
+            <Alert
+              type="error"
+              showIcon
+              message="No se ha podido cargar la cola de tickets"
+              description={errorMessage}
+            />
+          )}
+
+          {loadState === "ready" && tickets.length === 0 && (
             <Empty description="No hay tickets para mostrar con los filtros actuales" />
-          ) : (
-            <Table<AgentTicketQueueItem> rowKey="id" columns={columns} dataSource={EMPTY_QUEUE} pagination={{ pageSize: 10 }} />
+          )}
+
+          {loadState === "ready" && tickets.length > 0 && (
+            <Table<TicketSummary> rowKey="id" columns={columns} dataSource={tickets} pagination={{ pageSize: 10 }} />
           )}
         </Space>
       </Card>

--- a/ticketing-frontend/src/features/tickets/ui/AgentAdminTicketsPage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/AgentAdminTicketsPage.tsx
@@ -1,0 +1,136 @@
+import { Alert, Button, Card, Empty, Space, Table, Tag, Typography } from "antd";
+import type { TableProps } from "antd";
+import { useMemo, useState } from "react";
+
+type AgentTicketQueueItem = {
+  id: string;
+  title: string;
+  status: "OPEN" | "IN_PROGRESS" | "RESOLVED";
+  priority: "LOW" | "MEDIUM" | "HIGH" | "URGENT";
+  assignee: string | null;
+  updatedAt: string;
+};
+
+type QueueView = "unassigned" | "mine" | "all";
+
+const STATUS_LABEL: Record<AgentTicketQueueItem["status"], string> = {
+  OPEN: "Abierto",
+  IN_PROGRESS: "En progreso",
+  RESOLVED: "Resuelto",
+};
+
+const PRIORITY_LABEL: Record<AgentTicketQueueItem["priority"], string> = {
+  LOW: "Baja",
+  MEDIUM: "Media",
+  HIGH: "Alta",
+  URGENT: "Urgente",
+};
+
+const METRICS = [
+  { title: "Sin asignar", value: "--" },
+  { title: "Asignados a mí", value: "--" },
+  { title: "En progreso", value: "--" },
+  { title: "SLA en riesgo", value: "--" },
+] as const;
+
+const EMPTY_QUEUE: AgentTicketQueueItem[] = [];
+
+function formatDate(isoDate: string) {
+  return new Intl.DateTimeFormat("es-ES", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date(isoDate));
+}
+
+export function AgentAdminTicketsPage() {
+  const [view, setView] = useState<QueueView>("unassigned");
+
+  const columns: TableProps<AgentTicketQueueItem>["columns"] = useMemo(
+    () => [
+      { title: "ID", dataIndex: "id", key: "id", width: 180 },
+      { title: "Título", dataIndex: "title", key: "title" },
+      {
+        title: "Estado",
+        dataIndex: "status",
+        key: "status",
+        width: 140,
+        render: (statusValue: unknown) => <Tag>{STATUS_LABEL[statusValue as AgentTicketQueueItem["status"]]}</Tag>,
+      },
+      {
+        title: "Prioridad",
+        dataIndex: "priority",
+        key: "priority",
+        width: 140,
+        render: (priorityValue: unknown) => <Tag>{PRIORITY_LABEL[priorityValue as AgentTicketQueueItem["priority"]]}</Tag>,
+      },
+      {
+        title: "Asignado",
+        dataIndex: "assignee",
+        key: "assignee",
+        width: 160,
+        render: (assigneeValue: unknown) => (assigneeValue ? String(assigneeValue) : "Sin asignar"),
+      },
+      {
+        title: "Actualizado",
+        dataIndex: "updatedAt",
+        key: "updatedAt",
+        width: 180,
+        render: (updatedAtValue: unknown) => formatDate(String(updatedAtValue)),
+      },
+    ],
+    [],
+  );
+
+  const viewLabel =
+    view === "unassigned"
+      ? "Cola sin asignar"
+      : view === "mine"
+        ? "Tickets asignados a mí"
+        : "Todos los tickets";
+
+  return (
+    <Space direction="vertical" size={16} style={{ width: "100%" }}>
+      <Typography.Title level={3} style={{ margin: 0 }}>
+        Gestión de tickets
+      </Typography.Title>
+
+      <Space style={{ display: "grid", gridTemplateColumns: "repeat(4, minmax(0, 1fr))" }}>
+        {METRICS.map((metric) => (
+          <Card key={metric.title}>
+            <Typography.Text type="secondary">{metric.title}</Typography.Text>
+            <Typography.Title level={3} style={{ margin: "8px 0 0" }}>
+              {metric.value}
+            </Typography.Title>
+          </Card>
+        ))}
+      </Space>
+
+      <Alert
+        type="info"
+        showIcon
+        message="Panel AGENT/ADMIN preparado"
+        description="La estructura de cola, métricas y tabla ya está lista. En cuanto estén los endpoints de listado/filtros se conectará con datos reales."
+      />
+
+      <Space>
+        <Button type={view === "unassigned" ? "primary" : "default"} onClick={() => setView("unassigned")}>Sin asignar</Button>
+        <Button type={view === "mine" ? "primary" : "default"} onClick={() => setView("mine")}>Asignados a mí</Button>
+        <Button type={view === "all" ? "primary" : "default"} onClick={() => setView("all")}>Todos</Button>
+      </Space>
+
+      <Card>
+        <Space direction="vertical" size={12} style={{ width: "100%" }}>
+          <Typography.Title level={4} style={{ margin: 0 }}>
+            {viewLabel}
+          </Typography.Title>
+
+          {EMPTY_QUEUE.length === 0 ? (
+            <Empty description="No hay tickets para mostrar con los filtros actuales" />
+          ) : (
+            <Table<AgentTicketQueueItem> rowKey="id" columns={columns} dataSource={EMPTY_QUEUE} pagination={{ pageSize: 10 }} />
+          )}
+        </Space>
+      </Card>
+    </Space>
+  );
+}

--- a/ticketing-frontend/src/features/tickets/ui/UserTicketsHomePage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/UserTicketsHomePage.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { ConfigProvider } from "antd";
+import { MemoryRouter } from "react-router-dom";
+import { vi } from "vitest";
+import { UserTicketsHomePage } from "./UserTicketsHomePage";
+
+const getMyTicketsMock = vi.fn();
+
+vi.mock("../api/ticketsApi", () => ({
+  ticketsApi: {
+    getMyTickets: () => getMyTicketsMock(),
+  },
+}));
+
+describe("UserTicketsHomePage", () => {
+  it("renders empty state when user has no tickets", async () => {
+    getMyTicketsMock.mockResolvedValueOnce([]);
+
+    render(
+      <ConfigProvider>
+        <MemoryRouter>
+          <UserTicketsHomePage />
+        </MemoryRouter>
+      </ConfigProvider>,
+    );
+
+    expect(await screen.findByText("Aún no tienes tickets creados")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Crear ticket" })).toBeInTheDocument();
+  });
+});

--- a/ticketing-frontend/src/features/tickets/ui/UserTicketsHomePage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/UserTicketsHomePage.test.tsx
@@ -14,7 +14,7 @@ vi.mock("../api/ticketsApi", () => ({
 
 describe("UserTicketsHomePage", () => {
   it("renders empty state when user has no tickets", async () => {
-    getMyTicketsMock.mockResolvedValueOnce([]);
+    getMyTicketsMock.mockResolvedValueOnce({ items: [], page: 0, size: 20, total: 0 });
 
     render(
       <ConfigProvider>

--- a/ticketing-frontend/src/features/tickets/ui/UserTicketsHomePage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/UserTicketsHomePage.tsx
@@ -3,7 +3,7 @@ import { Alert, Button, Empty, Skeleton, Space, Table, Tag, Typography } from "a
 import type { TableProps } from "antd";
 import { useNavigate } from "react-router-dom";
 import { ticketsApi } from "../api/ticketsApi";
-import type { TicketStatus, TicketSummary } from "../model/types";
+import type { TicketPriority, TicketStatus, TicketSummary } from "../model/types";
 
 type LoadState = "loading" | "ready" | "error";
 
@@ -17,6 +17,13 @@ const statusLabelByValue: Record<TicketStatus, string> = {
   OPEN: "Abierto",
   IN_PROGRESS: "En progreso",
   RESOLVED: "Resuelto",
+};
+
+
+const priorityLabelByValue: Record<TicketPriority, string> = {
+  LOW: "Baja",
+  MEDIUM: "Media",
+  HIGH: "Alta",
 };
 
 function formatDate(isoDate: string) {
@@ -44,7 +51,7 @@ export function UserTicketsHomePage() {
 
         if (!isMounted) return;
 
-        setTickets(response);
+        setTickets(response.items);
         setLoadState("ready");
       } catch (error) {
         if (!isMounted) return;
@@ -79,11 +86,18 @@ export function UserTicketsHomePage() {
         title: "Estado",
         dataIndex: "status",
         key: "status",
-        width: 160,
+        width: 140,
         render: (statusValue: unknown) => {
           const status = statusValue as TicketStatus;
           return <Tag color={statusColorByValue[status]}>{statusLabelByValue[status]}</Tag>;
         },
+      },
+      {
+        title: "Prioridad",
+        dataIndex: "priority",
+        key: "priority",
+        width: 120,
+        render: (priorityValue: unknown) => <Tag>{priorityLabelByValue[priorityValue as TicketPriority]}</Tag>,
       },
       {
         title: "Fecha creación",

--- a/ticketing-frontend/src/features/tickets/ui/UserTicketsHomePage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/UserTicketsHomePage.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useMemo, useState } from "react";
+import { Alert, Button, Empty, Skeleton, Space, Table, Tag, Typography } from "antd";
+import type { TableProps } from "antd";
+import { useNavigate } from "react-router-dom";
+import { ticketsApi } from "../api/ticketsApi";
+import type { TicketStatus, TicketSummary } from "../model/types";
+
+type LoadState = "loading" | "ready" | "error";
+
+const statusColorByValue: Record<TicketStatus, string> = {
+  OPEN: "default",
+  IN_PROGRESS: "processing",
+  RESOLVED: "success",
+};
+
+const statusLabelByValue: Record<TicketStatus, string> = {
+  OPEN: "Abierto",
+  IN_PROGRESS: "En progreso",
+  RESOLVED: "Resuelto",
+};
+
+function formatDate(isoDate: string) {
+  return new Intl.DateTimeFormat("es-ES", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(isoDate));
+}
+
+export function UserTicketsHomePage() {
+  const navigate = useNavigate();
+  const [tickets, setTickets] = useState<TicketSummary[]>([]);
+  const [loadState, setLoadState] = useState<LoadState>("loading");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadTickets = async () => {
+      setLoadState("loading");
+      setErrorMessage(null);
+
+      try {
+        const response = await ticketsApi.getMyTickets();
+
+        if (!isMounted) return;
+
+        setTickets(response);
+        setLoadState("ready");
+      } catch (error) {
+        if (!isMounted) return;
+
+        setLoadState("error");
+        setErrorMessage(error instanceof Error ? error.message : "No se pudieron cargar tus tickets.");
+      }
+    };
+
+    void loadTickets();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const columns: TableProps<TicketSummary>["columns"] = useMemo(
+    () => [
+      {
+        title: "ID",
+        dataIndex: "id",
+        key: "id",
+        width: 240,
+        ellipsis: true,
+      },
+      {
+        title: "Título",
+        dataIndex: "title",
+        key: "title",
+      },
+      {
+        title: "Estado",
+        dataIndex: "status",
+        key: "status",
+        width: 160,
+        render: (statusValue: unknown) => {
+          const status = statusValue as TicketStatus;
+          return <Tag color={statusColorByValue[status]}>{statusLabelByValue[status]}</Tag>;
+        },
+      },
+      {
+        title: "Fecha creación",
+        dataIndex: "createdAt",
+        key: "createdAt",
+        width: 220,
+        render: (createdAtValue: unknown) => formatDate(String(createdAtValue)),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <Space direction="vertical" size={20} style={{ width: "100%" }}>
+      <Space style={{ width: "100%", justifyContent: "space-between" }}>
+        <Typography.Title level={3} style={{ margin: 0 }}>
+          Mis tickets
+        </Typography.Title>
+        <Button type="primary" size="large" onClick={() => navigate("/tickets/new")}>
+          Crear ticket
+        </Button>
+      </Space>
+
+      {loadState === "loading" && <Skeleton active paragraph={{ rows: 6 }} />}
+
+      {loadState === "error" && (
+        <Alert
+          type="error"
+          showIcon
+          message="No hemos podido cargar tus tickets"
+          description={errorMessage}
+        />
+      )}
+
+      {loadState === "ready" && tickets.length === 0 && (
+        <Empty description="Aún no tienes tickets creados" />
+      )}
+
+      {loadState === "ready" && tickets.length > 0 && (
+        <Table<TicketSummary>
+          rowKey="id"
+          columns={columns}
+          dataSource={tickets}
+          pagination={{ pageSize: 10, hideOnSinglePage: true }}
+        />
+      )}
+    </Space>
+  );
+}

--- a/ticketing-frontend/src/vendor/antd/index.tsx
+++ b/ticketing-frontend/src/vendor/antd/index.tsx
@@ -115,13 +115,13 @@ export function Card({ children }: { children: React.ReactNode }) {
   return <section style={{ border: "1px solid #e5e7eb", borderRadius: 10, padding: 20 }}>{children}</section>;
 }
 
-export function Button({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) {
+export function Button({ children, onClick, type, size }: { children: React.ReactNode; onClick?: () => void; type?: "primary" | "default"; size?: "small" | "middle" | "large" }) {
   const theme = useContext(ThemeContext);
   return (
     <button
       type="button"
       onClick={onClick}
-      style={{ background: theme?.token?.colorPrimary ?? "#0c9136", color: "#fff", border: "none", padding: "8px 12px", borderRadius: 6 }}
+      style={{ background: type === "primary" || !type ? theme?.token?.colorPrimary ?? "#0c9136" : "#fff", color: type === "primary" || !type ? "#fff" : "#111827", border: type === "primary" || !type ? "none" : "1px solid #d1d5db", padding: size === "large" ? "10px 16px" : "8px 12px", borderRadius: 6 }}
     >
       {children}
     </button>
@@ -135,5 +135,72 @@ export function Result({ title, subTitle, extra }: { status?: string; title: str
       {subTitle && <p>{subTitle}</p>}
       {extra}
     </section>
+  );
+}
+
+
+export function Space({ children, direction = "horizontal", size = 8, style }: { children: React.ReactNode; direction?: "horizontal" | "vertical"; size?: number; style?: React.CSSProperties }) {
+  return <div style={{ display: "flex", flexDirection: direction === "vertical" ? "column" : "row", gap: size, ...(style ?? {}) }}>{children}</div>;
+}
+
+export function Tag({ children }: { children: React.ReactNode; color?: string }) {
+  return <span style={{ background: "#f3f4f6", borderRadius: 999, padding: "2px 8px", fontSize: 12 }}>{children}</span>;
+}
+
+export function Skeleton({ paragraph }: { active?: boolean; paragraph?: { rows: number } }) {
+  return <div aria-label="skeleton">Cargando... ({paragraph?.rows ?? 3})</div>;
+}
+
+export function Empty({ description }: { description?: React.ReactNode }) {
+  return <div>{description ?? "Sin datos"}</div>;
+}
+
+export function Alert({ message, description }: { type?: string; showIcon?: boolean; message: React.ReactNode; description?: React.ReactNode }) {
+  return <div><strong>{message}</strong>{description ? <p>{description}</p> : null}</div>;
+}
+
+export type TableProps<T> = {
+  rowKey: keyof T | ((row: T) => React.Key);
+  columns: Array<{
+    title: React.ReactNode;
+    dataIndex: keyof T;
+    key: string;
+    width?: number;
+    ellipsis?: boolean;
+    render?: (value: unknown, row: T) => React.ReactNode;
+  }>;
+  dataSource: T[];
+  pagination?: { pageSize?: number; hideOnSinglePage?: boolean };
+};
+
+export function Table<T extends Record<string, unknown>>({ rowKey, columns, dataSource }: TableProps<T>) {
+  const keyGetter = typeof rowKey === "function" ? rowKey : (row: T) => row[rowKey] as React.Key;
+
+  return (
+    <table style={{ width: "100%", borderCollapse: "collapse" }}>
+      <thead>
+        <tr>
+          {columns.map((column) => (
+            <th key={column.key} style={{ textAlign: "left", borderBottom: "1px solid #e5e7eb", padding: "8px 4px" }}>
+              {column.title}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {dataSource.map((row) => (
+          <tr key={keyGetter(row)}>
+            {columns.map((column) => {
+              const value = row[column.dataIndex];
+              return (
+                <td key={column.key} style={{ borderBottom: "1px solid #f3f4f6", padding: "8px 4px" }}>
+                  {column.render ? column.render(value, row) : (value as React.ReactNode)}
+                </td>
+              );
+            })}
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 }


### PR DESCRIPTION
### Motivation
- Wire up role-aware landing and tickets UX so users and agents/admins see the correct landing page and ticket list.
- Provide a minimal tickets API client and types so the UI can request user tickets once the backend is available.
- Extend the mocked `antd` test helpers to support components used by the tickets UI and refine `AppShell`/login redirect behavior.

### Description
- Add `RoleLandingRedirect` and use it for the root route so the app redirects users to `"/tickets"` or agents/admins to `"/dashboard"` via `useAuth` and `Navigate`.
- Replace the `"/tickets"` route with a new `TicketsPage` that renders `UserTicketsHomePage` for normal users or a placeholder for agents/admins.
- Implement `UserTicketsHomePage` which loads tickets via `ticketsApi.getMyTickets`, shows loading/error/empty states and a table when tickets exist, and includes localized date formatting and status labels.
- Add a small `ticketsApi` client and types in `features/tickets` (`ticketsApi.ts`, `model/types.ts`) wired to the shared API client and localStorage token key.
- Update `LoginPage` to redirect to `"/"` by default after successful auth so the new root redirect logic takes effect.
- Improve the test vendor `antd` helpers to support `Button` `type`/`size`, `Space`, `Tag`, `Skeleton`, `Empty`, `Alert`, and a minimal `Table` implementation used by tests.
- Minor formatting/whitespace cleanups in `AppShell` and `getSelectedKey` sorting line alignment.

### Testing
- Added unit tests `RoleLandingRedirect.test.tsx`, `TicketsPage.test.tsx`, and `UserTicketsHomePage.test.tsx` which exercise redirection, role branching and the empty-state render respectively, and they passed when running the test suite.
- Ran the full unit test suite with `vitest` and the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5e6e746208328920345d9b6541b3a)