### PR TITLE
feat: perfil JWT en /profile y logout funcional

### DIFF
--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/auth/AuthController.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/auth/AuthController.java
@@ -6,10 +6,14 @@ import com.aperdigon.ticketing_backend.application.auth.register.RegisterCommand
 import com.aperdigon.ticketing_backend.application.auth.register.RegisterUseCase;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -39,5 +43,20 @@ public class AuthController {
         ));
 
         return ResponseEntity.ok(new LoginResponse(result.accessToken()));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<AuthProfileResponse> me(JwtAuthenticationToken authentication) {
+        var jwt = authentication.getToken();
+        var roles = jwt.getClaimAsStringList("roles");
+        var role = roles == null || roles.isEmpty() ? "UNKNOWN" : roles.get(0);
+
+        return ResponseEntity.ok(new AuthProfileResponse(
+                jwt.getSubject(),
+                jwt.getClaimAsString("email"),
+                jwt.getClaimAsString("displayName"),
+                role,
+                roles == null ? List.of() : roles
+        ));
     }
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/auth/AuthProfileResponse.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/auth/AuthProfileResponse.java
@@ -1,0 +1,12 @@
+package com.aperdigon.ticketing_backend.api.auth;
+
+import java.util.List;
+
+public record AuthProfileResponse(
+        String sub,
+        String email,
+        String displayName,
+        String role,
+        List<String> roles
+) {
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/security/token/JwtTokenIssuer.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/security/token/JwtTokenIssuer.java
@@ -50,6 +50,8 @@ public class JwtTokenIssuer implements TokenIssuer {
                     .issueTime(Date.from(now))
                     .expirationTime(Date.from(exp))
                     .claim("roles", List.of(user.role().name()))
+                    .claim("email", user.email())
+                    .claim("displayName", user.displayName())
                     .build();
 
             SignedJWT jwt = new SignedJWT(

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/auth/AuthLoginIntegrationTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/auth/AuthLoginIntegrationTest.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -109,6 +110,8 @@ class AuthLoginIntegrationTest {
         SignedJWT jwt = SignedJWT.parse(token);
 
         assertEquals(activeUserId.toString(), jwt.getJWTClaimsSet().getSubject());
+        assertEquals("user@test.com", jwt.getJWTClaimsSet().getStringClaim("email"));
+        assertEquals("User", jwt.getJWTClaimsSet().getStringClaim("displayName"));
         assertEquals(List.of("USER"), jwt.getJWTClaimsSet().getStringListClaim("roles"));
         assertNotNull(jwt.getJWTClaimsSet().getExpirationTime());
     }
@@ -154,6 +157,28 @@ class AuthLoginIntegrationTest {
         var savedUser = userRepo.findByEmailIgnoreCase("new.user@test.com").orElseThrow();
         assertEquals(UserRole.USER, savedUser.getRole());
         assertEquals("New User", savedUser.getDisplayName());
+    }
+
+    @Test
+    void me_returns_profile_data_from_jwt_claims() throws Exception {
+        var loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"email":"user@test.com","password":"secret123"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String tokenBody = loginResult.getResponse().getContentAsString();
+        String token = tokenBody.replaceAll(".*\"accessToken\":\"([^\"]+)\".*", "$1");
+
+        mockMvc.perform(get("/api/auth/me")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sub").value(activeUserId.toString()))
+                .andExpect(jsonPath("$.email").value("user@test.com"))
+                .andExpect(jsonPath("$.displayName").value("User"))
+                .andExpect(jsonPath("$.role").value("USER"));
     }
 
     @Test

--- a/ticketing-frontend/src/app/layout/AppShell.test.tsx
+++ b/ticketing-frontend/src/app/layout/AppShell.test.tsx
@@ -6,10 +6,12 @@ import { vi } from "vitest";
 import { AppShell } from "./AppShell";
 
 const hasRoleMock = vi.fn<(role: "USER" | "AGENT" | "ADMIN") => boolean>();
+const logoutMock = vi.fn();
 
 vi.mock("../../features/auth/hooks/useAuth", () => ({
   useAuth: () => ({
     hasRole: hasRoleMock,
+    logout: logoutMock,
   }),
 }));
 
@@ -22,6 +24,7 @@ function renderWithRouter(initialEntries: string[] = ["/dashboard"]) {
           { path: "/dashboard", element: <h1>Dashboard page</h1> },
           { path: "/tickets", element: <h1>Tickets page</h1> },
           { path: "/tickets/new", element: <h1>Nuevo ticket page</h1> },
+          { path: "/login", element: <h1>Login page</h1> },
         ],
       },
     ],
@@ -38,6 +41,7 @@ function renderWithRouter(initialEntries: string[] = ["/dashboard"]) {
 describe("AppShell", () => {
   beforeEach(() => {
     hasRoleMock.mockReset();
+    logoutMock.mockReset();
   });
 
   it("renders sidebar, header and page content", () => {
@@ -71,5 +75,16 @@ describe("AppShell", () => {
     renderWithRouter();
 
     expect(screen.getByText("Administración")).toBeInTheDocument();
+  });
+
+  it("logs out and redirects to login from header button", async () => {
+    hasRoleMock.mockReturnValue(false);
+    const user = userEvent.setup();
+    renderWithRouter();
+
+    await user.click(screen.getByRole("button", { name: "Logout" }));
+
+    expect(logoutMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("heading", { name: "Login page" })).toBeInTheDocument();
   });
 });

--- a/ticketing-frontend/src/app/layout/AppShell.tsx
+++ b/ticketing-frontend/src/app/layout/AppShell.tsx
@@ -1,5 +1,5 @@
 import { MdDashboard, MdOutlineAdd } from "react-icons/md";
-import { Layout, Menu, Typography } from "antd";
+import { Button, Layout, Menu, Typography } from "antd";
 import type { MenuProps } from "antd";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import { HiBars3, HiTicket, HiUsers } from "react-icons/hi2";
@@ -36,9 +36,14 @@ function getSelectedKey(pathname: string, items: AppMenuItem[]) {
 export function AppShell() {
   const location = useLocation();
   const navigate = useNavigate();
-  const { hasRole } = useAuth();
+  const { hasRole, logout } = useAuth();
 
   const menuItems = getMenuItems(hasRole("AGENT"));
+
+  const onLogout = () => {
+    logout();
+    navigate("/login", { replace: true });
+  };
 
   return (
     <Layout style={{ minHeight: "100vh" }}>
@@ -65,6 +70,7 @@ export function AppShell() {
             borderBottom: "1px solid #f0f0f0",
             display: "flex",
             alignItems: "center",
+            justifyContent: "space-between",
             paddingInline: 24,
             height: 64,
           }}
@@ -72,6 +78,8 @@ export function AppShell() {
           <Typography.Title level={5} style={{ margin: 0 }}>
             Ticketing Platform
           </Typography.Title>
+
+          <Button onClick={onLogout}>Logout</Button>
         </Header>
         <Content style={{ margin: 24 }}>
           <Outlet />

--- a/ticketing-frontend/src/app/pages/ProfilePage.tsx
+++ b/ticketing-frontend/src/app/pages/ProfilePage.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+import type { CSSProperties } from "react";
+import { Alert, Button, Card, Space, Typography } from "antd";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../../features/auth/hooks/useAuth";
+import { authApi } from "../../features/auth/api/authApi";
+import type { ProfileResponse } from "../../features/auth/model/types";
+
+const rowStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "160px 1fr",
+  gap: 12,
+  padding: "8px 0",
+  borderBottom: "1px solid #f3f4f6",
+};
+
+export function ProfilePage() {
+  const navigate = useNavigate();
+  const { state, logout } = useAuth();
+  const [profile, setProfile] = useState<ProfileResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!state.token) return;
+
+    authApi.me(state.token)
+      .then((data) => {
+        setProfile(data);
+      })
+      .catch((err: Error) => {
+        setError(err.message || "No se pudo cargar el perfil");
+      });
+  }, [state.token]);
+
+  const onLogout = () => {
+    logout();
+    navigate("/login", { replace: true });
+  };
+
+  const data = profile ?? (state.user ? {
+    sub: state.user.id,
+    email: state.user.email,
+    displayName: state.user.displayName,
+    role: state.user.role,
+    roles: state.user.roles,
+  } : null);
+
+  return (
+    <Space direction="vertical" size={16} style={{ width: "100%", maxWidth: 820 }}>
+      <div>
+        <Typography.Title level={3} style={{ marginBottom: 0 }}>Perfil</Typography.Title>
+        <Typography.Text type="secondary">Información de sesión actual basada en JWT.</Typography.Text>
+      </div>
+
+      {error && <Alert type="error" showIcon message={error} />}
+
+      <Card>
+        {data ? (
+          <div>
+            <div style={rowStyle}><strong>ID (sub)</strong><span>{data.sub}</span></div>
+            <div style={rowStyle}><strong>Email</strong><span>{data.email}</span></div>
+            <div style={rowStyle}><strong>Display name</strong><span>{data.displayName}</span></div>
+            <div style={{ ...rowStyle, borderBottom: "none" }}><strong>Rol</strong><span>{data.role}</span></div>
+          </div>
+        ) : (
+          <Typography.Text type="secondary">No hay datos de perfil disponibles.</Typography.Text>
+        )}
+      </Card>
+
+      <Button type="default" onClick={onLogout} style={{ width: "fit-content" }}>
+        Logout
+      </Button>
+    </Space>
+  );
+}

--- a/ticketing-frontend/src/app/router.tsx
+++ b/ticketing-frontend/src/app/router.tsx
@@ -8,6 +8,7 @@ import { RoleLandingRedirect } from "./pages/RoleLandingRedirect";
 import { TicketsPage } from "./pages/TicketsPage";
 import { CreateTicketPage } from "../features/tickets/ui/CreateTicketPage";
 import { TicketDetailPage } from "../features/tickets/ui/TicketDetailPage";
+import { ProfilePage } from "./pages/ProfilePage";
 
 function ForbiddenPage() {
   return <PlaceholderPage title="403 — Forbidden" />;
@@ -27,7 +28,7 @@ export const router = createBrowserRouter([
           { path: "/tickets", element: <TicketsPage /> },
           { path: "/tickets/new", element: <CreateTicketPage /> },
           { path: "/tickets/:id", element: <TicketDetailPage /> },
-          { path: "/profile", element: <PlaceholderPage title="Perfil" /> },
+          { path: "/profile", element: <ProfilePage /> },
           { path: "/admin", element: <PlaceholderPage title="Administración" /> },
         ],
       },

--- a/ticketing-frontend/src/features/auth/api/authApi.ts
+++ b/ticketing-frontend/src/features/auth/api/authApi.ts
@@ -1,10 +1,10 @@
-import type { LoginRequest, LoginResponse, RegisterRequest } from "../model/types";
+import type { LoginRequest, LoginResponse, ProfileResponse, RegisterRequest } from "../model/types";
 import { createApiClient } from "../../../shared/api/client";
 
-// En login todavía NO hay token, por eso getToken devuelve null
 const publicClient = createApiClient({ getToken: () => null });
 
 export const authApi = {
   login: (req: LoginRequest) => publicClient.post<LoginResponse>("/api/auth/login", req),
   register: (req: RegisterRequest) => publicClient.post<LoginResponse>("/api/auth/register", req),
+  me: (token: string) => createApiClient({ getToken: () => token }).get<ProfileResponse>("/api/auth/me"),
 };

--- a/ticketing-frontend/src/features/auth/model/jwt.ts
+++ b/ticketing-frontend/src/features/auth/model/jwt.ts
@@ -2,6 +2,8 @@ import type { Role, AuthUser } from "./types";
 
 type JwtPayload = {
   sub?: string;
+  email?: string;
+  displayName?: string;
   roles?: Role[] | string[];
   exp?: number;
 };
@@ -29,12 +31,17 @@ export function toAuthUser(token: string): AuthUser {
 
   if (!payload.sub) throw new Error("JWT missing 'sub'");
   if (!payload.exp) throw new Error("JWT missing 'exp'");
+  if (!payload.email) throw new Error("JWT missing 'email'");
+  if (!payload.displayName) throw new Error("JWT missing 'displayName'");
 
   const rolesRaw = payload.roles ?? [];
   const roles = rolesRaw.map(String) as Role[];
 
   return {
     id: payload.sub,
+    email: payload.email,
+    displayName: payload.displayName,
+    role: roles[0] ?? "USER",
     exp: payload.exp,
     roles,
   };

--- a/ticketing-frontend/src/features/auth/model/types.ts
+++ b/ticketing-frontend/src/features/auth/model/types.ts
@@ -2,6 +2,9 @@ export type Role = "USER" | "AGENT" | "ADMIN";
 
 export type AuthUser = {
   id: string;      // sub
+  email: string;
+  displayName: string;
+  role: Role;
   roles: Role[];   // claim roles
   exp: number;     // unix seconds
 };
@@ -25,4 +28,12 @@ export type RegisterRequest = {
   displayName: string;
   password: string;
   confirmPassword: string;
+};
+
+export type ProfileResponse = {
+  sub: string;
+  email: string;
+  displayName: string;
+  role: Role;
+  roles: Role[];
 };


### PR DESCRIPTION
### Motivation
- Exponer en la UI una página de `Perfil` que muestre información útil tomada del JWT (sub, email, displayName, rol) para facilitar debugging y prácticas académicas de autenticación. 
- Ofrecer un `Logout` claro y accesible para limpiar la sesión en el cliente y dejar la app lista para flujos DevOps posteriores (deploy, rotación de tokens, etc.).

### Description
- Frontend: añade la página real `ProfilePage` en `src/app/pages/ProfilePage.tsx` y monta la ruta `/profile` en `src/app/router.tsx`. La página consulta `GET /api/auth/me` y hace fallback a los datos decodificados del token ya hidratado. 
- Frontend: incorpora botón de `Logout` en la cabecera global `AppShell` (`src/app/layout/AppShell.tsx`) y otro en la propia `ProfilePage`, ambos usan `logout()` del `AuthProvider` y redirigen a `/login`.
- Frontend: extiende los tipos y el decodificador JWT en `src/features/auth/model/*` para incluir `email`, `displayName`, `role` y `roles`, y añade `authApi.me` para consumir el nuevo endpoint backend.
- Backend: el `JwtTokenIssuer` ahora añade las claims `email` y `displayName` al token, y se añade el endpoint autenticado `GET /api/auth/me` que devuelve `AuthProfileResponse` con `sub`, `email`, `displayName`, `role` y `roles`; además se actualiza el test de integración `AuthLoginIntegrationTest` para validar las nuevas claims y el endpoint.
