### PR TITLE
Add admin API and frontend UI for managing categories and users

### DIFF
--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/admin/AdminCategoryResponse.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/admin/AdminCategoryResponse.java
@@ -1,0 +1,15 @@
+package com.aperdigon.ticketing_backend.api.admin;
+
+import com.aperdigon.ticketing_backend.domain.category.Category;
+
+import java.util.UUID;
+
+public record AdminCategoryResponse(
+        UUID id,
+        String name,
+        boolean isActive
+) {
+    public static AdminCategoryResponse from(Category category) {
+        return new AdminCategoryResponse(category.id().value(), category.name(), category.isActive());
+    }
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/admin/AdminController.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/admin/AdminController.java
@@ -1,0 +1,92 @@
+package com.aperdigon.ticketing_backend.api.admin;
+
+import com.aperdigon.ticketing_backend.application.ports.CategoryRepository;
+import com.aperdigon.ticketing_backend.application.ports.UserRepository;
+import com.aperdigon.ticketing_backend.application.shared.exception.NotFoundException;
+import com.aperdigon.ticketing_backend.domain.category.Category;
+import com.aperdigon.ticketing_backend.domain.category.CategoryId;
+import com.aperdigon.ticketing_backend.domain.user.User;
+import com.aperdigon.ticketing_backend.domain.user.UserId;
+import jakarta.validation.Valid;
+import com.aperdigon.ticketing_backend.domain.shared.exception.InvalidArgumentException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/admin")
+public class AdminController {
+
+    private final CategoryRepository categoryRepository;
+    private final UserRepository userRepository;
+
+    public AdminController(CategoryRepository categoryRepository, UserRepository userRepository) {
+        this.categoryRepository = categoryRepository;
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping("/categories")
+    public List<AdminCategoryResponse> listCategories() {
+        return categoryRepository.findAll().stream()
+                .map(AdminCategoryResponse::from)
+                .toList();
+    }
+
+    @PostMapping("/categories")
+    public ResponseEntity<AdminCategoryResponse> createCategory(@Valid @RequestBody CreateCategoryRequest request) {
+        var trimmedName = request.name().trim();
+        if (categoryRepository.findByName(trimmedName).isPresent()) {
+            throw new InvalidArgumentException("Category already exists");
+        }
+
+        var category = new Category(new CategoryId(UUID.randomUUID()), trimmedName, true);
+        var saved = categoryRepository.save(category);
+
+        return ResponseEntity.created(URI.create("/api/admin/categories/" + saved.id().value()))
+                .body(AdminCategoryResponse.from(saved));
+    }
+
+    @PatchMapping("/categories/{categoryId}")
+    public AdminCategoryResponse updateCategory(
+            @PathVariable UUID categoryId,
+            @Valid @RequestBody UpdateCategoryRequest request
+    ) {
+        var existing = categoryRepository.findById(new CategoryId(categoryId))
+                .orElseThrow(() -> new NotFoundException("Category not found"));
+
+        var updated = new Category(existing.id(), request.name().trim(), request.isActive());
+        var saved = categoryRepository.save(updated);
+        return AdminCategoryResponse.from(saved);
+    }
+
+    @GetMapping("/users")
+    public List<AdminUserResponse> listUsers() {
+        return userRepository.findAll().stream()
+                .map(AdminUserResponse::from)
+                .toList();
+    }
+
+    @PatchMapping("/users/{userId}/active")
+    public AdminUserResponse updateUserActive(
+            @PathVariable UUID userId,
+            @Valid @RequestBody UpdateUserActiveRequest request
+    ) {
+        var existing = userRepository.findById(new UserId(userId))
+                .orElseThrow(() -> new NotFoundException("User not found"));
+
+        var updated = new User(
+                existing.id(),
+                existing.email(),
+                existing.displayName(),
+                existing.passwordHash(),
+                existing.role(),
+                request.isActive()
+        );
+
+        var saved = userRepository.save(updated);
+        return AdminUserResponse.from(saved);
+    }
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/admin/AdminUserResponse.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/admin/AdminUserResponse.java
@@ -1,0 +1,23 @@
+package com.aperdigon.ticketing_backend.api.admin;
+
+import com.aperdigon.ticketing_backend.domain.user.User;
+
+import java.util.UUID;
+
+public record AdminUserResponse(
+        UUID id,
+        String email,
+        String displayName,
+        String role,
+        boolean isActive
+) {
+    public static AdminUserResponse from(User user) {
+        return new AdminUserResponse(
+                user.id().value(),
+                user.email(),
+                user.displayName(),
+                user.role().name(),
+                user.isActive()
+        );
+    }
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/admin/CreateCategoryRequest.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/admin/CreateCategoryRequest.java
@@ -1,0 +1,7 @@
+package com.aperdigon.ticketing_backend.api.admin;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateCategoryRequest(
+        @NotBlank String name
+) {}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/admin/UpdateCategoryRequest.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/admin/UpdateCategoryRequest.java
@@ -1,0 +1,9 @@
+package com.aperdigon.ticketing_backend.api.admin;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateCategoryRequest(
+        @NotBlank String name,
+        @NotNull Boolean isActive
+) {}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/admin/UpdateUserActiveRequest.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/admin/UpdateUserActiveRequest.java
@@ -1,0 +1,7 @@
+package com.aperdigon.ticketing_backend.api.admin;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateUserActiveRequest(
+        @NotNull Boolean isActive
+) {}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/ports/CategoryRepository.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/ports/CategoryRepository.java
@@ -8,5 +8,8 @@ import java.util.Optional;
 
 public interface CategoryRepository {
     Optional<Category> findById(CategoryId id);
+    Optional<Category> findByName(String name);
+    List<Category> findAll();
     List<Category> findActive();
+    Category save(Category category);
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/ports/UserRepository.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/ports/UserRepository.java
@@ -4,9 +4,11 @@ import com.aperdigon.ticketing_backend.domain.user.User;
 import com.aperdigon.ticketing_backend.domain.user.UserId;
 
 import java.util.Optional;
+import java.util.List;
 
 public interface UserRepository {
     Optional<User> findById(UserId id);
     Optional<User> findByEmail(String email);
+    List<User> findAll();
     User save(User user);
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/adapter/JpaCategoryRepository.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/adapter/JpaCategoryRepository.java
@@ -25,9 +25,27 @@ public class JpaCategoryRepository implements CategoryRepository {
     }
 
     @Override
+    public Optional<Category> findByName(String name) {
+        return springRepo.findByNameIgnoreCase(name).map(CategoryMapper::toDomain);
+    }
+
+    @Override
+    public List<Category> findAll() {
+        return springRepo.findByOrderByNameAsc().stream()
+                .map(CategoryMapper::toDomain)
+                .toList();
+    }
+
+    @Override
     public List<Category> findActive() {
         return springRepo.findByIsActiveTrueOrderByNameAsc().stream()
                 .map(CategoryMapper::toDomain)
                 .toList();
+    }
+
+    @Override
+    public Category save(Category category) {
+        var savedEntity = springRepo.save(CategoryMapper.toJpa(category));
+        return CategoryMapper.toDomain(savedEntity);
     }
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/adapter/JpaUserRepository.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/adapter/JpaUserRepository.java
@@ -7,6 +7,7 @@ import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.mapper.Use
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.UserSpringDataRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -26,6 +27,13 @@ public class JpaUserRepository implements UserRepository {
     @Override
     public Optional<User> findByEmail(String email) {
         return springRepo.findByEmailIgnoreCase(email).map(UserMapper::toDomain);
+    }
+
+    @Override
+    public List<User> findAll() {
+        return springRepo.findByOrderByDisplayNameAsc().stream()
+                .map(UserMapper::toDomain)
+                .toList();
     }
 
     @Override

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/mapper/CategoryMapper.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/mapper/CategoryMapper.java
@@ -14,4 +14,12 @@ public final class CategoryMapper {
                 e.isActive()
         );
     }
+
+    public static CategoryJpaEntity toJpa(Category category) {
+        return new CategoryJpaEntity(
+                category.id().value(),
+                category.name(),
+                category.isActive()
+        );
+    }
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/repository/CategorySpringDataRepository.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/repository/CategorySpringDataRepository.java
@@ -4,8 +4,11 @@ import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.Cat
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface CategorySpringDataRepository extends JpaRepository<CategoryJpaEntity, UUID> {
+    Optional<CategoryJpaEntity> findByNameIgnoreCase(String name);
+    List<CategoryJpaEntity> findByOrderByNameAsc();
     List<CategoryJpaEntity> findByIsActiveTrueOrderByNameAsc();
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/repository/UserSpringDataRepository.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/repository/UserSpringDataRepository.java
@@ -4,8 +4,10 @@ import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.Use
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.List;
 import java.util.UUID;
 
 public interface UserSpringDataRepository extends JpaRepository<UserJpaEntity, UUID> {
     Optional<UserJpaEntity> findByEmailIgnoreCase(String email);
+    List<UserJpaEntity> findByOrderByDisplayNameAsc();
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/security/SecurityConfig.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/security/SecurityConfig.java
@@ -44,6 +44,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PATCH, "/api/tickets/*/status").hasAnyRole("AGENT", "ADMIN")
                         .requestMatchers(HttpMethod.PATCH, "/api/tickets/*/assignment/me").hasAnyRole("AGENT", "ADMIN")
 
+                        // administración solo ADMIN
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+
                         // resto API: requiere estar autenticado
                         .requestMatchers("/api/**").authenticated()
 

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/admin/AdminIntegrationTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/admin/AdminIntegrationTest.java
@@ -1,0 +1,144 @@
+package com.aperdigon.ticketing_backend.integration.admin;
+
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.CategoryJpaEntity;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.UserJpaEntity;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.CategorySpringDataRepository;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.UserSpringDataRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class AdminIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @DynamicPropertySource
+    static void configureDatasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+    }
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    UserSpringDataRepository userRepo;
+
+    @Autowired
+    CategorySpringDataRepository categoryRepo;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    private UUID managedUserId;
+
+    @BeforeEach
+    void setUp() {
+        categoryRepo.deleteAll();
+        userRepo.deleteAll();
+
+        userRepo.save(new UserJpaEntity(
+                UUID.randomUUID(),
+                "admin@test.com",
+                "Admin",
+                passwordEncoder.encode("secret123"),
+                UserRole.ADMIN,
+                true
+        ));
+
+        managedUserId = UUID.randomUUID();
+        userRepo.save(new UserJpaEntity(
+                managedUserId,
+                "user@test.com",
+                "Regular User",
+                passwordEncoder.encode("secret123"),
+                UserRole.USER,
+                true
+        ));
+
+        categoryRepo.save(new CategoryJpaEntity(UUID.randomUUID(), "Software", true));
+    }
+
+    @Test
+    void admin_can_list_categories_and_users() throws Exception {
+        String token = loginAndExtractToken("admin@test.com", "secret123");
+
+        mockMvc.perform(get("/api/admin/categories")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("Software"));
+
+        mockMvc.perform(get("/api/admin/users")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.email=='user@test.com')]").exists());
+    }
+
+    @Test
+    void admin_can_deactivate_user() throws Exception {
+        String token = loginAndExtractToken("admin@test.com", "secret123");
+
+        mockMvc.perform(patch("/api/admin/users/{userId}/active", managedUserId)
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"isActive":false}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isActive").value(false));
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"email":"user@test.com","password":"secret123"}
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void non_admin_cannot_access_admin_endpoints() throws Exception {
+        String token = loginAndExtractToken("user@test.com", "secret123");
+
+        mockMvc.perform(get("/api/admin/users")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isForbidden());
+    }
+
+    private String loginAndExtractToken(String email, String password) throws Exception {
+        var mvcResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"email":"%s","password":"%s"}
+                                """.formatted(email, password)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = mvcResult.getResponse().getContentAsString();
+        return body.replaceAll(".*\\\"accessToken\\\":\\\"([^\\\"]+)\\\".*", "$1");
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/InMemoryCategoryRepository.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/InMemoryCategoryRepository.java
@@ -22,10 +22,33 @@ public final class InMemoryCategoryRepository implements CategoryRepository {
     }
 
     @Override
+    public Optional<Category> findByName(String name) {
+        if (name == null) {
+            return Optional.empty();
+        }
+        return store.values().stream()
+                .filter(category -> category.name().equalsIgnoreCase(name))
+                .findFirst();
+    }
+
+    @Override
+    public List<Category> findAll() {
+        return store.values().stream()
+                .sorted((left, right) -> left.name().compareToIgnoreCase(right.name()))
+                .toList();
+    }
+
+    @Override
     public List<Category> findActive() {
         return store.values().stream()
                 .filter(Category::isActive)
                 .sorted((left, right) -> left.name().compareToIgnoreCase(right.name()))
                 .toList();
+    }
+
+    @Override
+    public Category save(Category category) {
+        store.put(category.id(), category);
+        return category;
     }
 }

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/InMemoryUserRepository.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/InMemoryUserRepository.java
@@ -6,6 +6,7 @@ import com.aperdigon.ticketing_backend.domain.user.UserId;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 import java.util.Optional;
 
 public final class InMemoryUserRepository implements UserRepository {
@@ -28,6 +29,13 @@ public final class InMemoryUserRepository implements UserRepository {
         return store.values().stream()
                 .filter(u -> u.email().equalsIgnoreCase(email))
                 .findFirst();
+    }
+
+    @Override
+    public List<User> findAll() {
+        return store.values().stream()
+                .sorted((left, right) -> left.displayName().compareToIgnoreCase(right.displayName()))
+                .toList();
     }
 
     @Override

--- a/ticketing-frontend/src/app/layout/AppShell.tsx
+++ b/ticketing-frontend/src/app/layout/AppShell.tsx
@@ -38,7 +38,7 @@ export function AppShell() {
   const navigate = useNavigate();
   const { hasRole, logout } = useAuth();
 
-  const menuItems = getMenuItems(hasRole("AGENT"));
+  const menuItems = getMenuItems(hasRole("ADMIN"));
 
   const onLogout = () => {
     logout();

--- a/ticketing-frontend/src/app/router.tsx
+++ b/ticketing-frontend/src/app/router.tsx
@@ -9,6 +9,8 @@ import { TicketsPage } from "./pages/TicketsPage";
 import { CreateTicketPage } from "../features/tickets/ui/CreateTicketPage";
 import { TicketDetailPage } from "../features/tickets/ui/TicketDetailPage";
 import { ProfilePage } from "./pages/ProfilePage";
+import { RequireRole } from "../features/auth/ui/RequireRole";
+import { AdminPage } from "../features/admin/ui/AdminPage";
 
 function ForbiddenPage() {
   return <PlaceholderPage title="403 — Forbidden" />;
@@ -29,7 +31,7 @@ export const router = createBrowserRouter([
           { path: "/tickets/new", element: <CreateTicketPage /> },
           { path: "/tickets/:id", element: <TicketDetailPage /> },
           { path: "/profile", element: <ProfilePage /> },
-          { path: "/admin", element: <PlaceholderPage title="Administración" /> },
+          { path: "/admin", element: <RequireRole anyOf={["ADMIN"]}><AdminPage /></RequireRole> },
         ],
       },
     ],

--- a/ticketing-frontend/src/features/admin/api/adminApi.ts
+++ b/ticketing-frontend/src/features/admin/api/adminApi.ts
@@ -1,0 +1,18 @@
+import { createApiClient } from "../../../shared/api/client";
+import type { AdminCategory, AdminUser } from "../model/types";
+
+const AUTH_TOKEN_STORAGE_KEY = "ticketing_access_token";
+
+const authClient = createApiClient({
+  getToken: () => localStorage.getItem(AUTH_TOKEN_STORAGE_KEY),
+});
+
+export const adminApi = {
+  getCategories: () => authClient.get<AdminCategory[]>("/api/admin/categories"),
+  createCategory: (name: string) => authClient.post<AdminCategory>("/api/admin/categories", { name }),
+  updateCategory: (categoryId: string, payload: { name: string; isActive: boolean }) =>
+    authClient.patch<AdminCategory>(`/api/admin/categories/${categoryId}`, payload),
+  getUsers: () => authClient.get<AdminUser[]>("/api/admin/users"),
+  updateUserActive: (userId: string, isActive: boolean) =>
+    authClient.patch<AdminUser>(`/api/admin/users/${userId}/active`, { isActive }),
+};

--- a/ticketing-frontend/src/features/admin/model/types.ts
+++ b/ticketing-frontend/src/features/admin/model/types.ts
@@ -1,0 +1,13 @@
+export type AdminCategory = {
+  id: string;
+  name: string;
+  isActive: boolean;
+};
+
+export type AdminUser = {
+  id: string;
+  email: string;
+  displayName: string;
+  role: "USER" | "AGENT" | "ADMIN";
+  isActive: boolean;
+};

--- a/ticketing-frontend/src/features/admin/ui/AdminPage.test.tsx
+++ b/ticketing-frontend/src/features/admin/ui/AdminPage.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { ConfigProvider } from "antd";
+import { AdminPage } from "./AdminPage";
+import { vi } from "vitest";
+
+const getCategoriesMock = vi.fn();
+const getUsersMock = vi.fn();
+
+vi.mock("../api/adminApi", () => ({
+  adminApi: {
+    getCategories: () => getCategoriesMock(),
+    createCategory: vi.fn(),
+    updateCategory: vi.fn(),
+    getUsers: () => getUsersMock(),
+    updateUserActive: vi.fn(),
+  },
+}));
+
+describe("AdminPage", () => {
+  it("renders admin tabs and loaded records", async () => {
+    getCategoriesMock.mockResolvedValueOnce([{ id: "1", name: "Software", isActive: true }]);
+    getUsersMock.mockResolvedValueOnce([
+      { id: "u1", email: "admin@test.com", displayName: "Admin", role: "ADMIN", isActive: true },
+    ]);
+
+    render(
+      <ConfigProvider>
+        <AdminPage />
+      </ConfigProvider>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Administración" })).toBeInTheDocument();
+    expect(await screen.findByText("Software")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Usuarios" })).toBeInTheDocument();
+  });
+});

--- a/ticketing-frontend/src/features/admin/ui/AdminPage.tsx
+++ b/ticketing-frontend/src/features/admin/ui/AdminPage.tsx
@@ -1,0 +1,202 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Button, Input, Modal, Space, Switch, Table, Tabs, Tag, Typography, message } from "antd";
+import { adminApi } from "../api/adminApi";
+import type { AdminCategory, AdminUser } from "../model/types";
+
+type SimpleColumn<T> = {
+  title: string;
+  key: string;
+  dataIndex?: keyof T;
+  render?: (value: unknown, row: T) => React.ReactNode;
+};
+
+export function AdminPage() {
+  const [categories, setCategories] = useState<AdminCategory[]>([]);
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [loadingCategories, setLoadingCategories] = useState(true);
+  const [loadingUsers, setLoadingUsers] = useState(true);
+  const [creatingCategory, setCreatingCategory] = useState(false);
+  const [newCategoryName, setNewCategoryName] = useState("");
+  const [editingCategory, setEditingCategory] = useState<AdminCategory | null>(null);
+  const [editingName, setEditingName] = useState("");
+  const [editingActive, setEditingActive] = useState(true);
+
+  async function loadCategories() {
+    setLoadingCategories(true);
+    try {
+      const data = await adminApi.getCategories();
+      setCategories(data);
+    } catch {
+      message.error("No se pudieron cargar las categorías");
+    } finally {
+      setLoadingCategories(false);
+    }
+  }
+
+  async function loadUsers() {
+    setLoadingUsers(true);
+    try {
+      const data = await adminApi.getUsers();
+      setUsers(data);
+    } catch {
+      message.error("No se pudieron cargar los usuarios");
+    } finally {
+      setLoadingUsers(false);
+    }
+  }
+
+  useEffect(() => {
+    void Promise.all([loadCategories(), loadUsers()]);
+  }, []);
+
+  const categoryColumns = useMemo<SimpleColumn<AdminCategory>[]>(
+    () => [
+      { title: "Nombre", dataIndex: "name", key: "name" },
+      {
+        title: "Estado",
+        key: "isActive",
+        render: (_: unknown, record: AdminCategory) => (record.isActive ? <Tag color="success">Activa</Tag> : <Tag>Inactiva</Tag>),
+      },
+      {
+        title: "Acciones",
+        key: "actions",
+        render: (_: unknown, record: AdminCategory) => (
+          <Button
+            onClick={() => {
+              setEditingCategory(record);
+              setEditingName(record.name);
+              setEditingActive(record.isActive);
+            }}
+          >
+            Editar
+          </Button>
+        ),
+      },
+    ],
+    [],
+  );
+
+  const userColumns = useMemo<SimpleColumn<AdminUser>[]>(
+    () => [
+      { title: "Nombre", dataIndex: "displayName", key: "displayName" },
+      { title: "Email", dataIndex: "email", key: "email" },
+      { title: "Rol", dataIndex: "role", key: "role", render: (role: unknown) => <Tag>{String(role)}</Tag> },
+      {
+        title: "Activo",
+        key: "isActive",
+        render: (_: unknown, record: AdminUser) => (
+          <Switch
+            checked={record.isActive}
+            onChange={async (checked) => {
+              try {
+                const updated = await adminApi.updateUserActive(record.id, checked);
+                setUsers((prev) => prev.map((user) => (user.id === updated.id ? updated : user)));
+                message.success("Estado de usuario actualizado");
+              } catch {
+                message.error("No se pudo actualizar el estado del usuario");
+              }
+            }}
+          />
+        ),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <Space direction="vertical" size={16} style={{ width: "100%" }}>
+      <Typography.Title level={3} style={{ margin: 0 }}>
+        Administración
+      </Typography.Title>
+      <Typography.Text type="secondary">
+        Gestiona categorías y usuarios de la plataforma. Solo los administradores tienen acceso.
+      </Typography.Text>
+
+      <Tabs
+        items={[
+          {
+            key: "categories",
+            label: "Categorías",
+            children: (
+              <Space direction="vertical" size={16} style={{ width: "100%" }}>
+                <Space>
+                  <Input value={newCategoryName} onChange={(event) => setNewCategoryName(event.target.value)} placeholder="Nueva categoría" />
+                  <Button
+                    type="primary"
+                    loading={creatingCategory}
+                    onClick={async () => {
+                      const name = newCategoryName.trim();
+                      if (!name) {
+                        message.error("Nombre obligatorio");
+                        return;
+                      }
+
+                      setCreatingCategory(true);
+                      try {
+                        const created = await adminApi.createCategory(name);
+                        setCategories((prev) => [...prev, created].sort((a, b) => a.name.localeCompare(b.name)));
+                        setNewCategoryName("");
+                        message.success("Categoría creada");
+                      } catch {
+                        message.error("No se pudo crear la categoría (puede que ya exista)");
+                      } finally {
+                        setCreatingCategory(false);
+                      }
+                    }}
+                  >
+                    Crear
+                  </Button>
+                </Space>
+
+                <Table rowKey="id" loading={loadingCategories} dataSource={categories} columns={categoryColumns} pagination={false} />
+              </Space>
+            ),
+          },
+          {
+            key: "users",
+            label: "Usuarios",
+            children: <Table rowKey="id" loading={loadingUsers} dataSource={users} columns={userColumns} pagination={false} />,
+          },
+        ]}
+      />
+
+      <Modal
+        title="Editar categoría"
+        open={Boolean(editingCategory)}
+        onCancel={() => setEditingCategory(null)}
+        onOk={async () => {
+          if (!editingCategory) {
+            return;
+          }
+
+          const name = editingName.trim();
+          if (!name) {
+            message.error("Nombre obligatorio");
+            return;
+          }
+
+          try {
+            const updated = await adminApi.updateCategory(editingCategory.id, {
+              name,
+              isActive: editingActive,
+            });
+            setCategories((prev) => prev.map((category) => (category.id === updated.id ? updated : category)));
+            setEditingCategory(null);
+            message.success("Categoría actualizada");
+          } catch {
+            message.error("No se pudo actualizar la categoría");
+          }
+        }}
+        okText="Guardar"
+      >
+        <Space direction="vertical" style={{ width: "100%" }}>
+          <Input value={editingName} onChange={(event) => setEditingName(event.target.value)} placeholder="Nombre" />
+          <Space>
+            <Typography.Text>Activa</Typography.Text>
+            <Switch checked={editingActive} onChange={setEditingActive} />
+          </Space>
+        </Space>
+      </Modal>
+    </Space>
+  );
+}

--- a/ticketing-frontend/src/vendor/antd/index.tsx
+++ b/ticketing-frontend/src/vendor/antd/index.tsx
@@ -164,18 +164,23 @@ export type TableProps<T> = {
   rowKey: keyof T | ((row: T) => React.Key);
   columns: Array<{
     title: React.ReactNode;
-    dataIndex: keyof T;
+    dataIndex?: keyof T;
     key: string;
     width?: number;
     ellipsis?: boolean;
     render?: (value: unknown, row: T) => React.ReactNode;
   }>;
   dataSource: T[];
-  pagination?: { pageSize?: number; hideOnSinglePage?: boolean };
+  pagination?: { pageSize?: number; hideOnSinglePage?: boolean } | boolean;
+  loading?: boolean;
 };
 
-export function Table<T extends Record<string, unknown>>({ rowKey, columns, dataSource }: TableProps<T>) {
+export function Table<T extends Record<string, unknown>>({ rowKey, columns, dataSource, loading }: TableProps<T>) {
   const keyGetter = typeof rowKey === "function" ? rowKey : (row: T) => row[rowKey] as React.Key;
+
+  if (loading) {
+    return <div>Cargando...</div>;
+  }
 
   return (
     <table style={{ width: "100%", borderCollapse: "collapse" }}>
@@ -192,7 +197,7 @@ export function Table<T extends Record<string, unknown>>({ rowKey, columns, data
         {dataSource.map((row) => (
           <tr key={keyGetter(row)}>
             {columns.map((column) => {
-              const value = row[column.dataIndex];
+              const value = column.dataIndex ? row[column.dataIndex] : undefined;
               return (
                 <td key={column.key} style={{ borderBottom: "1px solid #f3f4f6", padding: "8px 4px" }}>
                   {column.render ? column.render(value, row) : (value as React.ReactNode)}
@@ -205,3 +210,49 @@ export function Table<T extends Record<string, unknown>>({ rowKey, columns, data
     </table>
   );
 }
+
+export function Input({ value, onChange, placeholder }: { value?: string; onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void; placeholder?: string }) {
+  return <input value={value} onChange={onChange} placeholder={placeholder} />;
+}
+
+export function Switch({ checked, onChange }: { checked?: boolean; onChange?: (checked: boolean) => void }) {
+  return <input type="checkbox" checked={checked} onChange={(event) => onChange?.(event.target.checked)} />;
+}
+
+export function Tabs({ items }: { items: Array<{ key: string; label: React.ReactNode; children: React.ReactNode }> }) {
+  const [activeKey, setActiveKey] = React.useState(items[0]?.key);
+  const active = items.find((item) => item.key === activeKey) ?? items[0];
+
+  return (
+    <div>
+      <div style={{ display: "flex", gap: 8 }}>
+        {items.map((item) => (
+          <button key={item.key} role="tab" onClick={() => setActiveKey(item.key)}>
+            {item.label}
+          </button>
+        ))}
+      </div>
+      <div>{active?.children}</div>
+    </div>
+  );
+}
+
+export function Modal({ open, title, children, onCancel, onOk, okText }: { open: boolean; title: React.ReactNode; children: React.ReactNode; onCancel?: () => void; onOk?: () => void; okText?: string }) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div>
+      <h2>{title}</h2>
+      {children}
+      <button onClick={onCancel}>Cancelar</button>
+      <button onClick={onOk}>{okText ?? "OK"}</button>
+    </div>
+  );
+}
+
+export const message = {
+  success: (_text: string) => undefined,
+  error: (_text: string) => undefined,
+};

--- a/ticketing-frontend/src/vendor/antd/index.tsx
+++ b/ticketing-frontend/src/vendor/antd/index.tsx
@@ -212,11 +212,52 @@ export function Table<T extends Record<string, unknown>>({ rowKey, columns, data
 }
 
 export function Input({ value, onChange, placeholder }: { value?: string; onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void; placeholder?: string }) {
-  return <input value={value} onChange={onChange} placeholder={placeholder} />;
+  return (
+    <input
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      style={{
+        border: "1px solid #d9d9d9",
+        borderRadius: 6,
+        padding: "6px 10px",
+        minHeight: 32,
+      }}
+    />
+  );
 }
 
 export function Switch({ checked, onChange }: { checked?: boolean; onChange?: (checked: boolean) => void }) {
-  return <input type="checkbox" checked={checked} onChange={(event) => onChange?.(event.target.checked)} />;
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={Boolean(checked)}
+      onClick={() => onChange?.(!checked)}
+      style={{
+        width: 44,
+        height: 24,
+        borderRadius: 999,
+        border: "1px solid #d9d9d9",
+        background: checked ? "#0c9136" : "#d9d9d9",
+        cursor: "pointer",
+        padding: 2,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: checked ? "flex-end" : "flex-start",
+      }}
+    >
+      <span
+        style={{
+          width: 18,
+          height: 18,
+          borderRadius: "50%",
+          background: "#fff",
+          display: "inline-block",
+        }}
+      />
+    </button>
+  );
 }
 
 export function Tabs({ items }: { items: Array<{ key: string; label: React.ReactNode; children: React.ReactNode }> }) {
@@ -225,9 +266,23 @@ export function Tabs({ items }: { items: Array<{ key: string; label: React.React
 
   return (
     <div>
-      <div style={{ display: "flex", gap: 8 }}>
+      <div role="tablist" style={{ display: "flex", gap: 6, borderBottom: "1px solid #f0f0f0", marginBottom: 16 }}>
         {items.map((item) => (
-          <button key={item.key} role="tab" onClick={() => setActiveKey(item.key)}>
+          <button
+            key={item.key}
+            role="tab"
+            aria-selected={item.key === active.key}
+            onClick={() => setActiveKey(item.key)}
+            style={{
+              border: "none",
+              borderBottom: item.key === active.key ? "2px solid #0c9136" : "2px solid transparent",
+              background: "transparent",
+              color: item.key === active.key ? "#0c9136" : "#595959",
+              padding: "8px 4px",
+              cursor: "pointer",
+              fontWeight: 500,
+            }}
+          >
             {item.label}
           </button>
         ))}
@@ -243,11 +298,25 @@ export function Modal({ open, title, children, onCancel, onOk, okText }: { open:
   }
 
   return (
-    <div>
-      <h2>{title}</h2>
-      {children}
-      <button onClick={onCancel}>Cancelar</button>
-      <button onClick={onOk}>{okText ?? "OK"}</button>
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0, 0, 0, 0.45)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 1000,
+      }}
+    >
+      <div style={{ background: "#fff", borderRadius: 8, width: 520, maxWidth: "90vw", padding: 20 }}>
+        <h2 style={{ marginTop: 0 }}>{title}</h2>
+        <div style={{ marginBottom: 16 }}>{children}</div>
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+          <Button type="default" onClick={onCancel}>Cancelar</Button>
+          <Button type="primary" onClick={onOk}>{okText ?? "OK"}</Button>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
- Implement `AdminController` with endpoints for listing, creating and updating categories and listing/updating users, and introduce request/response DTOs (`CreateCategoryRequest`, `UpdateCategoryRequest`, `UpdateUserActiveRequest`, `AdminCategoryResponse`, `AdminUserResponse`).
- Extend repository ports with `findByName`, `findAll`, and `save` as needed and provide JPA adapters and mappers (`JpaCategoryRepository`, `JpaUserRepository`, `CategoryMapper`) to persist domain objects.
- Update Spring Data repositories with new query methods and update `SecurityConfig` to restrict `"/api/admin/**"` to `ROLE_ADMIN`.
- Add a React admin UI (`AdminPage`) with API client (`adminApi`), types, router integration (`RequireRole` + route), menu item in `AppShell`, and small antd test-support components; include tests for the frontend page (`AdminPage.test.tsx`).
- Add backend integration test `AdminIntegrationTest` using Testcontainers/Postgres and update in-memory test repositories (`InMemoryCategoryRepository`, `InMemoryUserRepository`) to support new methods.
