### PR TITLE
Add ticket events and comments, introduce ON_HOLD status and timeline UI

### DIFF
--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/shared/exception/GlobalExceptionHandler.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/shared/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.aperdigon.ticketing_backend.application.shared.exception.ForbiddenExc
 import com.aperdigon.ticketing_backend.application.shared.exception.NotFoundException;
 import com.aperdigon.ticketing_backend.application.shared.exception.UnauthorizedException;
 import com.aperdigon.ticketing_backend.domain.shared.exception.InvalidArgumentException;
+import com.aperdigon.ticketing_backend.domain.ticket.exceptions.TicketAlreadyAssigned;
 import com.aperdigon.ticketing_backend.domain.ticket.exceptions.TicketAlreadyResolved;
 import com.aperdigon.ticketing_backend.domain.ticket.exceptions.TicketInvalidStatusTransition;
 import org.springframework.http.HttpStatus;
@@ -33,7 +34,7 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiError.of("BAD_REQUEST", ex.getMessage()));
     }
 
-    @ExceptionHandler({TicketInvalidStatusTransition.class, TicketAlreadyResolved.class})
+    @ExceptionHandler({TicketInvalidStatusTransition.class, TicketAlreadyResolved.class, TicketAlreadyAssigned.class})
     public ResponseEntity<ApiError> conflict(RuntimeException ex) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(ApiError.of("CONFLICT", ex.getMessage()));
     }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/TicketController.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/TicketController.java
@@ -16,6 +16,7 @@ import com.aperdigon.ticketing_backend.application.tickets.add_comment.AddTicket
 import com.aperdigon.ticketing_backend.application.tickets.assign.AssignTicketToMeCommand;
 import com.aperdigon.ticketing_backend.application.tickets.assign.AssignTicketToMeUseCase;
 import com.aperdigon.ticketing_backend.application.ports.TicketEventRepository;
+import com.aperdigon.ticketing_backend.application.ports.UserRepository;
 import com.aperdigon.ticketing_backend.application.tickets.create.CreateTicketCommand;
 import com.aperdigon.ticketing_backend.application.tickets.create.CreateTicketUseCase;
 import com.aperdigon.ticketing_backend.application.tickets.get.GetTicketUseCase;
@@ -27,6 +28,7 @@ import com.aperdigon.ticketing_backend.application.tickets.list.TicketQueueScope
 import com.aperdigon.ticketing_backend.domain.category.CategoryId;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+import com.aperdigon.ticketing_backend.domain.user.UserId;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
@@ -34,6 +36,10 @@ import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 @RestController
@@ -48,6 +54,7 @@ public class TicketController {
     private final GetTicketUseCase getTicketUseCase;
     private final AddTicketCommentUseCase addTicketCommentUseCase;
     private final TicketEventRepository ticketEventRepository;
+    private final UserRepository userRepository;
     private final CurrentUserProvider currentUserProvider;
 
     public TicketController(
@@ -59,6 +66,7 @@ public class TicketController {
             GetTicketUseCase getTicketUseCase,
             AddTicketCommentUseCase addTicketCommentUseCase,
             TicketEventRepository ticketEventRepository,
+            UserRepository userRepository,
             CurrentUserProvider currentUserProvider
     ) {
         this.createTicketUseCase = createTicketUseCase;
@@ -69,6 +77,7 @@ public class TicketController {
         this.getTicketUseCase = getTicketUseCase;
         this.addTicketCommentUseCase = addTicketCommentUseCase;
         this.ticketEventRepository = ticketEventRepository;
+        this.userRepository = userRepository;
         this.currentUserProvider = currentUserProvider;
     }
 
@@ -123,7 +132,28 @@ public class TicketController {
         var actor = currentUserProvider.getCurrentUser();
         var ticket = getTicketUseCase.execute(new TicketId(id), actor);
         var events = ticketEventRepository.findByTicketId(new TicketId(id));
-        return TicketDetailResponse.from(ticket, events);
+
+        Set<UUID> userIds = new HashSet<>();
+        userIds.add(ticket.createdBy().value());
+        if (ticket.assignedTo() != null) {
+            userIds.add(ticket.assignedTo().value());
+        }
+        for (var comment : ticket.comments()) {
+            userIds.add(comment.authorId().value());
+        }
+        for (var event : events) {
+            if (event.actorUserId() != null) {
+                userIds.add(event.actorUserId().value());
+            }
+        }
+
+        Map<UUID, String> userNamesById = new HashMap<>();
+        for (var userId : userIds) {
+            userRepository.findById(new UserId(userId))
+                    .ifPresent(user -> userNamesById.put(userId, user.displayName()));
+        }
+
+        return TicketDetailResponse.from(ticket, events, userId -> userNamesById.getOrDefault(userId, userId.toString()));
     }
 
     @PostMapping("/{id}/comments")

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/TicketController.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/TicketController.java
@@ -3,14 +3,19 @@ package com.aperdigon.ticketing_backend.api.tickets;
 import com.aperdigon.ticketing_backend.api.shared.currentuser.CurrentUserProvider;
 import com.aperdigon.ticketing_backend.api.shared.pagination.PageResponse;
 import com.aperdigon.ticketing_backend.api.tickets.change_status.ChangeTicketStatusRequest;
+import com.aperdigon.ticketing_backend.api.tickets.comments.AddTicketCommentRequest;
+import com.aperdigon.ticketing_backend.api.tickets.comments.AddTicketCommentResponse;
 import com.aperdigon.ticketing_backend.api.tickets.create.CreateTicketRequest;
 import com.aperdigon.ticketing_backend.api.tickets.create.CreateTicketResponse;
 import com.aperdigon.ticketing_backend.api.tickets.detail.TicketDetailResponse;
 import com.aperdigon.ticketing_backend.api.tickets.list.TicketSummaryResponse;
 import com.aperdigon.ticketing_backend.application.tickets.change_status.ChangeTicketStatusCommand;
 import com.aperdigon.ticketing_backend.application.tickets.change_status.ChangeTicketStatusUseCase;
+import com.aperdigon.ticketing_backend.application.tickets.add_comment.AddTicketCommentCommand;
+import com.aperdigon.ticketing_backend.application.tickets.add_comment.AddTicketCommentUseCase;
 import com.aperdigon.ticketing_backend.application.tickets.assign.AssignTicketToMeCommand;
 import com.aperdigon.ticketing_backend.application.tickets.assign.AssignTicketToMeUseCase;
+import com.aperdigon.ticketing_backend.application.ports.TicketEventRepository;
 import com.aperdigon.ticketing_backend.application.tickets.create.CreateTicketCommand;
 import com.aperdigon.ticketing_backend.application.tickets.create.CreateTicketUseCase;
 import com.aperdigon.ticketing_backend.application.tickets.get.GetTicketUseCase;
@@ -41,6 +46,8 @@ public class TicketController {
     private final ListMyTicketsUseCase listMyTicketsUseCase;
     private final ListTicketsUseCase listTicketsUseCase;
     private final GetTicketUseCase getTicketUseCase;
+    private final AddTicketCommentUseCase addTicketCommentUseCase;
+    private final TicketEventRepository ticketEventRepository;
     private final CurrentUserProvider currentUserProvider;
 
     public TicketController(
@@ -50,6 +57,8 @@ public class TicketController {
             ListMyTicketsUseCase listMyTicketsUseCase,
             ListTicketsUseCase listTicketsUseCase,
             GetTicketUseCase getTicketUseCase,
+            AddTicketCommentUseCase addTicketCommentUseCase,
+            TicketEventRepository ticketEventRepository,
             CurrentUserProvider currentUserProvider
     ) {
         this.createTicketUseCase = createTicketUseCase;
@@ -58,6 +67,8 @@ public class TicketController {
         this.listMyTicketsUseCase = listMyTicketsUseCase;
         this.listTicketsUseCase = listTicketsUseCase;
         this.getTicketUseCase = getTicketUseCase;
+        this.addTicketCommentUseCase = addTicketCommentUseCase;
+        this.ticketEventRepository = ticketEventRepository;
         this.currentUserProvider = currentUserProvider;
     }
 
@@ -111,7 +122,16 @@ public class TicketController {
     public TicketDetailResponse getById(@PathVariable UUID id) {
         var actor = currentUserProvider.getCurrentUser();
         var ticket = getTicketUseCase.execute(new TicketId(id), actor);
-        return TicketDetailResponse.from(ticket);
+        var events = ticketEventRepository.findByTicketId(new TicketId(id));
+        return TicketDetailResponse.from(ticket, events);
+    }
+
+    @PostMapping("/{id}/comments")
+    public ResponseEntity<AddTicketCommentResponse> addComment(@PathVariable UUID id, @Valid @RequestBody AddTicketCommentRequest request) {
+        var actor = currentUserProvider.getCurrentUser();
+        var result = addTicketCommentUseCase.execute(new AddTicketCommentCommand(new TicketId(id), request.content(), actor));
+        return ResponseEntity.created(URI.create("/api/tickets/" + id + "/comments/" + result.commentId().value()))
+                .body(AddTicketCommentResponse.from(result));
     }
 
     @PatchMapping("/{id}/status")

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/comments/AddTicketCommentRequest.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/comments/AddTicketCommentRequest.java
@@ -1,0 +1,9 @@
+package com.aperdigon.ticketing_backend.api.tickets.comments;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AddTicketCommentRequest(
+        @NotBlank @Size(max = 2000) String content
+) {
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/comments/AddTicketCommentResponse.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/comments/AddTicketCommentResponse.java
@@ -1,0 +1,24 @@
+package com.aperdigon.ticketing_backend.api.tickets.comments;
+
+import com.aperdigon.ticketing_backend.application.tickets.add_comment.AddTicketCommentResult;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record AddTicketCommentResponse(
+        UUID id,
+        UUID ticketId,
+        UUID authorUserId,
+        String content,
+        Instant createdAt
+) {
+    public static AddTicketCommentResponse from(AddTicketCommentResult result) {
+        return new AddTicketCommentResponse(
+                result.commentId().value(),
+                result.ticketId().value(),
+                result.authorUserId().value(),
+                result.content(),
+                result.createdAt()
+        );
+    }
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/create/CreateTicketResponse.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/create/CreateTicketResponse.java
@@ -2,4 +2,4 @@ package com.aperdigon.ticketing_backend.api.tickets.create;
 
 import java.util.UUID;
 
-public record CreateTicketResponse(UUID id) {}
+public record CreateTicketResponse(UUID ticketId) {}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/detail/TicketDetailResponse.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/detail/TicketDetailResponse.java
@@ -12,6 +12,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
 
 public record TicketDetailResponse(
         UUID id,
@@ -22,21 +23,24 @@ public record TicketDetailResponse(
         Instant createdAt,
         Instant updatedAt,
         UUID createdByUserId,
+        String createdByDisplayName,
         UUID assignedToUserId,
+        String assignedToDisplayName,
         UUID categoryId,
         List<TimelineEntryResponse> timeline,
         List<TicketStatus> availableTransitions
 ) {
-    public static TicketDetailResponse from(Ticket ticket, List<TicketEvent> events) {
+    public static TicketDetailResponse from(Ticket ticket, List<TicketEvent> events, Function<UUID, String> userDisplayNameResolver) {
         List<TimelineEntryResponse> entries = new ArrayList<>();
 
         entries.add(new TimelineEntryResponse(
-                UUID.randomUUID(),
+                ticket.id().value(),
                 "MESSAGE",
                 ticket.createdAt(),
                 ticket.createdBy().value(),
+                userDisplayNameResolver.apply(ticket.createdBy().value()),
                 ticket.description(),
-                TicketEventType.TICKET_CREATED,
+                null,
                 Map.of()
         ));
 
@@ -46,6 +50,7 @@ public record TicketDetailResponse(
                     "MESSAGE",
                     c.createdAt(),
                     c.authorId().value(),
+                    userDisplayNameResolver.apply(c.authorId().value()),
                     c.content(),
                     null,
                     Map.of()
@@ -53,11 +58,15 @@ public record TicketDetailResponse(
         }
 
         for (var event : events) {
+            if (event.type() == TicketEventType.COMMENT_ADDED) {
+                continue;
+            }
             entries.add(new TimelineEntryResponse(
                     event.id(),
                     "EVENT",
                     event.createdAt(),
                     event.actorUserId() == null ? null : event.actorUserId().value(),
+                    event.actorUserId() == null ? null : userDisplayNameResolver.apply(event.actorUserId().value()),
                     null,
                     event.type(),
                     event.payload()
@@ -75,7 +84,9 @@ public record TicketDetailResponse(
                 ticket.createdAt(),
                 ticket.updatedAt(),
                 ticket.createdBy().value(),
+                userDisplayNameResolver.apply(ticket.createdBy().value()),
                 ticket.assignedTo() == null ? null : ticket.assignedTo().value(),
+                ticket.assignedTo() == null ? null : userDisplayNameResolver.apply(ticket.assignedTo().value()),
                 ticket.categoryId().value(),
                 entries,
                 availableTransitions(ticket.status())
@@ -96,6 +107,7 @@ public record TicketDetailResponse(
             String kind,
             Instant createdAt,
             UUID actorUserId,
+            String actorDisplayName,
             String content,
             TicketEventType eventType,
             Map<String, String> payload

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/detail/TicketDetailResponse.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/detail/TicketDetailResponse.java
@@ -73,7 +73,11 @@ public record TicketDetailResponse(
             ));
         }
 
-        entries.sort(Comparator.comparing(TimelineEntryResponse::createdAt));
+        entries.sort(
+                Comparator.comparing(TimelineEntryResponse::createdAt)
+                        .thenComparing(TimelineEntryResponse::kind)
+                        .thenComparing(entry -> entry.eventType() == TicketEventType.TICKET_CREATED ? 0 : 1)
+        );
 
         return new TicketDetailResponse(
                 ticket.id().value(),

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/detail/TicketDetailResponse.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/detail/TicketDetailResponse.java
@@ -3,8 +3,14 @@ package com.aperdigon.ticketing_backend.api.tickets.detail;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketPriority;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEvent;
+import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEventType;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public record TicketDetailResponse(
@@ -17,9 +23,49 @@ public record TicketDetailResponse(
         Instant updatedAt,
         UUID createdByUserId,
         UUID assignedToUserId,
-        UUID categoryId
+        UUID categoryId,
+        List<TimelineEntryResponse> timeline,
+        List<TicketStatus> availableTransitions
 ) {
-    public static TicketDetailResponse from(Ticket ticket) {
+    public static TicketDetailResponse from(Ticket ticket, List<TicketEvent> events) {
+        List<TimelineEntryResponse> entries = new ArrayList<>();
+
+        entries.add(new TimelineEntryResponse(
+                UUID.randomUUID(),
+                "MESSAGE",
+                ticket.createdAt(),
+                ticket.createdBy().value(),
+                ticket.description(),
+                TicketEventType.TICKET_CREATED,
+                Map.of()
+        ));
+
+        for (var c : ticket.comments()) {
+            entries.add(new TimelineEntryResponse(
+                    c.id().value(),
+                    "MESSAGE",
+                    c.createdAt(),
+                    c.authorId().value(),
+                    c.content(),
+                    null,
+                    Map.of()
+            ));
+        }
+
+        for (var event : events) {
+            entries.add(new TimelineEntryResponse(
+                    event.id(),
+                    "EVENT",
+                    event.createdAt(),
+                    event.actorUserId() == null ? null : event.actorUserId().value(),
+                    null,
+                    event.type(),
+                    event.payload()
+            ));
+        }
+
+        entries.sort(Comparator.comparing(TimelineEntryResponse::createdAt));
+
         return new TicketDetailResponse(
                 ticket.id().value(),
                 ticket.title(),
@@ -30,7 +76,29 @@ public record TicketDetailResponse(
                 ticket.updatedAt(),
                 ticket.createdBy().value(),
                 ticket.assignedTo() == null ? null : ticket.assignedTo().value(),
-                ticket.categoryId().value()
+                ticket.categoryId().value(),
+                entries,
+                availableTransitions(ticket.status())
         );
+    }
+
+    private static List<TicketStatus> availableTransitions(TicketStatus status) {
+        return switch (status) {
+            case OPEN -> List.of(TicketStatus.IN_PROGRESS);
+            case IN_PROGRESS -> List.of(TicketStatus.ON_HOLD, TicketStatus.RESOLVED);
+            case ON_HOLD -> List.of(TicketStatus.IN_PROGRESS, TicketStatus.RESOLVED);
+            case RESOLVED -> List.of();
+        };
+    }
+
+    public record TimelineEntryResponse(
+            UUID id,
+            String kind,
+            Instant createdAt,
+            UUID actorUserId,
+            String content,
+            TicketEventType eventType,
+            Map<String, String> payload
+    ) {
     }
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/ports/TicketEventRepository.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/ports/TicketEventRepository.java
@@ -1,0 +1,11 @@
+package com.aperdigon.ticketing_backend.application.ports;
+
+import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
+import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEvent;
+
+import java.util.List;
+
+public interface TicketEventRepository {
+    TicketEvent save(TicketEvent event);
+    List<TicketEvent> findByTicketId(TicketId ticketId);
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/add_comment/AddTicketCommentCommand.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/add_comment/AddTicketCommentCommand.java
@@ -1,0 +1,11 @@
+package com.aperdigon.ticketing_backend.application.tickets.add_comment;
+
+import com.aperdigon.ticketing_backend.application.shared.CurrentUser;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
+
+public record AddTicketCommentCommand(
+        TicketId ticketId,
+        String content,
+        CurrentUser actor
+) {
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/add_comment/AddTicketCommentResult.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/add_comment/AddTicketCommentResult.java
@@ -1,0 +1,16 @@
+package com.aperdigon.ticketing_backend.application.tickets.add_comment;
+
+import com.aperdigon.ticketing_backend.domain.ticket.CommentId;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
+import com.aperdigon.ticketing_backend.domain.user.UserId;
+
+import java.time.Instant;
+
+public record AddTicketCommentResult(
+        CommentId commentId,
+        TicketId ticketId,
+        UserId authorUserId,
+        String content,
+        Instant createdAt
+) {
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/add_comment/AddTicketCommentUseCase.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/add_comment/AddTicketCommentUseCase.java
@@ -1,11 +1,12 @@
-package com.aperdigon.ticketing_backend.application.tickets.change_status;
+package com.aperdigon.ticketing_backend.application.tickets.add_comment;
 
-import com.aperdigon.ticketing_backend.application.ports.TicketRepository;
 import com.aperdigon.ticketing_backend.application.ports.TicketEventRepository;
+import com.aperdigon.ticketing_backend.application.ports.TicketRepository;
 import com.aperdigon.ticketing_backend.application.shared.exception.ForbiddenException;
 import com.aperdigon.ticketing_backend.application.shared.exception.NotFoundException;
 import com.aperdigon.ticketing_backend.domain.shared.validation.Guard;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
 import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEvent;
 import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEventType;
 import org.springframework.stereotype.Service;
@@ -16,40 +17,50 @@ import java.util.Map;
 import java.util.UUID;
 
 @Service
-public final class ChangeTicketStatusUseCase {
+public class AddTicketCommentUseCase {
 
     private final TicketRepository ticketRepository;
     private final TicketEventRepository ticketEventRepository;
     private final Clock clock;
 
-    public ChangeTicketStatusUseCase(TicketRepository ticketRepository, TicketEventRepository ticketEventRepository, Clock clock) {
+    public AddTicketCommentUseCase(TicketRepository ticketRepository, TicketEventRepository ticketEventRepository, Clock clock) {
         this.ticketRepository = Guard.notNull(ticketRepository, "ticketRepository");
         this.ticketEventRepository = Guard.notNull(ticketEventRepository, "ticketEventRepository");
         this.clock = Guard.notNull(clock, "clock");
     }
 
-    public ChangeTicketStatusResult execute(ChangeTicketStatusCommand command) {
+    public AddTicketCommentResult execute(AddTicketCommentCommand command) {
         Guard.notNull(command, "command");
-
-        if (!command.actor().isAgentOrAdmin()) {
-            throw new ForbiddenException("Only AGENT/ADMIN can change ticket status");
-        }
 
         Ticket ticket = ticketRepository.findById(command.ticketId())
                 .orElseThrow(() -> new NotFoundException("Ticket not found: " + command.ticketId().value()));
 
-        var previousStatus = ticket.status();
-        ticket.changeStatus(command.newStatus(), clock);
+        if (!command.actor().isAgentOrAdmin() && !ticket.createdBy().equals(command.actor().id())) {
+            throw new ForbiddenException("You cannot comment this ticket");
+        }
+
+        if (ticket.status() == TicketStatus.RESOLVED) {
+            throw new ForbiddenException("Resolved ticket does not accept new comments");
+        }
+
+        var createdComment = ticket.addComment(command.content(), command.actor().id(), clock);
         ticketRepository.save(ticket);
+
         ticketEventRepository.save(new TicketEvent(
                 UUID.randomUUID(),
                 ticket.id(),
-                TicketEventType.STATUS_CHANGED,
+                TicketEventType.COMMENT_ADDED,
                 command.actor().id(),
-                Map.of("from", previousStatus.name(), "to", ticket.status().name()),
+                Map.of("commentId", createdComment.id().value().toString()),
                 Instant.now(clock)
         ));
 
-        return new ChangeTicketStatusResult(ticket.id(), ticket.status());
+        return new AddTicketCommentResult(
+                createdComment.id(),
+                ticket.id(),
+                createdComment.authorId(),
+                createdComment.content(),
+                createdComment.createdAt()
+        );
     }
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/add_comment/AddTicketCommentUseCase.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/add_comment/AddTicketCommentUseCase.java
@@ -1,31 +1,23 @@
 package com.aperdigon.ticketing_backend.application.tickets.add_comment;
 
-import com.aperdigon.ticketing_backend.application.ports.TicketEventRepository;
 import com.aperdigon.ticketing_backend.application.ports.TicketRepository;
 import com.aperdigon.ticketing_backend.application.shared.exception.ForbiddenException;
 import com.aperdigon.ticketing_backend.application.shared.exception.NotFoundException;
 import com.aperdigon.ticketing_backend.domain.shared.validation.Guard;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
-import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEvent;
-import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEventType;
 import org.springframework.stereotype.Service;
 
 import java.time.Clock;
-import java.time.Instant;
-import java.util.Map;
-import java.util.UUID;
 
 @Service
 public class AddTicketCommentUseCase {
 
     private final TicketRepository ticketRepository;
-    private final TicketEventRepository ticketEventRepository;
     private final Clock clock;
 
-    public AddTicketCommentUseCase(TicketRepository ticketRepository, TicketEventRepository ticketEventRepository, Clock clock) {
+    public AddTicketCommentUseCase(TicketRepository ticketRepository, Clock clock) {
         this.ticketRepository = Guard.notNull(ticketRepository, "ticketRepository");
-        this.ticketEventRepository = Guard.notNull(ticketEventRepository, "ticketEventRepository");
         this.clock = Guard.notNull(clock, "clock");
     }
 
@@ -45,15 +37,6 @@ public class AddTicketCommentUseCase {
 
         var createdComment = ticket.addComment(command.content(), command.actor().id(), clock);
         ticketRepository.save(ticket);
-
-        ticketEventRepository.save(new TicketEvent(
-                UUID.randomUUID(),
-                ticket.id(),
-                TicketEventType.COMMENT_ADDED,
-                command.actor().id(),
-                Map.of("commentId", createdComment.id().value().toString()),
-                Instant.now(clock)
-        ));
 
         return new AddTicketCommentResult(
                 createdComment.id(),

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/assign/AssignTicketToMeUseCase.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/assign/AssignTicketToMeUseCase.java
@@ -6,6 +6,7 @@ import com.aperdigon.ticketing_backend.application.shared.exception.ForbiddenExc
 import com.aperdigon.ticketing_backend.application.shared.exception.NotFoundException;
 import com.aperdigon.ticketing_backend.domain.shared.validation.Guard;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
+import com.aperdigon.ticketing_backend.domain.ticket.exceptions.TicketAlreadyAssigned;
 import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEvent;
 import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEventType;
 import org.springframework.stereotype.Service;
@@ -37,6 +38,10 @@ public class AssignTicketToMeUseCase {
 
         Ticket ticket = ticketRepository.findById(command.ticketId())
                 .orElseThrow(() -> new NotFoundException("Ticket not found: " + command.ticketId().value()));
+
+        if (ticket.assignedTo() != null) {
+            throw new TicketAlreadyAssigned();
+        }
 
         ticket.assignTo(command.actor().id(), clock);
         ticketRepository.save(ticket);

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/assign/AssignTicketToMeUseCase.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/assign/AssignTicketToMeUseCase.java
@@ -1,22 +1,30 @@
 package com.aperdigon.ticketing_backend.application.tickets.assign;
 
 import com.aperdigon.ticketing_backend.application.ports.TicketRepository;
+import com.aperdigon.ticketing_backend.application.ports.TicketEventRepository;
 import com.aperdigon.ticketing_backend.application.shared.exception.ForbiddenException;
 import com.aperdigon.ticketing_backend.application.shared.exception.NotFoundException;
 import com.aperdigon.ticketing_backend.domain.shared.validation.Guard;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
+import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEvent;
+import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEventType;
 import org.springframework.stereotype.Service;
 
 import java.time.Clock;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
 
 @Service
 public class AssignTicketToMeUseCase {
 
     private final TicketRepository ticketRepository;
+    private final TicketEventRepository ticketEventRepository;
     private final Clock clock;
 
-    public AssignTicketToMeUseCase(TicketRepository ticketRepository, Clock clock) {
+    public AssignTicketToMeUseCase(TicketRepository ticketRepository, TicketEventRepository ticketEventRepository, Clock clock) {
         this.ticketRepository = Guard.notNull(ticketRepository, "ticketRepository");
+        this.ticketEventRepository = Guard.notNull(ticketEventRepository, "ticketEventRepository");
         this.clock = Guard.notNull(clock, "clock");
     }
 
@@ -32,6 +40,14 @@ public class AssignTicketToMeUseCase {
 
         ticket.assignTo(command.actor().id(), clock);
         ticketRepository.save(ticket);
+        ticketEventRepository.save(new TicketEvent(
+                UUID.randomUUID(),
+                ticket.id(),
+                TicketEventType.ASSIGNED_TO_ME,
+                command.actor().id(),
+                Map.of("assignedToUserId", command.actor().id().value().toString()),
+                Instant.now(clock)
+        ));
 
         return new AssignTicketToMeResult(ticket.id(), command.actor().id());
     }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/create/CreateTicketUseCase.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/create/CreateTicketUseCase.java
@@ -1,16 +1,22 @@
 package com.aperdigon.ticketing_backend.application.tickets.create;
 
 import com.aperdigon.ticketing_backend.application.ports.CategoryRepository;
+import com.aperdigon.ticketing_backend.application.ports.TicketEventRepository;
 import com.aperdigon.ticketing_backend.application.ports.TicketRepository;
 import com.aperdigon.ticketing_backend.application.ports.UserRepository;
 import com.aperdigon.ticketing_backend.application.shared.exception.NotFoundException;
 import com.aperdigon.ticketing_backend.domain.category.Category;
 import com.aperdigon.ticketing_backend.domain.shared.validation.Guard;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
+import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEvent;
+import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEventType;
 import com.aperdigon.ticketing_backend.domain.user.User;
 import org.springframework.stereotype.Service;
 
 import java.time.Clock;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
 
 @Service
 public final class CreateTicketUseCase {
@@ -18,17 +24,20 @@ public final class CreateTicketUseCase {
     private final TicketRepository ticketRepository;
     private final CategoryRepository categoryRepository;
     private final UserRepository userRepository;
+    private final TicketEventRepository ticketEventRepository;
     private final Clock clock;
 
     public CreateTicketUseCase(
             TicketRepository ticketRepository,
             CategoryRepository categoryRepository,
             UserRepository userRepository,
+            TicketEventRepository ticketEventRepository,
             Clock clock
     ) {
         this.ticketRepository = Guard.notNull(ticketRepository, "ticketRepository");
         this.categoryRepository = Guard.notNull(categoryRepository, "categoryRepository");
         this.userRepository = Guard.notNull(userRepository, "userRepository");
+        this.ticketEventRepository = Guard.notNull(ticketEventRepository, "ticketEventRepository");
         this.clock = Guard.notNull(clock, "clock");
     }
 
@@ -51,6 +60,14 @@ public final class CreateTicketUseCase {
         );
 
         Ticket saved = ticketRepository.save(ticket);
+        ticketEventRepository.save(new TicketEvent(
+                UUID.randomUUID(),
+                saved.id(),
+                TicketEventType.TICKET_CREATED,
+                creator.id(),
+                Map.of(),
+                Instant.now(clock)
+        ));
         return new CreateTicketResult(saved.id());
     }
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/domain/ticket/Ticket.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/domain/ticket/Ticket.java
@@ -174,7 +174,8 @@ public final class Ticket {
     private static boolean isValidTransition(TicketStatus from, TicketStatus to) {
         return switch (from) {
             case OPEN -> to == TicketStatus.IN_PROGRESS;
-            case IN_PROGRESS -> to == TicketStatus.RESOLVED;
+            case IN_PROGRESS -> to == TicketStatus.ON_HOLD || to == TicketStatus.RESOLVED;
+            case ON_HOLD -> to == TicketStatus.IN_PROGRESS || to == TicketStatus.RESOLVED;
             case RESOLVED -> false;
         };
     }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/domain/ticket/TicketStatus.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/domain/ticket/TicketStatus.java
@@ -3,5 +3,6 @@ package com.aperdigon.ticketing_backend.domain.ticket;
 public enum TicketStatus {
     OPEN,
     IN_PROGRESS,
+    ON_HOLD,
     RESOLVED
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/domain/ticket/exceptions/TicketAlreadyAssigned.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/domain/ticket/exceptions/TicketAlreadyAssigned.java
@@ -1,0 +1,10 @@
+package com.aperdigon.ticketing_backend.domain.ticket.exceptions;
+
+import com.aperdigon.ticketing_backend.domain.shared.exception.DomainException;
+
+public final class TicketAlreadyAssigned extends DomainException {
+    public TicketAlreadyAssigned() {
+        super("Ticket is already assigned");
+    }
+}
+

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/domain/ticket_event/TicketEvent.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/domain/ticket_event/TicketEvent.java
@@ -1,0 +1,26 @@
+package com.aperdigon.ticketing_backend.domain.ticket_event;
+
+import com.aperdigon.ticketing_backend.domain.shared.validation.Guard;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
+import com.aperdigon.ticketing_backend.domain.user.UserId;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+public record TicketEvent(
+        UUID id,
+        TicketId ticketId,
+        TicketEventType type,
+        UserId actorUserId,
+        Map<String, String> payload,
+        Instant createdAt
+) {
+    public TicketEvent {
+        Guard.notNull(id, "id");
+        Guard.notNull(ticketId, "ticketId");
+        Guard.notNull(type, "type");
+        Guard.notNull(payload, "payload");
+        Guard.notNull(createdAt, "createdAt");
+    }
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/domain/ticket_event/TicketEventType.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/domain/ticket_event/TicketEventType.java
@@ -1,0 +1,8 @@
+package com.aperdigon.ticketing_backend.domain.ticket_event;
+
+public enum TicketEventType {
+    TICKET_CREATED,
+    STATUS_CHANGED,
+    ASSIGNED_TO_ME,
+    COMMENT_ADDED
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/adapter/JpaTicketEventRepository.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/adapter/JpaTicketEventRepository.java
@@ -1,0 +1,86 @@
+package com.aperdigon.ticketing_backend.infrastructure.persistence.adapter;
+
+import com.aperdigon.ticketing_backend.application.ports.TicketEventRepository;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
+import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEvent;
+import com.aperdigon.ticketing_backend.domain.user.UserId;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.TicketEventJpaEntity;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.TicketEventSpringDataRepository;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.TicketSpringDataRepository;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.UserSpringDataRepository;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+@Repository
+public class JpaTicketEventRepository implements TicketEventRepository {
+
+    private static final TypeReference<Map<String, String>> MAP_TYPE = new TypeReference<>() {};
+
+    private final TicketEventSpringDataRepository eventRepository;
+    private final TicketSpringDataRepository ticketRepository;
+    private final UserSpringDataRepository userRepository;
+    private final ObjectMapper objectMapper;
+
+    public JpaTicketEventRepository(
+            TicketEventSpringDataRepository eventRepository,
+            TicketSpringDataRepository ticketRepository,
+            UserSpringDataRepository userRepository,
+            ObjectMapper objectMapper
+    ) {
+        this.eventRepository = eventRepository;
+        this.ticketRepository = ticketRepository;
+        this.userRepository = userRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    @Transactional
+    public TicketEvent save(TicketEvent event) {
+        try {
+            var ticketRef = ticketRepository.getReferenceById(event.ticketId().value());
+            var actorRef = event.actorUserId() == null ? null : userRepository.getReferenceById(event.actorUserId().value());
+            String payloadJson = objectMapper.writeValueAsString(event.payload());
+            var saved = eventRepository.save(new TicketEventJpaEntity(
+                    event.id(),
+                    ticketRef,
+                    event.type(),
+                    actorRef,
+                    payloadJson,
+                    event.createdAt()
+            ));
+            return toDomain(saved);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Unable to persist ticket event", ex);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<TicketEvent> findByTicketId(TicketId ticketId) {
+        return eventRepository.findByTicket_IdOrderByCreatedAtAsc(ticketId.value())
+                .stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    private TicketEvent toDomain(TicketEventJpaEntity e) {
+        try {
+            Map<String, String> payload = objectMapper.readValue(e.getPayloadJson(), MAP_TYPE);
+            return new TicketEvent(
+                    e.getId(),
+                    new TicketId(e.getTicket().getId()),
+                    e.getEventType(),
+                    e.getActor() == null ? null : new UserId(e.getActor().getId()),
+                    payload,
+                    e.getCreatedAt()
+            );
+        } catch (Exception ex) {
+            throw new IllegalStateException("Unable to parse ticket event payload", ex);
+        }
+    }
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/entity/TicketEventJpaEntity.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/entity/TicketEventJpaEntity.java
@@ -1,0 +1,53 @@
+package com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity;
+
+import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEventType;
+import jakarta.persistence.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "ticket_events")
+public class TicketEventJpaEntity {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private UUID id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "ticket_id", nullable = false)
+    private TicketJpaEntity ticket;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, length = 40)
+    private TicketEventType eventType;
+
+    @ManyToOne(optional = true, fetch = FetchType.LAZY)
+    @JoinColumn(name = "actor_user_id")
+    private UserJpaEntity actor;
+
+    @Column(name = "payload_json", nullable = false, columnDefinition = "text")
+    private String payloadJson;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    protected TicketEventJpaEntity() {
+    }
+
+    public TicketEventJpaEntity(UUID id, TicketJpaEntity ticket, TicketEventType eventType, UserJpaEntity actor, String payloadJson, Instant createdAt) {
+        this.id = id;
+        this.ticket = ticket;
+        this.eventType = eventType;
+        this.actor = actor;
+        this.payloadJson = payloadJson;
+        this.createdAt = createdAt;
+    }
+
+    public UUID getId() { return id; }
+    public TicketJpaEntity getTicket() { return ticket; }
+    public TicketEventType getEventType() { return eventType; }
+    public UserJpaEntity getActor() { return actor; }
+    public String getPayloadJson() { return payloadJson; }
+    public Instant getCreatedAt() { return createdAt; }
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/repository/TicketEventSpringDataRepository.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/repository/TicketEventSpringDataRepository.java
@@ -1,0 +1,11 @@
+package com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository;
+
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.TicketEventJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface TicketEventSpringDataRepository extends JpaRepository<TicketEventJpaEntity, UUID> {
+    List<TicketEventJpaEntity> findByTicket_IdOrderByCreatedAtAsc(UUID ticketId);
+}

--- a/ticketing-backend/src/main/resources/db/migration/V4__add_on_hold_and_ticket_events.sql
+++ b/ticketing-backend/src/main/resources/db/migration/V4__add_on_hold_and_ticket_events.sql
@@ -1,0 +1,11 @@
+CREATE TABLE ticket_events (
+    id UUID PRIMARY KEY,
+    ticket_id UUID NOT NULL REFERENCES tickets(id) ON DELETE CASCADE,
+    event_type VARCHAR(40) NOT NULL,
+    actor_user_id UUID REFERENCES users(id),
+    payload_json TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL
+);
+
+CREATE INDEX idx_ticket_events_ticket_created_at ON ticket_events(ticket_id, created_at);
+CREATE INDEX idx_ticket_events_type ON ticket_events(event_type);

--- a/ticketing-backend/src/main/resources/db/migration/V5__update_ticket_status_check_for_on_hold.sql
+++ b/ticketing-backend/src/main/resources/db/migration/V5__update_ticket_status_check_for_on_hold.sql
@@ -1,0 +1,5 @@
+ALTER TABLE tickets DROP CONSTRAINT IF EXISTS tickets_status_check;
+
+ALTER TABLE tickets
+    ADD CONSTRAINT tickets_status_check
+        CHECK (status IN ('OPEN', 'IN_PROGRESS', 'ON_HOLD', 'RESOLVED'));

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/InMemoryTicketEventRepository.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/InMemoryTicketEventRepository.java
@@ -1,0 +1,23 @@
+package com.aperdigon.ticketing_backend.test_support;
+
+import com.aperdigon.ticketing_backend.application.ports.TicketEventRepository;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
+import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class InMemoryTicketEventRepository implements TicketEventRepository {
+    private final List<TicketEvent> store = new ArrayList<>();
+
+    @Override
+    public TicketEvent save(TicketEvent event) {
+        store.add(event);
+        return event;
+    }
+
+    @Override
+    public List<TicketEvent> findByTicketId(TicketId ticketId) {
+        return store.stream().filter(e -> e.ticketId().equals(ticketId)).toList();
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/InMemoryTicketRepository.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/InMemoryTicketRepository.java
@@ -1,8 +1,14 @@
 package com.aperdigon.ticketing_backend.test_support;
 
 import com.aperdigon.ticketing_backend.application.ports.TicketRepository;
+import com.aperdigon.ticketing_backend.application.tickets.list.TicketQueueScope;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+import com.aperdigon.ticketing_backend.domain.user.UserId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,5 +26,15 @@ public final class InMemoryTicketRepository implements TicketRepository {
     @Override
     public Optional<Ticket> findById(TicketId id) {
         return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Page<Ticket> findMyTickets(UserId createdBy, TicketStatus status, String q, Pageable pageable) {
+        return new PageImpl<>(store.values().stream().toList(), pageable, store.size());
+    }
+
+    @Override
+    public Page<Ticket> findAgentTickets(UserId actorId, TicketQueueScope scope, TicketStatus status, String q, Pageable pageable) {
+        return new PageImpl<>(store.values().stream().toList(), pageable, store.size());
     }
 }

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/AssignTicketToMeUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/AssignTicketToMeUseCaseTest.java
@@ -9,6 +9,7 @@ import com.aperdigon.ticketing_backend.domain.category.Category;
 import com.aperdigon.ticketing_backend.domain.category.CategoryId;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
+import com.aperdigon.ticketing_backend.domain.ticket.exceptions.TicketAlreadyAssigned;
 import com.aperdigon.ticketing_backend.domain.user.User;
 import com.aperdigon.ticketing_backend.domain.user.UserId;
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
@@ -68,5 +69,27 @@ public class AssignTicketToMeUseCaseTest {
                 TicketId.of(UUID.randomUUID()),
                 new CurrentUser(UserId.of(UUID.randomUUID()), UserRole.ADMIN)
         )));
+    }
+
+    @Test
+    void cannot_assign_ticket_twice() {
+        Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
+
+        var ticketRepo = new InMemoryTicketRepository();
+        var eventRepo = new InMemoryTicketEventRepository();
+        var useCase = new AssignTicketToMeUseCase(ticketRepo, eventRepo, clock);
+
+        User creator = new User(UserId.of(UUID.randomUUID()), "u@test.com", "U", "$2a$10$abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG", UserRole.USER, true);
+        Category category = new Category(CategoryId.of(UUID.randomUUID()), "General", true);
+        Ticket ticket = Ticket.openNew("T", "D", category, creator, clock);
+        ticketRepo.save(ticket);
+
+        UserId firstAgent = UserId.of(UUID.randomUUID());
+        useCase.execute(new AssignTicketToMeCommand(ticket.id(), new CurrentUser(firstAgent, UserRole.AGENT)));
+
+        UserId secondAgent = UserId.of(UUID.randomUUID());
+        assertThrows(TicketAlreadyAssigned.class, () ->
+                useCase.execute(new AssignTicketToMeCommand(ticket.id(), new CurrentUser(secondAgent, UserRole.AGENT)))
+        );
     }
 }

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/AssignTicketToMeUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/AssignTicketToMeUseCaseTest.java
@@ -13,6 +13,7 @@ import com.aperdigon.ticketing_backend.domain.user.User;
 import com.aperdigon.ticketing_backend.domain.user.UserId;
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
 import com.aperdigon.ticketing_backend.test_support.InMemoryTicketRepository;
+import com.aperdigon.ticketing_backend.test_support.InMemoryTicketEventRepository;
 import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
@@ -30,7 +31,8 @@ public class AssignTicketToMeUseCaseTest {
         Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
 
         var ticketRepo = new InMemoryTicketRepository();
-        var useCase = new AssignTicketToMeUseCase(ticketRepo, clock);
+        var eventRepo = new InMemoryTicketEventRepository();
+        var useCase = new AssignTicketToMeUseCase(ticketRepo, eventRepo, clock);
 
         User creator = new User(UserId.of(UUID.randomUUID()), "u@test.com", "U", "$2a$10$abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG", UserRole.USER, true);
         Category category = new Category(CategoryId.of(UUID.randomUUID()), "General", true);
@@ -47,7 +49,8 @@ public class AssignTicketToMeUseCaseTest {
     @Test
     void user_cannot_assign_ticket() {
         var ticketRepo = new InMemoryTicketRepository();
-        var useCase = new AssignTicketToMeUseCase(ticketRepo, Clock.systemUTC());
+        var eventRepo = new InMemoryTicketEventRepository();
+        var useCase = new AssignTicketToMeUseCase(ticketRepo, eventRepo, Clock.systemUTC());
 
         assertThrows(ForbiddenException.class, () -> useCase.execute(new AssignTicketToMeCommand(
                 TicketId.of(UUID.randomUUID()),
@@ -58,7 +61,8 @@ public class AssignTicketToMeUseCaseTest {
     @Test
     void throws_not_found_if_ticket_does_not_exist() {
         var ticketRepo = new InMemoryTicketRepository();
-        var useCase = new AssignTicketToMeUseCase(ticketRepo, Clock.systemUTC());
+        var eventRepo = new InMemoryTicketEventRepository();
+        var useCase = new AssignTicketToMeUseCase(ticketRepo, eventRepo, Clock.systemUTC());
 
         assertThrows(NotFoundException.class, () -> useCase.execute(new AssignTicketToMeCommand(
                 TicketId.of(UUID.randomUUID()),

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/ChangeTicketStatusUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/ChangeTicketStatusUseCaseTest.java
@@ -23,6 +23,7 @@ import com.aperdigon.ticketing_backend.domain.user.User;
 import com.aperdigon.ticketing_backend.domain.user.UserId;
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
 import com.aperdigon.ticketing_backend.test_support.InMemoryTicketRepository;
+import com.aperdigon.ticketing_backend.test_support.InMemoryTicketEventRepository;
 import org.junit.jupiter.api.Test;
 
 
@@ -33,7 +34,8 @@ public final class ChangeTicketStatusUseCaseTest {
         Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
 
         var ticketRepo = new InMemoryTicketRepository();
-        var useCase = new ChangeTicketStatusUseCase(ticketRepo, clock);
+        var eventRepo = new InMemoryTicketEventRepository();
+        var useCase = new ChangeTicketStatusUseCase(ticketRepo, eventRepo, clock);
 
         User creator = new User(UserId.of(UUID.randomUUID()), "u@test.com", "U", "$2a$10$abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG", UserRole.USER, true);
         Category category = new Category(CategoryId.of(UUID.randomUUID()), "General", true);
@@ -59,7 +61,8 @@ public final class ChangeTicketStatusUseCaseTest {
         Clock clock = Clock.systemUTC();
 
         var ticketRepo = new InMemoryTicketRepository();
-        var useCase = new ChangeTicketStatusUseCase(ticketRepo, clock);
+        var eventRepo = new InMemoryTicketEventRepository();
+        var useCase = new ChangeTicketStatusUseCase(ticketRepo, eventRepo, clock);
 
         var cmd = new ChangeTicketStatusCommand(
                 TicketId.of(UUID.randomUUID()),
@@ -75,7 +78,8 @@ public final class ChangeTicketStatusUseCaseTest {
         Clock clock = Clock.systemUTC();
 
         var ticketRepo = new InMemoryTicketRepository();
-        var useCase = new ChangeTicketStatusUseCase(ticketRepo, clock);
+        var eventRepo = new InMemoryTicketEventRepository();
+        var useCase = new ChangeTicketStatusUseCase(ticketRepo, eventRepo, clock);
 
         var cmd = new ChangeTicketStatusCommand(
                 TicketId.of(UUID.randomUUID()),
@@ -91,7 +95,8 @@ public final class ChangeTicketStatusUseCaseTest {
         Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
 
         var ticketRepo = new InMemoryTicketRepository();
-        var useCase = new ChangeTicketStatusUseCase(ticketRepo, clock);
+        var eventRepo = new InMemoryTicketEventRepository();
+        var useCase = new ChangeTicketStatusUseCase(ticketRepo, eventRepo, clock);
 
         User creator = new User(UserId.of(UUID.randomUUID()), "u@test.com", "U", "$2a$10$abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG", UserRole.USER, true);
         Category category = new Category(CategoryId.of(UUID.randomUUID()), "General", true);
@@ -107,5 +112,31 @@ public final class ChangeTicketStatusUseCaseTest {
         );
 
         assertThrows(TicketInvalidStatusTransition.class, () -> useCase.execute(cmd));
+    }
+
+    @Test
+    void can_move_from_in_progress_to_on_hold() {
+        Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
+
+        var ticketRepo = new InMemoryTicketRepository();
+        var eventRepo = new InMemoryTicketEventRepository();
+        var useCase = new ChangeTicketStatusUseCase(ticketRepo, eventRepo, clock);
+
+        User creator = new User(UserId.of(UUID.randomUUID()), "u@test.com", "U", "$2a$10$abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG", UserRole.USER, true);
+        Category category = new Category(CategoryId.of(UUID.randomUUID()), "General", true);
+
+        Ticket ticket = Ticket.openNew("T", "D", category, creator, clock);
+        ticket.changeStatus(TicketStatus.IN_PROGRESS, clock);
+        ticketRepo.save(ticket);
+
+        var cmd = new ChangeTicketStatusCommand(
+                ticket.id(),
+                TicketStatus.ON_HOLD,
+                new CurrentUser(UserId.of(UUID.randomUUID()), UserRole.AGENT)
+        );
+
+        ChangeTicketStatusResult result = useCase.execute(cmd);
+
+        assertEquals(TicketStatus.ON_HOLD, result.status());
     }
 }

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/CreateTicketUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/CreateTicketUseCaseTest.java
@@ -22,6 +22,7 @@ import com.aperdigon.ticketing_backend.domain.user.UserId;
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
 import com.aperdigon.ticketing_backend.test_support.InMemoryCategoryRepository;
 import com.aperdigon.ticketing_backend.test_support.InMemoryTicketRepository;
+import com.aperdigon.ticketing_backend.test_support.InMemoryTicketEventRepository;
 import com.aperdigon.ticketing_backend.test_support.InMemoryUserRepository;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +35,7 @@ public final class CreateTicketUseCaseTest {
         var ticketRepo = new InMemoryTicketRepository();
         var categoryRepo = new InMemoryCategoryRepository();
         var userRepo = new InMemoryUserRepository();
+        var eventRepo = new InMemoryTicketEventRepository();
 
         User creator = new User(
                 UserId.of(UUID.randomUUID()),
@@ -48,7 +50,7 @@ public final class CreateTicketUseCaseTest {
         Category category = new Category(CategoryId.of(UUID.randomUUID()), "General", true);
         categoryRepo.put(category);
 
-        var useCase = new CreateTicketUseCase(ticketRepo, categoryRepo, userRepo, clock);
+        var useCase = new CreateTicketUseCase(ticketRepo, categoryRepo, userRepo, eventRepo, clock);
 
         var cmd = new CreateTicketCommand(
                 "Printer not working",
@@ -76,6 +78,7 @@ public final class CreateTicketUseCaseTest {
         var ticketRepo = new InMemoryTicketRepository();
         var categoryRepo = new InMemoryCategoryRepository();
         var userRepo = new InMemoryUserRepository();
+        var eventRepo = new InMemoryTicketEventRepository();
 
         User creator = new User(
                 UserId.of(UUID.randomUUID()),
@@ -87,7 +90,7 @@ public final class CreateTicketUseCaseTest {
         );
         userRepo.put(creator);
 
-        var useCase = new CreateTicketUseCase(ticketRepo, categoryRepo, userRepo, clock);
+        var useCase = new CreateTicketUseCase(ticketRepo, categoryRepo, userRepo, eventRepo, clock);
 
         var cmd = new CreateTicketCommand(
                 "Title",

--- a/ticketing-frontend/src/features/tickets/api/ticketsApi.ts
+++ b/ticketing-frontend/src/features/tickets/api/ticketsApi.ts
@@ -1,6 +1,7 @@
 import { createApiClient } from "../../../shared/api/client";
 import type {
   CreateTicketInput,
+  AddTicketCommentResponse,
   CreateTicketResponse,
   PaginatedResponse,
   TicketCategory,
@@ -46,4 +47,7 @@ export const ticketsApi = {
     authClient.patch<void>(`/api/tickets/${ticketId}/status`, { status }),
 
   assignToMe: (ticketId: string) => authClient.patch<void>(`/api/tickets/${ticketId}/assignment/me`, {}),
+
+  addComment: (ticketId: string, content: string) =>
+    authClient.post<AddTicketCommentResponse>(`/api/tickets/${ticketId}/comments`, { content }),
 };

--- a/ticketing-frontend/src/features/tickets/model/presentation.ts
+++ b/ticketing-frontend/src/features/tickets/model/presentation.ts
@@ -3,12 +3,14 @@ import type { TicketPriority, TicketStatus } from "./types";
 export const ticketStatusLabel: Record<TicketStatus, string> = {
   OPEN: "Abierto",
   IN_PROGRESS: "En progreso",
+  ON_HOLD: "En espera",
   RESOLVED: "Resuelto",
 };
 
 export const ticketStatusColor: Record<TicketStatus, string> = {
   OPEN: "default",
   IN_PROGRESS: "processing",
+  ON_HOLD: "warning",
   RESOLVED: "success",
 };
 
@@ -17,4 +19,3 @@ export const ticketPriorityLabel: Record<TicketPriority, string> = {
   MEDIUM: "Media",
   HIGH: "Alta",
 };
-

--- a/ticketing-frontend/src/features/tickets/model/types.ts
+++ b/ticketing-frontend/src/features/tickets/model/types.ts
@@ -1,4 +1,4 @@
-export type TicketStatus = "OPEN" | "IN_PROGRESS" | "RESOLVED";
+export type TicketStatus = "OPEN" | "IN_PROGRESS" | "ON_HOLD" | "RESOLVED";
 export type TicketPriority = "LOW" | "MEDIUM" | "HIGH";
 export type TicketQueueScope = "UNASSIGNED" | "MINE" | "OTHERS" | "ALL";
 
@@ -24,6 +24,28 @@ export type TicketDetail = {
   createdByUserId: string;
   assignedToUserId: string | null;
   categoryId: string;
+  timeline: TimelineEntry[];
+  availableTransitions: TicketStatus[];
+};
+
+export type TicketEventType = "TICKET_CREATED" | "STATUS_CHANGED" | "ASSIGNED_TO_ME" | "COMMENT_ADDED";
+
+export type TimelineEntry = {
+  id: string;
+  kind: "MESSAGE" | "EVENT";
+  createdAt: string;
+  actorUserId: string | null;
+  content: string | null;
+  eventType: TicketEventType | null;
+  payload: Record<string, string>;
+};
+
+export type AddTicketCommentResponse = {
+  id: string;
+  ticketId: string;
+  authorUserId: string;
+  content: string;
+  createdAt: string;
 };
 
 export type TicketCategory = {

--- a/ticketing-frontend/src/features/tickets/model/types.ts
+++ b/ticketing-frontend/src/features/tickets/model/types.ts
@@ -22,7 +22,9 @@ export type TicketDetail = {
   createdAt: string;
   updatedAt: string;
   createdByUserId: string;
+  createdByDisplayName: string;
   assignedToUserId: string | null;
+  assignedToDisplayName: string | null;
   categoryId: string;
   timeline: TimelineEntry[];
   availableTransitions: TicketStatus[];
@@ -35,6 +37,7 @@ export type TimelineEntry = {
   kind: "MESSAGE" | "EVENT";
   createdAt: string;
   actorUserId: string | null;
+  actorDisplayName: string | null;
   content: string | null;
   eventType: TicketEventType | null;
   payload: Record<string, string>;

--- a/ticketing-frontend/src/features/tickets/ui/create/CreateTicketPage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/create/CreateTicketPage.test.tsx
@@ -63,11 +63,8 @@ describe("CreateTicketPage", () => {
     await user.type(await screen.findByLabelText("Título"), "Impresora bloqueada");
     await user.type(screen.getByLabelText("Descripción"), "Da error E23 cuando intento imprimir un PDF.");
     const categoryCombobox = screen.getByRole("combobox", { name: "Categoría" });
-    const categorySelector = categoryCombobox.closest(".ant-select")?.querySelector(".ant-select-selector");
-    expect(categorySelector).toBeTruthy();
-    fireEvent.mouseDown(categorySelector as Element);
-    fireEvent.keyDown(categoryCombobox, { key: "ArrowDown" });
-    fireEvent.keyDown(categoryCombobox, { key: "Enter" });
+    fireEvent.mouseDown(categoryCombobox);
+    await user.click(await screen.findByText("General"));
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Crear ticket" })).toBeEnabled();

--- a/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.tsx
@@ -39,15 +39,14 @@ export function TicketDetailPage() {
           <Typography.Text type="secondary">{formatDate(entry.createdAt)}</Typography.Text>
           {entry.kind === "MESSAGE" ? (
             <>
-              <Typography.Text><strong>{entry.actorUserId ?? "Sistema"}</strong></Typography.Text>
+              <Typography.Text><strong>{entry.actorDisplayName ?? "Sistema"}</strong></Typography.Text>
               <Typography.Paragraph style={{ margin: 0 }}>{entry.content}</Typography.Paragraph>
             </>
           ) : (
             <Typography.Text>
               {entry.eventType === "STATUS_CHANGED" && `Cambio de estado: ${entry.payload.from} → ${entry.payload.to}`}
-              {entry.eventType === "ASSIGNED_TO_ME" && `Asignado a ${entry.payload.assignedToUserId}`}
+              {entry.eventType === "ASSIGNED_TO_ME" && `Asignado a ${entry.actorDisplayName ?? "agente"}`}
               {entry.eventType === "TICKET_CREATED" && "Ticket creado"}
-              {entry.eventType === "COMMENT_ADDED" && "Comentario añadido"}
             </Typography.Text>
           )}
         </Space>
@@ -162,8 +161,8 @@ export function TicketDetailPage() {
               <Typography.Title level={5} style={{ margin: 0 }}>Metadata</Typography.Title>
               <Typography.Text>ID: {ticket.id}</Typography.Text>
               <Typography.Text>Categoría: {ticket.categoryId}</Typography.Text>
-              <Typography.Text>Creado por: {ticket.createdByUserId}</Typography.Text>
-              <Typography.Text>Asignado a: {ticket.assignedToUserId ?? "Sin asignar"}</Typography.Text>
+              <Typography.Text>Creado por: {ticket.createdByDisplayName}</Typography.Text>
+              <Typography.Text>Asignado a: {ticket.assignedToDisplayName ?? "Sin asignar"}</Typography.Text>
               <Typography.Text>Creado: {formatDate(ticket.createdAt)}</Typography.Text>
               <Typography.Text>Actualizado: {formatDate(ticket.updatedAt)}</Typography.Text>
             </Space>
@@ -214,7 +213,9 @@ export function TicketDetailPage() {
 
             {canManage && (
               <Space direction="vertical" style={{ width: "100%" }} size={12}>
-                <Button loading={busyAction === "assign"} onClick={handleAssignToMe}>Asignarme ticket</Button>
+                {!ticket.assignedToUserId && (
+                  <Button loading={busyAction === "assign"} onClick={handleAssignToMe}>Asignarme ticket</Button>
+                )}
                 <Typography.Title level={5} style={{ margin: 0 }}>Cambiar estado</Typography.Title>
                 {availableStatusTransitions.length === 0 && <Typography.Text type="secondary">No hay transiciones disponibles.</Typography.Text>}
                 {availableStatusTransitions.map((nextStatus) => (

--- a/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.tsx
@@ -1,10 +1,10 @@
-import { Alert, Button, Card, Empty, Skeleton, Space, Tag, Typography } from "antd";
+import { Alert, Button, Card, Empty, Input, Skeleton, Space, Tag, Typography } from "antd";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useAuth } from "../../../auth/hooks/useAuth";
 import { ticketsApi } from "../../api/ticketsApi";
 import { ticketPriorityLabel, ticketStatusColor, ticketStatusLabel } from "../../model/presentation";
-import type { TicketDetail, TicketStatus } from "../../model/types";
+import type { TicketDetail, TicketStatus, TimelineEntry } from "../../model/types";
 
 type LoadState = "loading" | "ready" | "error";
 
@@ -25,12 +25,34 @@ export function TicketDetailPage() {
   const [ticket, setTicket] = useState<TicketDetail | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [busyAction, setBusyAction] = useState<"assign" | "status" | null>(null);
+  const [commentText, setCommentText] = useState("");
+  const [busyComment, setBusyComment] = useState(false);
 
-  const availableStatusTransitions = useMemo(() => {
-    if (!ticket) return [] as TicketStatus[];
-    if (ticket.status === "OPEN") return ["IN_PROGRESS"] as TicketStatus[];
-    if (ticket.status === "IN_PROGRESS") return ["RESOLVED"] as TicketStatus[];
-    return [] as TicketStatus[];
+  const availableStatusTransitions = useMemo(() => ticket?.availableTransitions ?? ([] as TicketStatus[]), [ticket]);
+
+  const timelineItems = useMemo(() => {
+    if (!ticket) return [];
+    return ticket.timeline.map((entry: TimelineEntry) => ({
+      key: entry.id,
+      children: (
+        <Space direction="vertical" size={4}>
+          <Typography.Text type="secondary">{formatDate(entry.createdAt)}</Typography.Text>
+          {entry.kind === "MESSAGE" ? (
+            <>
+              <Typography.Text><strong>{entry.actorUserId ?? "Sistema"}</strong></Typography.Text>
+              <Typography.Paragraph style={{ margin: 0 }}>{entry.content}</Typography.Paragraph>
+            </>
+          ) : (
+            <Typography.Text>
+              {entry.eventType === "STATUS_CHANGED" && `Cambio de estado: ${entry.payload.from} → ${entry.payload.to}`}
+              {entry.eventType === "ASSIGNED_TO_ME" && `Asignado a ${entry.payload.assignedToUserId}`}
+              {entry.eventType === "TICKET_CREATED" && "Ticket creado"}
+              {entry.eventType === "COMMENT_ADDED" && "Comentario añadido"}
+            </Typography.Text>
+          )}
+        </Space>
+      ),
+    }));
   }, [ticket]);
 
   useEffect(() => {
@@ -98,6 +120,21 @@ export function TicketDetailPage() {
     }
   };
 
+  const handleAddComment = async () => {
+    if (!id || !commentText.trim()) return;
+    setBusyComment(true);
+    setErrorMessage(null);
+    try {
+      await ticketsApi.addComment(id, commentText.trim());
+      setCommentText("");
+      await reload();
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "No se pudo añadir el comentario.");
+    } finally {
+      setBusyComment(false);
+    }
+  };
+
   if (loadState === "loading") {
     return <Skeleton active paragraph={{ rows: 10 }} />;
   }
@@ -137,8 +174,28 @@ export function TicketDetailPage() {
           <Card>
             <Space direction="vertical" size={12} style={{ width: "100%" }}>
               <Typography.Title level={5} style={{ margin: 0 }}>Conversación</Typography.Title>
-              <Typography.Paragraph>{ticket.description}</Typography.Paragraph>
-              <Empty description="Sin comentarios todavía" />
+              {timelineItems.length === 0 ? (
+                <Empty description="Sin actividad todavía" />
+              ) : (
+                <div style={{ maxHeight: 420, overflowY: "auto", paddingRight: 8 }}>
+                  <Space direction="vertical" size={12} style={{ width: "100%" }}>
+                    {timelineItems.map((item) => (
+                      <Card key={item.key}>{item.children}</Card>
+                    ))}
+                  </Space>
+                </div>
+              )}
+              {ticket.status === "RESOLVED" && <Alert type="info" message="Ticket resuelto" description="No admite nuevos comentarios." />}
+              <Input.TextArea
+                rows={3}
+                value={commentText}
+                maxLength={2000}
+                placeholder="Escribe un comentario"
+                onChange={(event) => setCommentText(event.target.value)}
+              />
+              <Button type="primary" loading={busyComment} disabled={!commentText.trim() || ticket.status === "RESOLVED"} onClick={handleAddComment}>
+                Enviar comentario
+              </Button>
             </Space>
           </Card>
         </div>

--- a/ticketing-frontend/src/features/tickets/ui/ticketsPage/AgentAdminTicketsPage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/ticketsPage/AgentAdminTicketsPage.tsx
@@ -14,6 +14,7 @@ const statusFilterOptions: Array<{ label: string; value: QueueFilter }> = [
   { label: "Todos los estados", value: "all" },
   { label: "Abierto", value: "OPEN" },
   { label: "En progreso", value: "IN_PROGRESS" },
+  { label: "En espera", value: "ON_HOLD" },
   { label: "Resuelto", value: "RESOLVED" },
 ];
 
@@ -26,7 +27,7 @@ function toQueueView(value: string | null): QueueView {
 }
 
 function toStatusFilter(value: string | null): QueueFilter {
-  if (value === "OPEN" || value === "IN_PROGRESS" || value === "RESOLVED") {
+  if (value === "OPEN" || value === "IN_PROGRESS" || value === "ON_HOLD" || value === "RESOLVED") {
     return value;
   }
 


### PR DESCRIPTION
- Provide an event/timeline model for tickets to record lifecycle events and comments and expose them in the ticket detail.
- Allow users/agents to add comments and show those in the UI while enforcing domain rules (no comments on resolved tickets, permission checks).
- Support a new `ON_HOLD` ticket status and the corresponding domain transitions.

