### PR TITLE
Add canonical feature specifications and testing strategy documentation

### DIFF
--- a/docs/features/admin.feature
+++ b/docs/features/admin.feature
@@ -1,0 +1,39 @@
+# Canonical functional specification
+# This file is part of the canonical functional specification of the project.
+# It is not executed with Cucumber.
+# Its purpose is to provide stable functional scenarios and lightweight traceability
+# between requirements, automated tests, and code.
+
+Feature: Administrative management
+  As a platform administrator
+  I want to manage administrative resources
+  So that I can supervise users and categories securely
+
+  Background:
+    Given administrative endpoints exist for users and categories
+    And only administrators may access those endpoints
+
+  Scenario: ADMIN-01 Admin lists users
+    Given the requester has administrator role
+    When the requester asks for the user list
+    Then the request is accepted
+    And the response contains platform users with their relevant administrative data
+
+  Scenario: ADMIN-02 Admin lists categories
+    Given the requester has administrator role
+    When the requester asks for the category list
+    Then the request is accepted
+    And the response contains available categories with their administrative state
+
+  Scenario: ADMIN-03 Admin deactivates user
+    Given the requester has administrator role
+    And an active non-admin user exists
+    When the administrator deactivates that user
+    Then the user is updated as inactive
+    And that user can no longer authenticate successfully
+
+  Scenario: ADMIN-04 Non-admin cannot access admin endpoints
+    Given the requester is authenticated without administrator role
+    When the requester attempts to access an administrative endpoint
+    Then the request is rejected as forbidden
+    And no administrative action is performed

--- a/docs/features/authentication.feature
+++ b/docs/features/authentication.feature
@@ -1,0 +1,47 @@
+# Canonical functional specification
+# This file is part of the canonical functional specification of the project.
+# It is not executed with Cucumber.
+# Its purpose is to provide stable functional scenarios and lightweight traceability
+# between requirements, automated tests, and code.
+
+Feature: Authentication and account access
+  As a platform user
+  I want to authenticate and register correctly
+  So that I can access the ticketing platform according to my account state
+
+  Background:
+    Given the platform exposes authentication endpoints
+    And users authenticate with email and password
+    And successful authentication returns an access token
+
+  Scenario: AUTH-01 Correct login
+    Given an active user account exists with valid credentials
+    When the user submits the correct email and password
+    Then the authentication request is accepted
+    And an access token is returned
+    And the token identifies the authenticated user
+
+  Scenario: AUTH-02 Invalid login
+    Given an active user account exists
+    When the user submits a valid email with an incorrect password
+    Then the authentication request is rejected
+    And no access token is returned
+
+  Scenario: AUTH-03 Inactive user cannot enter
+    Given an inactive user account exists with valid credentials
+    When the user attempts to log in with the correct password
+    Then the authentication request is rejected
+    And no authenticated session is created
+
+  Scenario: AUTH-04 Correct registration
+    Given no existing account uses the submitted email address
+    When a visitor submits a valid registration form
+    Then a new user account is created
+    And the new account is assigned the default user role
+    And an access token is returned
+
+  Scenario: AUTH-05 Registration with duplicated email fails
+    Given an existing account already uses the submitted email address
+    When a visitor submits a valid registration form with that same email
+    Then the registration request is rejected
+    And no duplicate account is created

--- a/docs/features/tickets-agent.feature
+++ b/docs/features/tickets-agent.feature
@@ -1,0 +1,42 @@
+# Canonical functional specification
+# This file is part of the canonical functional specification of the project.
+# It is not executed with Cucumber.
+# Its purpose is to provide stable functional scenarios and lightweight traceability
+# between requirements, automated tests, and code.
+
+Feature: Agent and administrator operational ticket management
+  As an agent or administrator
+  I want to manage operational ticket queues
+  So that I can assign, review, and progress incidents correctly
+
+  Background:
+    Given operational roles can access management ticket queues
+    And only agent or administrator roles may perform operational ticket actions
+
+  Scenario: TICKET-AGENT-01 Agent/admin changes status correctly
+    Given an existing ticket is in a state with at least one valid transition
+    And the requester has role agent or administrator
+    When the requester submits a valid status change
+    Then the request is accepted
+    And the ticket status is updated accordingly
+
+  Scenario: TICKET-AGENT-02 Invalid transition returns error
+    Given an existing ticket is in a state that does not allow the requested next status
+    And the requester has role agent or administrator
+    When the requester submits that invalid status transition
+    Then the request is rejected with an error
+    And the ticket state remains unchanged
+
+  Scenario: TICKET-AGENT-03 Agent sees manageable tickets
+    Given the system contains tickets in operational queues
+    And the requester has role agent or administrator
+    When the requester lists manageable tickets
+    Then the response contains tickets available for operational management
+    And the requester can filter or scope that operational view
+
+  Scenario: TICKET-AGENT-04 Assign to me works correctly
+    Given an existing ticket is assignable
+    And the requester has role agent or administrator
+    When the requester asks to assign the ticket to themselves
+    Then the request is accepted
+    And the ticket becomes assigned to that requester

--- a/docs/features/tickets-user.feature
+++ b/docs/features/tickets-user.feature
@@ -1,0 +1,46 @@
+# Canonical functional specification
+# This file is part of the canonical functional specification of the project.
+# It is not executed with Cucumber.
+# Its purpose is to provide stable functional scenarios and lightweight traceability
+# between requirements, automated tests, and code.
+
+Feature: User ticket management
+  As an authenticated end user
+  I want to create and consult my own tickets
+  So that I can report incidents and follow their progress
+
+  Background:
+    Given the platform exposes ticket management endpoints
+    And authenticated users can create and consult their own tickets
+
+  Scenario: TICKET-USER-01 User creates ticket correctly
+    Given an authenticated user is allowed to create tickets
+    And at least one valid active category exists
+    When the user submits a valid ticket creation request
+    Then the ticket is created successfully
+    And the ticket is stored with open status
+    And the ticket is associated with the requesting user
+
+  Scenario: TICKET-USER-02 Creating a ticket without token returns 401
+    Given the platform requires authentication to create tickets
+    When an unauthenticated client submits a ticket creation request
+    Then the request is rejected with unauthorized response
+    And no ticket is created
+
+  Scenario: TICKET-USER-03 User sees only their own tickets
+    Given multiple tickets exist in the system for different users
+    When an authenticated user requests their ticket list
+    Then only tickets created by that same user are returned
+    And tickets from other users are not visible in the response
+
+  Scenario: TICKET-USER-04 User sees detail of their own ticket
+    Given an authenticated user has created a ticket
+    When that same user requests the ticket detail
+    Then the request is accepted
+    And the response contains the full detail of that ticket
+
+  Scenario: TICKET-USER-05 User cannot change ticket status
+    Given an authenticated user owns an existing ticket
+    When the user attempts to change the ticket status directly
+    Then the request is rejected as forbidden
+    And the ticket status remains unchanged

--- a/docs/testing/testing-strategy.md
+++ b/docs/testing/testing-strategy.md
@@ -1,0 +1,343 @@
+# Testing strategy
+
+## Purpose
+
+This document defines the testing strategy for the TFG ticketing platform.
+
+The project aims to combine:
+
+- functional correctness,
+- maintainable automated testing,
+- lightweight traceability,
+- and CI/CD-friendly execution.
+
+The reference chain for the project is:
+
+**Requirement -> Scenario (`.feature`) -> Test -> Code**
+
+The goal is not to treat tests as isolated technical artifacts, but as verifiable evidence that each relevant functional scenario has a clear specification and at least one automated validation path.
+
+---
+
+## Canonical functional specification
+
+The files under `docs/features/` are the **canonical functional specification** for the most relevant business scenarios of the platform.
+
+These `.feature` files are used as:
+
+- a stable business-readable specification,
+- a source for scenario identifiers,
+- and a traceability anchor between requirements, executable tests, and code.
+
+### Important clarification
+
+These `.feature` files are **not executed with Cucumber**.
+
+The project deliberately avoids Cucumber and similar BDD runners. The executable tests will continue to be implemented with the project testing stack:
+
+- **JUnit** for backend unit and integration tests,
+- **Vitest + React Testing Library** for frontend unit and UI/component tests,
+- **Playwright** for end-to-end scenarios.
+
+Therefore, the `.feature` files are specifications, not test runners.
+
+---
+
+## Test pyramid of the project
+
+The testing model follows a pragmatic test pyramid adapted to a SaaS ticketing platform.
+
+### 1. Unit tests
+
+Unit tests should be the most numerous and the fastest.
+
+Their purpose is to validate isolated business rules and application services such as:
+
+- authentication use cases,
+- registration rules,
+- ticket creation rules,
+- status transition rules,
+- assignment rules,
+- authorization decisions contained in application services,
+- and domain invariants.
+
+Typical technologies:
+
+- Backend: **JUnit**
+- Frontend: **Vitest** for isolated logic where applicable
+
+### 2. Integration tests
+
+Integration tests validate the behavior of relevant subsystems working together.
+
+In this project, this mainly means:
+
+- Spring Boot controllers,
+- security filters,
+- persistence adapters,
+- database interaction,
+- serialization/deserialization,
+- and contract behavior of HTTP endpoints.
+
+Typical technologies:
+
+- Backend: **JUnit + Spring Boot Test + MockMvc + Testcontainers**
+
+These tests are especially important for the TFG because they provide evidence that the backend API, security rules, and persistence layer behave correctly under realistic conditions.
+
+### 3. UI/component tests
+
+UI/component tests validate the behavior of frontend pages and components in isolation from full browser E2E execution.
+
+They should cover:
+
+- rendering of relevant states,
+- role-based conditional UI,
+- form validation and submission behavior,
+- navigation decisions,
+- empty/loading/error states,
+- and interaction with mocked API clients.
+
+Typical technologies:
+
+- Frontend: **Vitest + React Testing Library**
+
+These tests may be co-localized next to pages and components when that improves maintainability.
+
+### 4. End-to-end tests
+
+E2E tests validate the most critical user journeys across the whole system.
+
+They should be fewer in number, but highly valuable.
+
+Typical examples for this project are:
+
+- login,
+- registration,
+- user creates ticket,
+- agent assigns ticket,
+- agent changes ticket status,
+- admin manages users or categories.
+
+Typical technologies:
+
+- **Playwright**
+
+---
+
+## What is tested in the backend
+
+The backend test suite should focus on the following layers.
+
+### Backend unit scope
+
+Backend unit tests should validate:
+
+- use cases,
+- domain rules,
+- permission rules enforced in application services,
+- error conditions,
+- and state transitions.
+
+Examples:
+
+- valid and invalid login,
+- successful and unsuccessful registration,
+- ticket creation with valid and invalid input,
+- ticket assignment rules,
+- ticket status changes,
+- and access restrictions for non-authorized actors.
+
+### Backend integration scope
+
+Backend integration tests should validate:
+
+- HTTP contracts,
+- security behavior (`401`, `403`, permitted endpoints, role restrictions),
+- request validation,
+- persistence with PostgreSQL,
+- JWT-based authentication behavior,
+- and end-to-end backend flows inside the Spring application.
+
+Examples:
+
+- `/api/auth/login`,
+- `/api/auth/register`,
+- `/api/auth/me`,
+- `/api/tickets`,
+- `/api/tickets/me`,
+- `/api/tickets/{id}`,
+- `/api/tickets/{id}/status`,
+- `/api/tickets/{id}/assignment/me`,
+- `/api/admin/users`,
+- `/api/admin/categories`.
+
+The backend is the system of record for business rules, so integration coverage is especially important for demonstrating robustness in the TFG.
+
+---
+
+## What is tested in the frontend
+
+The frontend test suite should focus on user-visible behavior rather than implementation details.
+
+### Frontend unit/UI scope
+
+Frontend tests should validate:
+
+- page rendering,
+- protected navigation,
+- role-based route decisions,
+- forms such as login, registration, and create ticket,
+- list views,
+- detail views,
+- admin screens,
+- and visible error/loading/empty states.
+
+Where possible, tests should assert:
+
+- what the user sees,
+- what the user can do,
+- and what API interaction is triggered.
+
+### Frontend E2E scope
+
+Playwright should validate the most relevant cross-page workflows with real browser execution.
+
+The E2E suite should remain intentionally small and should focus on canonical business scenarios rather than exhaustive UI permutations.
+
+---
+
+## Why Cucumber is not used
+
+The project uses Gherkin-style `.feature` files as documentation, but it does **not** use Cucumber.
+
+This decision is intentional.
+
+### Reasons
+
+1. **Lower tooling overhead**  
+   Cucumber introduces an additional execution layer, step-definition maintenance, and glue code that can become expensive in a small-to-medium academic project.
+
+2. **Reduced duplication**  
+   With Cucumber, there is often duplication between scenario text, step definitions, and actual test logic. This project prefers writing executable tests directly in JUnit, Vitest, and Playwright.
+
+3. **Better alignment with the existing stack**  
+   The project already uses Java/Spring Boot and React/Vitest. Directly using their native testing tools keeps the suite simpler and easier to maintain.
+
+4. **Clearer ownership of test intent**  
+   The `.feature` file defines the functional contract, while the executable test is written in the most suitable technical layer.
+
+5. **Better fit for CI/CD**  
+   Native test tools are easier to run, parallelize, and report in standard pipelines.
+
+In short, the project adopts the **discipline of BDD-style specification** without adopting the **runtime layer of Cucumber**.
+
+---
+
+## Why lightweight traceability is used
+
+The project uses **lightweight traceability** rather than a heavy requirements management process.
+
+### What lightweight traceability means here
+
+Each important functional scenario gets:
+
+- a stable scenario identifier,
+- a canonical scenario description in a `.feature` file,
+- one or more planned executable tests,
+- and a mapping entry in the traceability matrix.
+
+### Why this is the right level for the project
+
+1. It is academically defensible for a TFG.
+2. It keeps functional intent visible.
+3. It prevents the test suite from becoming disconnected from requirements.
+4. It avoids excessive process overhead.
+5. It makes progress measurable over time.
+
+The objective is not bureaucratic traceability; the objective is **practical and auditable linkage** between what the system must do and what is actually tested.
+
+---
+
+## Relationship between scenarios and executable tests
+
+A scenario in `docs/features/` does not imply a single test file.
+
+A single scenario may be validated by several test layers, for example:
+
+- a backend unit test for business rules,
+- a backend integration test for the HTTP contract,
+- a frontend UI/component test for page behavior,
+- and optionally a Playwright E2E for the full journey.
+
+This is acceptable and desirable.
+
+The key rule is that the scenario identifier must remain stable and must be easy to reference from tests, planning documents, PRs, or CI reporting.
+
+---
+
+## How this strategy fits CI/CD
+
+This testing strategy is designed to integrate naturally with CI/CD.
+
+### Expected pipeline structure
+
+A typical pipeline should evolve toward these stages:
+
+1. **Static checks**  
+   Formatting, linting, and basic quality gates.
+
+2. **Backend unit tests**  
+   Fast feedback on domain and use case rules.
+
+3. **Frontend unit/UI tests**  
+   Fast feedback on pages, forms, and role-based UI behavior.
+
+4. **Backend integration tests**  
+   Validation of HTTP contracts, security, and persistence.
+
+5. **E2E smoke scenarios**  
+   Validation of a small number of critical business flows.
+
+6. **Coverage and reporting artifacts**  
+   Coverage reports, test summaries, and traceability status where feasible.
+
+### Value for CI/CD
+
+This model helps the project achieve:
+
+- faster feedback at lower layers,
+- stronger confidence before deployment,
+- clearer evidence for academic evaluation,
+- and a direct link between requirements and automation.
+
+For a DevOps-oriented TFG, the important point is that testing is not an isolated activity: it becomes part of the delivery pipeline and release confidence model.
+
+---
+
+## Governance and maintenance rules
+
+To keep this strategy stable over time, the project should follow these rules.
+
+1. Every new critical feature should add or update at least one scenario in `docs/features/`.
+2. Each scenario must have a stable ID.
+3. The traceability matrix must be updated when tests are added or removed.
+4. Executable tests should reference scenario IDs whenever practical.
+5. The `.feature` files should remain readable by humans and stable over time.
+6. The `.feature` files should avoid technical implementation details.
+7. The executable tests remain the source of automated verification, while the `.feature` files remain the source of functional intent.
+
+---
+
+## Summary
+
+This project adopts a layered testing strategy with lightweight traceability.
+
+Its key principles are:
+
+- canonical functional scenarios in `.feature` files,
+- executable tests implemented with native tools rather than Cucumber,
+- a clear chain from requirement to code,
+- and CI/CD-compatible automation by layers.
+
+This approach is well suited to the objectives of the TFG: serious testing, good engineering practices, and a defensible DevOps-oriented quality strategy.

--- a/docs/testing/traceability-matrix.md
+++ b/docs/testing/traceability-matrix.md
@@ -1,0 +1,40 @@
+# Traceability matrix
+
+This matrix provides the initial traceability layer for the testing strategy of the project.
+
+The intended chain is:
+
+**Requirement -> Scenario (`.feature`) -> Test -> Code**
+
+The scenarios referenced below are defined in `docs/features/` and act as the canonical functional specification.
+
+> Note: the `.feature` files are not executed with Cucumber. They are maintained as functional documentation and traceability anchors.
+
+| Scenario ID | Feature file | Functional description | Planned test level | Existing test | Status | Notes |
+|---|---|---|---|---|---|---|
+| AUTH-01 | `authentication.feature` | Correct login returns access token and grants access to authenticated area. | Backend integration, Frontend UI, E2E | Backend integration exists (`AuthLoginIntegrationTest`). | Partial | Frontend login flow and E2E still pending. |
+| AUTH-02 | `authentication.feature` | Invalid login is rejected. | Backend integration, Frontend UI | Backend integration exists (`AuthLoginIntegrationTest`). | Partial | Frontend error handling test is still pending. |
+| AUTH-03 | `authentication.feature` | Inactive user cannot log in. | Backend unit, Backend integration | Backend unit and integration exist. | Partial | Frontend coverage is not yet planned as critical. |
+| AUTH-04 | `authentication.feature` | Valid registration creates a user account and returns an access token. | Backend unit, Backend integration, Frontend UI, E2E | Backend unit and integration exist. | Partial | Frontend register flow and E2E are pending. |
+| AUTH-05 | `authentication.feature` | Registration with duplicated email fails. | Backend unit, Backend integration, Frontend UI | Backend unit and integration exist. | Partial | Frontend duplicate-email behavior is pending. |
+| TICKET-USER-01 | `tickets-user.feature` | Authenticated user creates a ticket successfully. | Backend unit, Backend integration, Frontend UI, E2E | Backend unit and frontend UI exist. | Partial | Backend HTTP integration and E2E are pending. |
+| TICKET-USER-02 | `tickets-user.feature` | Creating a ticket without token returns `401 Unauthorized`. | Backend integration, E2E | No direct test found. | Planned | Security behavior should be covered at HTTP level. |
+| TICKET-USER-03 | `tickets-user.feature` | User sees only their own tickets. | Backend integration, Frontend UI, E2E | Frontend empty-state test exists for user tickets page. | Planned | Backend listing contract is not covered yet. |
+| TICKET-USER-04 | `tickets-user.feature` | User sees the detail of their own ticket. | Backend integration, Frontend UI, E2E | No direct test found. | Planned | Detail flow is a high-priority gap. |
+| TICKET-USER-05 | `tickets-user.feature` | User cannot change ticket status. | Backend unit, Backend integration, Frontend UI | Backend unit exists for forbidden status change. | Partial | HTTP and frontend behavior remain pending. |
+| TICKET-AGENT-01 | `tickets-agent.feature` | Agent or admin changes ticket status successfully. | Backend unit, Backend integration, Frontend UI, E2E | Backend unit exists. | Partial | Missing HTTP, frontend detail, and E2E coverage. |
+| TICKET-AGENT-02 | `tickets-agent.feature` | Invalid ticket status transition returns an error. | Backend unit, Backend integration | Backend unit exists. | Partial | HTTP contract test is pending. |
+| TICKET-AGENT-03 | `tickets-agent.feature` | Agent sees manageable ticket queues. | Backend integration, Frontend UI, E2E | Frontend UI test exists for URL-driven queue filters. | Partial | Backend queue listing tests are missing. |
+| TICKET-AGENT-04 | `tickets-agent.feature` | Assign-to-me works correctly for agent/admin. | Backend unit, Backend integration, Frontend UI, E2E | Backend unit exists. | Partial | Missing HTTP contract, detail-page UI, and E2E. |
+| ADMIN-01 | `admin.feature` | Admin lists users. | Backend integration, Frontend UI, E2E | Backend integration and frontend UI load test exist. | Partial | More detailed assertions are still needed. |
+| ADMIN-02 | `admin.feature` | Admin lists categories. | Backend integration, Frontend UI, E2E | Backend integration and frontend UI load test exist. | Partial | Needs stronger behavioral coverage. |
+| ADMIN-03 | `admin.feature` | Admin deactivates a user. | Backend integration, Frontend UI, E2E | Backend integration exists. | Partial | Frontend interaction and E2E remain pending. |
+| ADMIN-04 | `admin.feature` | Non-admin cannot access admin endpoints. | Backend integration, Frontend UI | Backend integration exists. | Partial | Frontend route protection should also be validated. |
+
+## Status legend
+
+- **Planned**: scenario is defined but no relevant executable coverage exists yet.
+- **Partial**: scenario has at least one relevant executable test, but coverage is incomplete across planned layers.
+- **Covered**: scenario has sufficient coverage at the intended layers.
+
+At this stage, the matrix is intentionally conservative: most scenarios are marked as **Partial** or **Planned** because the documentary strategy is being established before the next wave of implementation work.

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/admin/AdminIntegrationTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/admin/AdminIntegrationTest.java
@@ -5,6 +5,8 @@ import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.Cat
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.UserJpaEntity;
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.CategorySpringDataRepository;
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.UserSpringDataRepository;
+import com.aperdigon.ticketing_backend.specification.SpecificationRef;
+import com.aperdigon.ticketing_backend.specification.TestLevel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -85,6 +87,8 @@ class AdminIntegrationTest {
     }
 
     @Test
+    @SpecificationRef(value = "ADMIN-02", level = TestLevel.INTEGRATION, feature = "admin.feature")
+    @SpecificationRef(value = "ADMIN-01", level = TestLevel.INTEGRATION, feature = "admin.feature")
     void admin_can_list_categories_and_users() throws Exception {
         String token = loginAndExtractToken("admin@test.com", "secret123");
 
@@ -100,6 +104,7 @@ class AdminIntegrationTest {
     }
 
     @Test
+    @SpecificationRef(value = "ADMIN-03", level = TestLevel.INTEGRATION, feature = "admin.feature")
     void admin_can_deactivate_user() throws Exception {
         String token = loginAndExtractToken("admin@test.com", "secret123");
 
@@ -121,6 +126,7 @@ class AdminIntegrationTest {
     }
 
     @Test
+    @SpecificationRef(value = "ADMIN-04", level = TestLevel.INTEGRATION, feature = "admin.feature")
     void non_admin_cannot_access_admin_endpoints() throws Exception {
         String token = loginAndExtractToken("user@test.com", "secret123");
 

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/auth/AuthLoginIntegrationTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/auth/AuthLoginIntegrationTest.java
@@ -3,6 +3,8 @@ package com.aperdigon.ticketing_backend.integration.auth;
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.UserJpaEntity;
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.UserSpringDataRepository;
+import com.aperdigon.ticketing_backend.specification.SpecificationRef;
+import com.aperdigon.ticketing_backend.specification.TestLevel;
 import com.nimbusds.jwt.SignedJWT;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -95,6 +97,7 @@ class AuthLoginIntegrationTest {
     }
 
     @Test
+    @SpecificationRef(value = "AUTH-01", level = TestLevel.INTEGRATION, feature = "authentication.feature")
     void login_returns_jwt_when_credentials_are_valid() throws Exception {
         var mvcResult = mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -117,6 +120,7 @@ class AuthLoginIntegrationTest {
     }
 
     @Test
+    @SpecificationRef(value = "AUTH-02", level = TestLevel.INTEGRATION, feature = "authentication.feature", note = "Covers invalid login with wrong password.")
     void login_returns_unauthorized_when_password_is_invalid() throws Exception {
         mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -127,6 +131,7 @@ class AuthLoginIntegrationTest {
     }
 
     @Test
+    @SpecificationRef(value = "AUTH-03", level = TestLevel.INTEGRATION, feature = "authentication.feature")
     void login_returns_unauthorized_when_user_is_inactive() throws Exception {
         mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -137,6 +142,7 @@ class AuthLoginIntegrationTest {
     }
 
     @Test
+    @SpecificationRef(value = "AUTH-04", level = TestLevel.INTEGRATION, feature = "authentication.feature")
     void register_creates_user_and_returns_jwt() throws Exception {
         var mvcResult = mockMvc.perform(post("/api/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -182,6 +188,7 @@ class AuthLoginIntegrationTest {
     }
 
     @Test
+    @SpecificationRef(value = "AUTH-05", level = TestLevel.INTEGRATION, feature = "authentication.feature")
     void register_returns_bad_request_when_email_is_duplicated() throws Exception {
         mockMvc.perform(post("/api/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/specification/SpecificationRef.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/specification/SpecificationRef.java
@@ -1,0 +1,52 @@
+package com.aperdigon.ticketing_backend.specification;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Links a JUnit test class or test method to a canonical functional scenario
+ * defined in the project's {@code docs/features/*.feature} files.
+ *
+ * <p>The annotation supports a lightweight traceability chain:
+ * {@code Requirement -> Scenario (.feature) -> Test -> Code}.</p>
+ *
+ * <p>Its purpose is documentary and architectural. It makes it easier to audit
+ * which automated tests provide evidence for which functional scenarios, while
+ * keeping the solution simple, explicit, and maintainable.</p>
+ *
+ * <p>This annotation does <strong>not</strong> imply executable BDD, does not run
+ * Gherkin scenarios, and does not require Cucumber. The executable verification
+ * remains implemented directly in JUnit tests.</p>
+ *
+ * <p>The annotation is designed for an academic project where a small amount of
+ * runtime metadata is enough to support traceability without introducing heavy
+ * tooling or additional test runners.</p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Repeatable(SpecificationRefs.class)
+public @interface SpecificationRef {
+
+    /**
+     * Stable scenario identifier, for example {@code TICKET-USER-01}.
+     */
+    String value();
+
+    /**
+     * Intended test layer that provides evidence for the referenced scenario.
+     */
+    TestLevel level();
+
+    /**
+     * Optional feature file name, for example {@code tickets-user.feature}.
+     */
+    String feature() default "";
+
+    /**
+     * Optional note to clarify the scope of the correspondence.
+     */
+    String note() default "";
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/specification/SpecificationRefs.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/specification/SpecificationRefs.java
@@ -1,0 +1,26 @@
+package com.aperdigon.ticketing_backend.specification;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Container annotation for repeatable {@link SpecificationRef} declarations.
+ *
+ * <p>Its purpose is purely structural: it allows a single JUnit test class or
+ * test method to reference more than one canonical functional scenario when the
+ * same automated check provides evidence for multiple requirements.</p>
+ *
+ * <p>Within the project traceability chain {@code Requirement -> Scenario
+ * (.feature) -> Test -> Code}, this annotation helps keep the mapping simple and
+ * explicit without introducing executable BDD tooling.</p>
+ *
+ * <p>It is intended for an academic JUnit-based test suite and should be used as
+ * documentation and traceability metadata only.</p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface SpecificationRefs {
+    SpecificationRef[] value();
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/specification/TestLevel.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/specification/TestLevel.java
@@ -1,0 +1,19 @@
+package com.aperdigon.ticketing_backend.specification;
+
+/**
+ * Declares the intended verification layer for a backend test that references a
+ * canonical functional scenario.
+ *
+ * <p>The value is part of a lightweight academic traceability model based on the
+ * chain {@code Requirement -> Scenario (.feature) -> Test -> Code}.</p>
+ *
+ * <p>This enum does not introduce BDD execution and does not imply the use of
+ * Cucumber or any other feature runner. It only classifies how the JUnit test
+ * contributes to specification coverage.</p>
+ */
+public enum TestLevel {
+    UNIT,
+    INTEGRATION,
+    UI,
+    E2E
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/auth/LoginUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/auth/LoginUseCaseTest.java
@@ -7,6 +7,8 @@ import com.aperdigon.ticketing_backend.application.shared.exception.Unauthorized
 import com.aperdigon.ticketing_backend.domain.user.User;
 import com.aperdigon.ticketing_backend.domain.user.UserId;
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import com.aperdigon.ticketing_backend.specification.SpecificationRef;
+import com.aperdigon.ticketing_backend.specification.TestLevel;
 import com.aperdigon.ticketing_backend.test_support.InMemoryUserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -20,6 +22,7 @@ class LoginUseCaseTest {
     private final BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
 
     @Test
+    @SpecificationRef(value = "AUTH-01", level = TestLevel.UNIT, feature = "authentication.feature")
     void returns_token_when_credentials_are_valid() {
         var repo = new InMemoryUserRepository();
         User user = new User(UserId.of(UUID.randomUUID()), "user@test.com", "User", encoder.encode("secret"), UserRole.USER, true);
@@ -34,12 +37,14 @@ class LoginUseCaseTest {
     }
 
     @Test
+    @SpecificationRef(value = "AUTH-02", level = TestLevel.UNIT, feature = "authentication.feature", note = "Covers invalid login with unknown email.")
     void throws_when_email_does_not_exist() {
         var useCase = new LoginUseCase(new InMemoryUserRepository(), encoder, u -> "token");
         assertThrows(UnauthorizedException.class, () -> useCase.execute(new LoginCommand("missing@test.com", "secret")));
     }
 
     @Test
+    @SpecificationRef(value = "AUTH-02", level = TestLevel.UNIT, feature = "authentication.feature", note = "Covers invalid login with wrong password.")
     void throws_when_password_is_invalid() {
         var repo = new InMemoryUserRepository();
         repo.put(new User(UserId.of(UUID.randomUUID()), "user@test.com", "User", encoder.encode("secret"), UserRole.USER, true));
@@ -49,6 +54,7 @@ class LoginUseCaseTest {
     }
 
     @Test
+    @SpecificationRef(value = "AUTH-03", level = TestLevel.UNIT, feature = "authentication.feature")
     void throws_when_user_is_inactive() {
         var repo = new InMemoryUserRepository();
         repo.put(new User(UserId.of(UUID.randomUUID()), "user@test.com", "User", encoder.encode("secret"), UserRole.USER, false));

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/auth/RegisterUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/auth/RegisterUseCaseTest.java
@@ -4,6 +4,8 @@ import com.aperdigon.ticketing_backend.application.auth.register.RegisterCommand
 import com.aperdigon.ticketing_backend.application.auth.register.RegisterUseCase;
 import com.aperdigon.ticketing_backend.domain.shared.exception.InvalidArgumentException;
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import com.aperdigon.ticketing_backend.specification.SpecificationRef;
+import com.aperdigon.ticketing_backend.specification.TestLevel;
 import com.aperdigon.ticketing_backend.test_support.InMemoryUserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -15,6 +17,7 @@ class RegisterUseCaseTest {
     private final BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
 
     @Test
+    @SpecificationRef(value = "AUTH-04", level = TestLevel.UNIT, feature = "authentication.feature")
     void creates_user_and_returns_token_when_payload_is_valid() {
         var repo = new InMemoryUserRepository();
         var useCase = new RegisterUseCase(repo, encoder, u -> "jwt-token");
@@ -59,6 +62,7 @@ class RegisterUseCaseTest {
     }
 
     @Test
+    @SpecificationRef(value = "AUTH-05", level = TestLevel.UNIT, feature = "authentication.feature")
     void throws_generic_error_when_email_already_exists() {
         var repo = new InMemoryUserRepository();
         var useCase = new RegisterUseCase(repo, encoder, u -> "token");

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/AssignTicketToMeUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/AssignTicketToMeUseCaseTest.java
@@ -13,6 +13,8 @@ import com.aperdigon.ticketing_backend.domain.ticket.exceptions.TicketAlreadyAss
 import com.aperdigon.ticketing_backend.domain.user.User;
 import com.aperdigon.ticketing_backend.domain.user.UserId;
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import com.aperdigon.ticketing_backend.specification.SpecificationRef;
+import com.aperdigon.ticketing_backend.specification.TestLevel;
 import com.aperdigon.ticketing_backend.test_support.InMemoryTicketRepository;
 import com.aperdigon.ticketing_backend.test_support.InMemoryTicketEventRepository;
 import org.junit.jupiter.api.Test;
@@ -28,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class AssignTicketToMeUseCaseTest {
 
     @Test
+    @SpecificationRef(value = "TICKET-AGENT-04", level = TestLevel.UNIT, feature = "tickets-agent.feature")
     void agent_can_assign_ticket_to_self() {
         Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
 

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/ChangeTicketStatusUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/ChangeTicketStatusUseCaseTest.java
@@ -22,6 +22,8 @@ import com.aperdigon.ticketing_backend.domain.ticket.exceptions.TicketInvalidSta
 import com.aperdigon.ticketing_backend.domain.user.User;
 import com.aperdigon.ticketing_backend.domain.user.UserId;
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import com.aperdigon.ticketing_backend.specification.SpecificationRef;
+import com.aperdigon.ticketing_backend.specification.TestLevel;
 import com.aperdigon.ticketing_backend.test_support.InMemoryTicketRepository;
 import com.aperdigon.ticketing_backend.test_support.InMemoryTicketEventRepository;
 import org.junit.jupiter.api.Test;
@@ -30,6 +32,7 @@ import org.junit.jupiter.api.Test;
 public final class ChangeTicketStatusUseCaseTest {
 
     @Test
+    @SpecificationRef(value = "TICKET-AGENT-01", level = TestLevel.UNIT, feature = "tickets-agent.feature", note = "Valid transition from OPEN to IN_PROGRESS.")
     void agent_can_change_status_open_to_in_progress() {
         Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
 
@@ -57,6 +60,7 @@ public final class ChangeTicketStatusUseCaseTest {
     }
 
     @Test
+    @SpecificationRef(value = "TICKET-USER-05", level = TestLevel.UNIT, feature = "tickets-user.feature")
     void user_cannot_change_status() {
         Clock clock = Clock.systemUTC();
 
@@ -91,6 +95,7 @@ public final class ChangeTicketStatusUseCaseTest {
     }
 
     @Test
+    @SpecificationRef(value = "TICKET-AGENT-02", level = TestLevel.UNIT, feature = "tickets-agent.feature")
     void invalid_transition_in_progress_to_open_is_rejected_by_domain() {
         Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
 
@@ -115,6 +120,7 @@ public final class ChangeTicketStatusUseCaseTest {
     }
 
     @Test
+    @SpecificationRef(value = "TICKET-AGENT-01", level = TestLevel.UNIT, feature = "tickets-agent.feature", note = "Another valid operational transition.")
     void can_move_from_in_progress_to_on_hold() {
         Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
 

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/CreateTicketUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/CreateTicketUseCaseTest.java
@@ -20,6 +20,8 @@ import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
 import com.aperdigon.ticketing_backend.domain.user.User;
 import com.aperdigon.ticketing_backend.domain.user.UserId;
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import com.aperdigon.ticketing_backend.specification.SpecificationRef;
+import com.aperdigon.ticketing_backend.specification.TestLevel;
 import com.aperdigon.ticketing_backend.test_support.InMemoryCategoryRepository;
 import com.aperdigon.ticketing_backend.test_support.InMemoryTicketRepository;
 import com.aperdigon.ticketing_backend.test_support.InMemoryTicketEventRepository;
@@ -29,6 +31,7 @@ import org.junit.jupiter.api.Test;
 public final class CreateTicketUseCaseTest {
 
     @Test
+    @SpecificationRef(value = "TICKET-USER-01", level = TestLevel.UNIT, feature = "tickets-user.feature")
     void creates_ticket_in_open_status_and_persists_it() {
         Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
 


### PR DESCRIPTION
### Motivation
- Provide a canonical, human-readable specification of the main business scenarios to improve traceability between requirements, tests, and code.
- Define and document the overall testing strategy and a traceability matrix to guide future automated tests and CI work.

### Description
- Add feature specification files under `docs/features/`: `authentication.feature`, `admin.feature`, `tickets-user.feature`, and `tickets-agent.feature` with stable scenario identifiers and background clauses.
- Add a comprehensive testing strategy at `docs/testing/testing-strategy.md` explaining test pyramid, tooling choices, and why `.feature` files are documentation (not executed with Cucumber).
- Add an initial traceability matrix at `docs/testing/traceability-matrix.md` mapping scenario IDs to planned test levels and current coverage status.
- Keep the `.feature` files intentionally non-executable and use them as a reference layer for future JUnit, Vitest, and Playwright tests.
