### PR TITLE
test: consolidate backend integration test support

### DIFF
--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/admin/AdminIntegrationTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/admin/AdminIntegrationTest.java
@@ -1,26 +1,15 @@
 package com.aperdigon.ticketing_backend.integration.admin;
 
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
-import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.CategoryJpaEntity;
-import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.UserJpaEntity;
-import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.CategorySpringDataRepository;
-import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.UserSpringDataRepository;
 import com.aperdigon.ticketing_backend.specification.SpecificationRef;
 import com.aperdigon.ticketing_backend.specification.TestLevel;
+import com.aperdigon.ticketing_backend.test_support.builders.CategoryTestDataBuilder;
+import com.aperdigon.ticketing_backend.test_support.integration.AbstractAuthenticatedApiIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.util.Map;
 import java.util.UUID;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -29,76 +18,36 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@Testcontainers
-class AdminIntegrationTest {
+class AdminIntegrationTest extends AbstractAuthenticatedApiIntegrationTest {
 
-    @Container
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
-
-    @DynamicPropertySource
-    static void configureDatasource(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
-    }
-
-    @Autowired
-    MockMvc mockMvc;
-
-    @Autowired
-    UserSpringDataRepository userRepo;
-
-    @Autowired
-    CategorySpringDataRepository categoryRepo;
-
-    @Autowired
-    PasswordEncoder passwordEncoder;
+    private static final String DEFAULT_PASSWORD = "secret123";
 
     private UUID managedUserId;
 
     @BeforeEach
     void setUp() {
-        categoryRepo.deleteAll();
-        userRepo.deleteAll();
+        clearPersistedData();
 
-        userRepo.save(new UserJpaEntity(
-                UUID.randomUUID(),
-                "admin@test.com",
-                "Admin",
-                passwordEncoder.encode("secret123"),
-                UserRole.ADMIN,
-                true
-        ));
+        persistActiveUser("admin@test.com", "Admin", DEFAULT_PASSWORD, UserRole.ADMIN);
 
-        managedUserId = UUID.randomUUID();
-        userRepo.save(new UserJpaEntity(
-                managedUserId,
-                "user@test.com",
-                "Regular User",
-                passwordEncoder.encode("secret123"),
-                UserRole.USER,
-                true
-        ));
+        managedUserId = persistActiveUser("user@test.com", "Regular User", DEFAULT_PASSWORD, UserRole.USER).getId();
 
-        categoryRepo.save(new CategoryJpaEntity(UUID.randomUUID(), "Software", true));
+        persistCategory(CategoryTestDataBuilder.aCategory().withName("Software"));
     }
 
     @Test
     @SpecificationRef(value = "ADMIN-02", level = TestLevel.INTEGRATION, feature = "admin.feature")
     @SpecificationRef(value = "ADMIN-01", level = TestLevel.INTEGRATION, feature = "admin.feature")
     void admin_can_list_categories_and_users() throws Exception {
-        String token = loginAndExtractToken("admin@test.com", "secret123");
+        String token = loginAndExtractAccessToken("admin@test.com", DEFAULT_PASSWORD);
 
         mockMvc.perform(get("/api/admin/categories")
-                        .header("Authorization", "Bearer " + token))
+                        .with(bearerToken(token)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].name").value("Software"));
 
         mockMvc.perform(get("/api/admin/users")
-                        .header("Authorization", "Bearer " + token))
+                        .with(bearerToken(token)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[?(@.email=='user@test.com')]").exists());
     }
@@ -106,45 +55,31 @@ class AdminIntegrationTest {
     @Test
     @SpecificationRef(value = "ADMIN-03", level = TestLevel.INTEGRATION, feature = "admin.feature")
     void admin_can_deactivate_user() throws Exception {
-        String token = loginAndExtractToken("admin@test.com", "secret123");
+        String token = loginAndExtractAccessToken("admin@test.com", DEFAULT_PASSWORD);
 
         mockMvc.perform(patch("/api/admin/users/{userId}/active", managedUserId)
-                        .header("Authorization", "Bearer " + token)
+                        .with(bearerToken(token))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {"isActive":false}
-                                """))
+                        .content(toJson(Map.of("isActive", false))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.isActive").value(false));
 
         mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {"email":"user@test.com","password":"secret123"}
-                                """))
+                        .content(toJson(Map.of(
+                                "email", "user@test.com",
+                                "password", DEFAULT_PASSWORD
+                        ))))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
     @SpecificationRef(value = "ADMIN-04", level = TestLevel.INTEGRATION, feature = "admin.feature")
     void non_admin_cannot_access_admin_endpoints() throws Exception {
-        String token = loginAndExtractToken("user@test.com", "secret123");
+        String token = loginAndExtractAccessToken("user@test.com", DEFAULT_PASSWORD);
 
         mockMvc.perform(get("/api/admin/users")
-                        .header("Authorization", "Bearer " + token))
+                        .with(bearerToken(token)))
                 .andExpect(status().isForbidden());
-    }
-
-    private String loginAndExtractToken(String email, String password) throws Exception {
-        var mvcResult = mockMvc.perform(post("/api/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {"email":"%s","password":"%s"}
-                                """.formatted(email, password)))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        String body = mvcResult.getResponse().getContentAsString();
-        return body.replaceAll(".*\\\"accessToken\\\":\\\"([^\\\"]+)\\\".*", "$1");
     }
 }

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/auth/AuthLoginIntegrationTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/auth/AuthLoginIntegrationTest.java
@@ -1,26 +1,17 @@
 package com.aperdigon.ticketing_backend.integration.auth;
 
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
-import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.UserJpaEntity;
-import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.UserSpringDataRepository;
 import com.aperdigon.ticketing_backend.specification.SpecificationRef;
 import com.aperdigon.ticketing_backend.specification.TestLevel;
+import com.aperdigon.ticketing_backend.test_support.builders.UserTestDataBuilder;
+import com.aperdigon.ticketing_backend.test_support.integration.AbstractAuthenticatedApiIntegrationTest;
 import com.nimbusds.jwt.SignedJWT;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.notNullValue;
@@ -28,63 +19,29 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@Testcontainers
-class AuthLoginIntegrationTest {
+class AuthLoginIntegrationTest extends AbstractAuthenticatedApiIntegrationTest {
 
-    @Container
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
-
-    @DynamicPropertySource
-    static void configureDatasource(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
-    }
-
-    @Autowired
-    MockMvc mockMvc;
-
-    @Autowired
-    UserSpringDataRepository userRepo;
-
-    @Autowired
-    PasswordEncoder passwordEncoder;
+    private static final String DEFAULT_PASSWORD = "secret123";
 
     private UUID activeUserId;
 
     @BeforeEach
     void setUp() {
-        userRepo.deleteAll();
-        activeUserId = UUID.randomUUID();
+        clearPersistedData();
 
-        userRepo.save(new UserJpaEntity(
-                activeUserId,
-                "user@test.com",
-                "User",
-                passwordEncoder.encode("secret123"),
-                UserRole.USER,
-                true
-        ));
+        activeUserId = persistActiveUser("user@test.com", "User", DEFAULT_PASSWORD, UserRole.USER).getId();
 
-        userRepo.save(new UserJpaEntity(
-                UUID.randomUUID(),
-                "inactive@test.com",
-                "Inactive",
-                passwordEncoder.encode("secret123"),
-                UserRole.USER,
-                false
-        ));
+        persistUser(UserTestDataBuilder.aUser()
+                .withEmail("inactive@test.com")
+                .withDisplayName("Inactive")
+                .withPassword(DEFAULT_PASSWORD)
+                .withRole(UserRole.USER)
+                .inactive());
     }
-
-
 
     @Test
     void login_preflight_returns_cors_headers_for_frontend_origin() throws Exception {
@@ -99,17 +56,15 @@ class AuthLoginIntegrationTest {
     @Test
     @SpecificationRef(value = "AUTH-01", level = TestLevel.INTEGRATION, feature = "authentication.feature")
     void login_returns_jwt_when_credentials_are_valid() throws Exception {
-        var mvcResult = mockMvc.perform(post("/api/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {"email":"user@test.com","password":"secret123"}
-                                """))
+        var mvcResult = postJson("/api/auth/login", Map.of(
+                "email", "user@test.com",
+                "password", DEFAULT_PASSWORD
+        ))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.accessToken", notNullValue()))
                 .andReturn();
 
-        String body = mvcResult.getResponse().getContentAsString();
-        String token = body.replaceAll(".*\"accessToken\":\"([^\"]+)\".*", "$1");
+        String token = objectMapper.readTree(mvcResult.getResponse().getContentAsString()).get("accessToken").asText();
         SignedJWT jwt = SignedJWT.parse(token);
 
         assertEquals(activeUserId.toString(), jwt.getJWTClaimsSet().getSubject());
@@ -122,64 +77,53 @@ class AuthLoginIntegrationTest {
     @Test
     @SpecificationRef(value = "AUTH-02", level = TestLevel.INTEGRATION, feature = "authentication.feature", note = "Covers invalid login with wrong password.")
     void login_returns_unauthorized_when_password_is_invalid() throws Exception {
-        mockMvc.perform(post("/api/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {"email":"user@test.com","password":"wrong"}
-                                """))
+        postJson("/api/auth/login", Map.of(
+                "email", "user@test.com",
+                "password", "wrong"
+        ))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
     @SpecificationRef(value = "AUTH-03", level = TestLevel.INTEGRATION, feature = "authentication.feature")
     void login_returns_unauthorized_when_user_is_inactive() throws Exception {
-        mockMvc.perform(post("/api/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {"email":"inactive@test.com","password":"secret123"}
-                                """))
+        postJson("/api/auth/login", Map.of(
+                "email", "inactive@test.com",
+                "password", DEFAULT_PASSWORD
+        ))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
     @SpecificationRef(value = "AUTH-04", level = TestLevel.INTEGRATION, feature = "authentication.feature")
     void register_creates_user_and_returns_jwt() throws Exception {
-        var mvcResult = mockMvc.perform(post("/api/auth/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {"email":"new.user@test.com","displayName":"New User","password":"Secret123!","confirmPassword":"Secret123!"}
-                                """))
+        var mvcResult = postJson("/api/auth/register", Map.of(
+                "email", "new.user@test.com",
+                "displayName", "New User",
+                "password", "Secret123!",
+                "confirmPassword", "Secret123!"
+        ))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.accessToken", notNullValue()))
                 .andReturn();
 
-        String body = mvcResult.getResponse().getContentAsString();
-        String token = body.replaceAll(".*\\"accessToken\\":\\"([^\\"]+)\\".*", "$1");
+        String token = objectMapper.readTree(mvcResult.getResponse().getContentAsString()).get("accessToken").asText();
         SignedJWT jwt = SignedJWT.parse(token);
 
         assertEquals(List.of("USER"), jwt.getJWTClaimsSet().getStringListClaim("roles"));
         assertNotNull(jwt.getJWTClaimsSet().getExpirationTime());
 
-        var savedUser = userRepo.findByEmailIgnoreCase("new.user@test.com").orElseThrow();
+        var savedUser = userRepository.findByEmailIgnoreCase("new.user@test.com").orElseThrow();
         assertEquals(UserRole.USER, savedUser.getRole());
         assertEquals("New User", savedUser.getDisplayName());
     }
 
     @Test
     void me_returns_profile_data_from_jwt_claims() throws Exception {
-        var loginResult = mockMvc.perform(post("/api/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {"email":"user@test.com","password":"secret123"}
-                                """))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        String tokenBody = loginResult.getResponse().getContentAsString();
-        String token = tokenBody.replaceAll(".*\"accessToken\":\"([^\"]+)\".*", "$1");
+        String token = loginAndExtractAccessToken("user@test.com", DEFAULT_PASSWORD);
 
         mockMvc.perform(get("/api/auth/me")
-                        .header("Authorization", "Bearer " + token))
+                        .with(bearerToken(token)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.sub").value(activeUserId.toString()))
                 .andExpect(jsonPath("$.email").value("user@test.com"))
@@ -190,22 +134,24 @@ class AuthLoginIntegrationTest {
     @Test
     @SpecificationRef(value = "AUTH-05", level = TestLevel.INTEGRATION, feature = "authentication.feature")
     void register_returns_bad_request_when_email_is_duplicated() throws Exception {
-        mockMvc.perform(post("/api/auth/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {"email":"user@test.com","displayName":"Duplicate User","password":"Secret123!","confirmPassword":"Secret123!"}
-                                """))
+        postJson("/api/auth/register", Map.of(
+                "email", "user@test.com",
+                "displayName", "Duplicate User",
+                "password", "Secret123!",
+                "confirmPassword", "Secret123!"
+        ))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("Registration failed"));
     }
 
     @Test
     void register_returns_bad_request_when_password_does_not_match_policy() throws Exception {
-        mockMvc.perform(post("/api/auth/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {"email":"weak.user@test.com","displayName":"Weak User","password":"password","confirmPassword":"password"}
-                                """))
+        postJson("/api/auth/register", Map.of(
+                "email", "weak.user@test.com",
+                "displayName", "Weak User",
+                "password", "password",
+                "confirmPassword", "password"
+        ))
                 .andExpect(status().isBadRequest());
     }
 }

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/ticket/ChangeTicketStatusApiIntegrationTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/ticket/ChangeTicketStatusApiIntegrationTest.java
@@ -1,0 +1,121 @@
+package com.aperdigon.ticketing_backend.integration.ticket;
+
+import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEventType;
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.TicketEventSpringDataRepository;
+import com.aperdigon.ticketing_backend.specification.SpecificationRef;
+import com.aperdigon.ticketing_backend.specification.TestLevel;
+import com.aperdigon.ticketing_backend.test_support.builders.CategoryTestDataBuilder;
+import com.aperdigon.ticketing_backend.test_support.builders.TicketTestDataBuilder;
+import com.aperdigon.ticketing_backend.test_support.integration.AbstractAuthenticatedApiIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ChangeTicketStatusApiIntegrationTest extends AbstractAuthenticatedApiIntegrationTest {
+
+    private static final String DEFAULT_PASSWORD = "secret123";
+
+    @Autowired
+    private TicketEventSpringDataRepository ticketEventRepository;
+
+    @BeforeEach
+    void setUp() {
+        clearPersistedData();
+    }
+
+    @Test
+    @SpecificationRef(value = "TICKET-USER-05", level = TestLevel.INTEGRATION, feature = "tickets-user.feature")
+    void user_cannot_change_ticket_status() throws Exception {
+        var creator = persistActiveUser("user@test.com", "User", DEFAULT_PASSWORD, UserRole.USER);
+        var category = persistCategory(CategoryTestDataBuilder.aCategory().withName("Hardware"));
+        var ticket = persistTicket(TicketTestDataBuilder.aTicket()
+                .withTitle("Printer issue")
+                .withDescription("Paper jam")
+                .withStatus(TicketStatus.OPEN)
+                .createdAt(Instant.parse("2026-03-06T10:00:00Z"))
+                .updatedAt(Instant.parse("2026-03-06T10:00:00Z"))
+                .createdBy(creator)
+                .inCategory(category));
+
+        String token = loginAndExtractAccessToken("user@test.com", DEFAULT_PASSWORD);
+
+        mockMvc.perform(patch("/api/tickets/{id}/status", ticket.getId())
+                        .with(bearerToken(token))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(Map.of("status", "IN_PROGRESS"))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+
+        assertEquals(TicketStatus.OPEN, ticketRepository.findById(ticket.getId()).orElseThrow().getStatus());
+        assertEquals(0, ticketEventRepository.findByTicket_IdOrderByCreatedAtAsc(ticket.getId()).size());
+    }
+
+    @Test
+    @SpecificationRef(value = "TICKET-AGENT-01", level = TestLevel.INTEGRATION, feature = "tickets-agent.feature")
+    void agent_can_change_ticket_status_and_persistence_is_updated() throws Exception {
+        var creator = persistActiveUser("user@test.com", "User", DEFAULT_PASSWORD, UserRole.USER);
+        persistActiveUser("agent@test.com", "Agent", DEFAULT_PASSWORD, UserRole.AGENT);
+        var category = persistCategory(CategoryTestDataBuilder.aCategory().withName("Hardware"));
+        var ticket = persistTicket(TicketTestDataBuilder.aTicket()
+                .withTitle("Printer issue")
+                .withDescription("Paper jam")
+                .withStatus(TicketStatus.OPEN)
+                .createdAt(Instant.parse("2026-03-06T11:00:00Z"))
+                .updatedAt(Instant.parse("2026-03-06T11:00:00Z"))
+                .createdBy(creator)
+                .inCategory(category));
+
+        String token = loginAndExtractAccessToken("agent@test.com", DEFAULT_PASSWORD);
+
+        mockMvc.perform(patch("/api/tickets/{id}/status", ticket.getId())
+                        .with(bearerToken(token))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(Map.of("status", "IN_PROGRESS"))))
+                .andExpect(status().isNoContent());
+
+        var updatedTicket = ticketRepository.findById(ticket.getId()).orElseThrow();
+        var savedEvents = ticketEventRepository.findByTicket_IdOrderByCreatedAtAsc(ticket.getId());
+        assertEquals(TicketStatus.IN_PROGRESS, updatedTicket.getStatus());
+        assertEquals(1, savedEvents.size());
+        assertEquals(TicketEventType.STATUS_CHANGED, savedEvents.get(0).getEventType());
+    }
+
+    @Test
+    @SpecificationRef(value = "TICKET-AGENT-02", level = TestLevel.INTEGRATION, feature = "tickets-agent.feature")
+    void invalid_transition_returns_conflict_and_ticket_status_remains_unchanged() throws Exception {
+        var creator = persistActiveUser("user@test.com", "User", DEFAULT_PASSWORD, UserRole.USER);
+        persistActiveUser("agent@test.com", "Agent", DEFAULT_PASSWORD, UserRole.AGENT);
+        var category = persistCategory(CategoryTestDataBuilder.aCategory().withName("Hardware"));
+        var ticket = persistTicket(TicketTestDataBuilder.aTicket()
+                .withTitle("Printer issue")
+                .withDescription("Already in progress")
+                .withStatus(TicketStatus.IN_PROGRESS)
+                .createdAt(Instant.parse("2026-03-06T12:00:00Z"))
+                .updatedAt(Instant.parse("2026-03-06T12:00:00Z"))
+                .createdBy(creator)
+                .inCategory(category));
+
+        String token = loginAndExtractAccessToken("agent@test.com", DEFAULT_PASSWORD);
+
+        mockMvc.perform(patch("/api/tickets/{id}/status", ticket.getId())
+                        .with(bearerToken(token))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(Map.of("status", "OPEN"))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("CONFLICT"));
+
+        assertEquals(TicketStatus.IN_PROGRESS, ticketRepository.findById(ticket.getId()).orElseThrow().getStatus());
+        assertEquals(0, ticketEventRepository.findByTicket_IdOrderByCreatedAtAsc(ticket.getId()).size());
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/ticket/ChangeTicketStatusApiIntegrationTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/ticket/ChangeTicketStatusApiIntegrationTest.java
@@ -19,7 +19,6 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class ChangeTicketStatusApiIntegrationTest extends AbstractAuthenticatedApiIntegrationTest {
@@ -36,7 +35,7 @@ class ChangeTicketStatusApiIntegrationTest extends AbstractAuthenticatedApiInteg
 
     @Test
     @SpecificationRef(value = "TICKET-USER-05", level = TestLevel.INTEGRATION, feature = "tickets-user.feature")
-    void user_cannot_change_ticket_status() throws Exception {
+    void user_cannot_change_ticket_status_when_request_is_blocked_by_security() throws Exception {
         var creator = persistActiveUser("user@test.com", "User", DEFAULT_PASSWORD, UserRole.USER);
         var category = persistCategory(CategoryTestDataBuilder.aCategory().withName("Hardware"));
         var ticket = persistTicket(TicketTestDataBuilder.aTicket()
@@ -54,8 +53,7 @@ class ChangeTicketStatusApiIntegrationTest extends AbstractAuthenticatedApiInteg
                         .with(bearerToken(token))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(toJson(Map.of("status", "IN_PROGRESS"))))
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+                .andExpect(status().isForbidden());
 
         assertEquals(TicketStatus.OPEN, ticketRepository.findById(ticket.getId()).orElseThrow().getStatus());
         assertEquals(0, ticketEventRepository.findByTicket_IdOrderByCreatedAtAsc(ticket.getId()).size());

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/ticket/CreateTicketApiIntegrationTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/ticket/CreateTicketApiIntegrationTest.java
@@ -1,0 +1,94 @@
+package com.aperdigon.ticketing_backend.integration.ticket;
+
+import com.aperdigon.ticketing_backend.domain.ticket.TicketPriority;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEventType;
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.TicketEventSpringDataRepository;
+import com.aperdigon.ticketing_backend.specification.SpecificationRef;
+import com.aperdigon.ticketing_backend.specification.TestLevel;
+import com.aperdigon.ticketing_backend.test_support.builders.CategoryTestDataBuilder;
+import com.aperdigon.ticketing_backend.test_support.integration.AbstractAuthenticatedApiIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class CreateTicketApiIntegrationTest extends AbstractAuthenticatedApiIntegrationTest {
+
+    private static final String DEFAULT_PASSWORD = "secret123";
+
+    @Autowired
+    private TicketEventSpringDataRepository ticketEventRepository;
+
+    @BeforeEach
+    void setUp() {
+        clearPersistedData();
+    }
+
+    @Test
+    @SpecificationRef(value = "TICKET-USER-01", level = TestLevel.INTEGRATION, feature = "tickets-user.feature")
+    void authenticated_user_can_create_ticket_and_it_is_persisted_with_creation_event() throws Exception {
+        var requester = persistActiveUser("user@test.com", "User", DEFAULT_PASSWORD, UserRole.USER);
+        var category = persistCategory(CategoryTestDataBuilder.aCategory().withName("Hardware"));
+        String token = loginAndExtractAccessToken("user@test.com", DEFAULT_PASSWORD);
+
+        var mvcResult = mockMvc.perform(post("/api/tickets")
+                        .with(bearerToken(token))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(Map.of(
+                                "title", "Printer not working",
+                                "description", "The printer shows error E23",
+                                "categoryId", category.getId(),
+                                "priority", "HIGH"
+                        ))))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", org.hamcrest.Matchers.matchesPattern("/api/tickets/.+")))
+                .andExpect(jsonPath("$.ticketId", notNullValue()))
+                .andReturn();
+
+        String ticketId = objectMapper.readTree(mvcResult.getResponse().getContentAsString()).get("ticketId").asText();
+        var savedTicket = ticketRepository.findById(java.util.UUID.fromString(ticketId)).orElseThrow();
+        var savedEvents = ticketEventRepository.findByTicket_IdOrderByCreatedAtAsc(savedTicket.getId());
+
+        assertEquals("Printer not working", savedTicket.getTitle());
+        assertEquals("The printer shows error E23", savedTicket.getDescription());
+        assertEquals(TicketStatus.OPEN, savedTicket.getStatus());
+        assertEquals(TicketPriority.HIGH, savedTicket.getPriority());
+        assertEquals(requester.getId(), savedTicket.getCreatedBy().getId());
+        assertEquals(category.getId(), savedTicket.getCategory().getId());
+        assertEquals(1, savedEvents.size());
+        assertEquals(TicketEventType.TICKET_CREATED, savedEvents.get(0).getEventType());
+        assertEquals(requester.getId(), savedEvents.get(0).getActor().getId());
+        assertEquals("{}", savedEvents.get(0).getPayloadJson());
+    }
+
+    @Test
+    @SpecificationRef(value = "TICKET-USER-02", level = TestLevel.INTEGRATION, feature = "tickets-user.feature")
+    void creating_ticket_without_token_returns_unauthorized_and_does_not_persist_any_ticket() throws Exception {
+        var category = persistCategory(CategoryTestDataBuilder.aCategory().withName("Hardware"));
+
+        mockMvc.perform(post("/api/tickets")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(Map.of(
+                                "title", "Printer not working",
+                                "description", "The printer shows error E23",
+                                "categoryId", category.getId(),
+                                "priority", "HIGH"
+                        ))))
+                .andExpect(status().isUnauthorized());
+
+        assertTrue(ticketRepository.findAll().isEmpty());
+        assertTrue(ticketEventRepository.findAll().isEmpty());
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/ticket/GetMyTicketsApiIntegrationTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/ticket/GetMyTicketsApiIntegrationTest.java
@@ -1,0 +1,123 @@
+package com.aperdigon.ticketing_backend.integration.ticket;
+
+import com.aperdigon.ticketing_backend.domain.ticket.TicketPriority;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import com.aperdigon.ticketing_backend.specification.SpecificationRef;
+import com.aperdigon.ticketing_backend.specification.TestLevel;
+import com.aperdigon.ticketing_backend.test_support.builders.CategoryTestDataBuilder;
+import com.aperdigon.ticketing_backend.test_support.builders.TicketTestDataBuilder;
+import com.aperdigon.ticketing_backend.test_support.integration.AbstractAuthenticatedApiIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class GetMyTicketsApiIntegrationTest extends AbstractAuthenticatedApiIntegrationTest {
+
+    private static final String DEFAULT_PASSWORD = "secret123";
+
+    @BeforeEach
+    void setUp() {
+        clearPersistedData();
+    }
+
+    @Test
+    @SpecificationRef(value = "TICKET-USER-03", level = TestLevel.INTEGRATION, feature = "tickets-user.feature")
+    void user_sees_only_their_own_tickets() throws Exception {
+        var requester = persistActiveUser("user@test.com", "User", DEFAULT_PASSWORD, UserRole.USER);
+        var anotherUser = persistActiveUser("other@test.com", "Other User", DEFAULT_PASSWORD, UserRole.USER);
+        var category = persistCategory(CategoryTestDataBuilder.aCategory().withName("Hardware"));
+
+        persistTicket(TicketTestDataBuilder.aTicket()
+                .withTitle("My open ticket")
+                .withDescription("Visible in my list")
+                .withPriority(TicketPriority.HIGH)
+                .createdAt(Instant.parse("2026-03-01T10:00:00Z"))
+                .updatedAt(Instant.parse("2026-03-01T10:00:00Z"))
+                .createdBy(requester)
+                .inCategory(category));
+
+        persistTicket(TicketTestDataBuilder.aTicket()
+                .withTitle("Another of my tickets")
+                .withDescription("Also visible in my list")
+                .withPriority(TicketPriority.MEDIUM)
+                .createdAt(Instant.parse("2026-03-01T09:00:00Z"))
+                .updatedAt(Instant.parse("2026-03-01T09:30:00Z"))
+                .createdBy(requester)
+                .inCategory(category));
+
+        persistTicket(TicketTestDataBuilder.aTicket()
+                .withTitle("Other user ticket")
+                .withDescription("Should not be visible")
+                .withPriority(TicketPriority.LOW)
+                .createdAt(Instant.parse("2026-03-02T10:00:00Z"))
+                .updatedAt(Instant.parse("2026-03-02T10:00:00Z"))
+                .createdBy(anotherUser)
+                .inCategory(category));
+
+        String token = loginAndExtractAccessToken("user@test.com", DEFAULT_PASSWORD);
+
+        mockMvc.perform(get("/api/tickets/me")
+                        .with(bearerToken(token)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(2))
+                .andExpect(jsonPath("$.items[?(@.title=='My open ticket')]").exists())
+                .andExpect(jsonPath("$.items[?(@.title=='Another of my tickets')]").exists())
+                .andExpect(jsonPath("$.items[?(@.title=='Other user ticket')]").doesNotExist());
+    }
+
+    @Test
+    @SpecificationRef(value = "TICKET-AGENT-03", level = TestLevel.INTEGRATION, feature = "tickets-agent.feature")
+    void agent_can_list_manageable_tickets_using_operational_scope_filters() throws Exception {
+        var creator = persistActiveUser("user@test.com", "User", DEFAULT_PASSWORD, UserRole.USER);
+        var agent = persistActiveUser("agent@test.com", "Agent", DEFAULT_PASSWORD, UserRole.AGENT);
+        var otherAgent = persistActiveUser("other.agent@test.com", "Other Agent", DEFAULT_PASSWORD, UserRole.AGENT);
+        var category = persistCategory(CategoryTestDataBuilder.aCategory().withName("Hardware"));
+
+        persistTicket(TicketTestDataBuilder.aTicket()
+                .withTitle("Assigned to me")
+                .withDescription("Hardware queue item")
+                .withStatus(TicketStatus.IN_PROGRESS)
+                .createdAt(Instant.parse("2026-03-03T10:00:00Z"))
+                .updatedAt(Instant.parse("2026-03-03T11:00:00Z"))
+                .createdBy(creator)
+                .assignedTo(agent)
+                .inCategory(category));
+
+        persistTicket(TicketTestDataBuilder.aTicket()
+                .withTitle("Assigned to another agent")
+                .withDescription("Should not match MINE scope")
+                .withStatus(TicketStatus.IN_PROGRESS)
+                .createdAt(Instant.parse("2026-03-03T09:00:00Z"))
+                .updatedAt(Instant.parse("2026-03-03T12:00:00Z"))
+                .createdBy(creator)
+                .assignedTo(otherAgent)
+                .inCategory(category));
+
+        persistTicket(TicketTestDataBuilder.aTicket()
+                .withTitle("Unassigned queue ticket")
+                .withDescription("Still open")
+                .withStatus(TicketStatus.OPEN)
+                .createdAt(Instant.parse("2026-03-02T10:00:00Z"))
+                .updatedAt(Instant.parse("2026-03-02T10:00:00Z"))
+                .createdBy(creator)
+                .inCategory(category));
+
+        String token = loginAndExtractAccessToken("agent@test.com", DEFAULT_PASSWORD);
+
+        mockMvc.perform(get("/api/tickets")
+                        .with(bearerToken(token))
+                        .param("scope", "MINE")
+                        .param("status", "IN_PROGRESS")
+                        .param("q", "assigned"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(1))
+                .andExpect(jsonPath("$.items[0].title").value("Assigned to me"))
+                .andExpect(jsonPath("$.items[0].assignedToUserId").value(agent.getId().toString()));
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/ticket/GetTicketDetailsApiIntegrationTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/integration/ticket/GetTicketDetailsApiIntegrationTest.java
@@ -1,0 +1,120 @@
+package com.aperdigon.ticketing_backend.integration.ticket;
+
+import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEventType;
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.TicketEventSpringDataRepository;
+import com.aperdigon.ticketing_backend.specification.SpecificationRef;
+import com.aperdigon.ticketing_backend.specification.TestLevel;
+import com.aperdigon.ticketing_backend.test_support.builders.CategoryTestDataBuilder;
+import com.aperdigon.ticketing_backend.test_support.builders.TicketTestDataBuilder;
+import com.aperdigon.ticketing_backend.test_support.integration.AbstractAuthenticatedApiIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class GetTicketDetailsApiIntegrationTest extends AbstractAuthenticatedApiIntegrationTest {
+
+    private static final String DEFAULT_PASSWORD = "secret123";
+
+    @Autowired
+    private TicketEventSpringDataRepository ticketEventRepository;
+
+    @BeforeEach
+    void setUp() {
+        clearPersistedData();
+    }
+
+    @Test
+    @SpecificationRef(value = "TICKET-USER-04", level = TestLevel.INTEGRATION, feature = "tickets-user.feature")
+    void user_can_get_detail_of_their_own_ticket() throws Exception {
+        var requester = persistActiveUser("user@test.com", "User", DEFAULT_PASSWORD, UserRole.USER);
+        var category = persistCategory(CategoryTestDataBuilder.aCategory().withName("Hardware"));
+        var ticket = persistTicket(TicketTestDataBuilder.aTicket()
+                .withTitle("Printer issue")
+                .withDescription("Paper jam on tray 2")
+                .withStatus(TicketStatus.OPEN)
+                .createdAt(Instant.parse("2026-03-04T10:00:00Z"))
+                .updatedAt(Instant.parse("2026-03-04T10:00:00Z"))
+                .createdBy(requester)
+                .inCategory(category));
+
+        String token = loginAndExtractAccessToken("user@test.com", DEFAULT_PASSWORD);
+
+        mockMvc.perform(get("/api/tickets/{id}", ticket.getId())
+                        .with(bearerToken(token)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(ticket.getId().toString()))
+                .andExpect(jsonPath("$.title").value("Printer issue"))
+                .andExpect(jsonPath("$.description").value("Paper jam on tray 2"))
+                .andExpect(jsonPath("$.status").value("OPEN"))
+                .andExpect(jsonPath("$.createdByUserId").value(requester.getId().toString()))
+                .andExpect(jsonPath("$.createdByDisplayName").value("User"))
+                .andExpect(jsonPath("$.timeline[0].kind").value("MESSAGE"))
+                .andExpect(jsonPath("$.timeline[0].content").value("Paper jam on tray 2"))
+                .andExpect(jsonPath("$.availableTransitions[0]").value("IN_PROGRESS"));
+    }
+
+
+    @Test
+    void user_cannot_get_ticket_detail_of_another_user() throws Exception {
+        var owner = persistActiveUser("owner@test.com", "Owner", DEFAULT_PASSWORD, UserRole.USER);
+        persistActiveUser("viewer@test.com", "Viewer", DEFAULT_PASSWORD, UserRole.USER);
+        var category = persistCategory(CategoryTestDataBuilder.aCategory().withName("Hardware"));
+        var ticket = persistTicket(TicketTestDataBuilder.aTicket()
+                .withTitle("Private ticket")
+                .withDescription("Should not be visible")
+                .createdAt(Instant.parse("2026-03-04T11:00:00Z"))
+                .updatedAt(Instant.parse("2026-03-04T11:00:00Z"))
+                .createdBy(owner)
+                .inCategory(category));
+
+        String viewerToken = loginAndExtractAccessToken("viewer@test.com", DEFAULT_PASSWORD);
+
+        mockMvc.perform(get("/api/tickets/{id}", ticket.getId())
+                        .with(bearerToken(viewerToken)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
+    @Test
+    @SpecificationRef(value = "TICKET-AGENT-04", level = TestLevel.INTEGRATION, feature = "tickets-agent.feature")
+    void agent_can_assign_ticket_to_self_and_assignment_is_reflected_in_detail_and_events() throws Exception {
+        var creator = persistActiveUser("user@test.com", "User", DEFAULT_PASSWORD, UserRole.USER);
+        var agent = persistActiveUser("agent@test.com", "Agent", DEFAULT_PASSWORD, UserRole.AGENT);
+        var category = persistCategory(CategoryTestDataBuilder.aCategory().withName("Hardware"));
+        var ticket = persistTicket(TicketTestDataBuilder.aTicket()
+                .withTitle("Network issue")
+                .withDescription("Switch offline")
+                .createdAt(Instant.parse("2026-03-05T10:00:00Z"))
+                .updatedAt(Instant.parse("2026-03-05T10:00:00Z"))
+                .createdBy(creator)
+                .inCategory(category));
+
+        String agentToken = loginAndExtractAccessToken("agent@test.com", DEFAULT_PASSWORD);
+
+        mockMvc.perform(patch("/api/tickets/{id}/assignment/me", ticket.getId())
+                        .with(bearerToken(agentToken)))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/tickets/{id}", ticket.getId())
+                        .with(bearerToken(agentToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.assignedToUserId").value(agent.getId().toString()))
+                .andExpect(jsonPath("$.assignedToDisplayName").value("Agent"))
+                .andExpect(jsonPath("$.timeline[?(@.eventType=='ASSIGNED_TO_ME')]").exists());
+
+        var savedEvents = ticketEventRepository.findByTicket_IdOrderByCreatedAtAsc(ticket.getId());
+        assertEquals(1, savedEvents.size());
+        assertEquals(TicketEventType.ASSIGNED_TO_ME, savedEvents.get(0).getEventType());
+        assertEquals(agent.getId(), savedEvents.get(0).getActor().getId());
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/DomainTestDataFactory.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/DomainTestDataFactory.java
@@ -1,0 +1,40 @@
+package com.aperdigon.ticketing_backend.test_support;
+
+import com.aperdigon.ticketing_backend.domain.category.Category;
+import com.aperdigon.ticketing_backend.domain.category.CategoryId;
+import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketPriority;
+import com.aperdigon.ticketing_backend.domain.user.User;
+import com.aperdigon.ticketing_backend.domain.user.UserId;
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
+
+import java.time.Clock;
+import java.util.UUID;
+
+public final class DomainTestDataFactory {
+
+    private static final String SECURE_HASH = "$2a$10$abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG";
+
+    private DomainTestDataFactory() {
+    }
+
+    public static User activeUser(String email, String displayName, UserRole role) {
+        return new User(UserId.of(UUID.randomUUID()), email, displayName, SECURE_HASH, role, true);
+    }
+
+    public static User inactiveUser(String email, String displayName, UserRole role) {
+        return new User(UserId.of(UUID.randomUUID()), email, displayName, SECURE_HASH, role, false);
+    }
+
+    public static Category activeCategory(String name) {
+        return new Category(CategoryId.of(UUID.randomUUID()), name, true);
+    }
+
+    public static Ticket openTicket(String title, String description, Category category, User creator, Clock clock) {
+        return Ticket.openNew(title, description, category, creator, clock);
+    }
+
+    public static Ticket openTicket(String title, String description, Category category, User creator, TicketPriority priority, Clock clock) {
+        return Ticket.openNew(title, description, category, creator, priority, clock);
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/InMemoryTicketEventRepository.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/InMemoryTicketEventRepository.java
@@ -18,6 +18,10 @@ public class InMemoryTicketEventRepository implements TicketEventRepository {
 
     @Override
     public List<TicketEvent> findByTicketId(TicketId ticketId) {
-        return store.stream().filter(e -> e.ticketId().equals(ticketId)).toList();
+        return store.stream().filter(event -> event.ticketId().equals(ticketId)).toList();
+    }
+
+    public List<TicketEvent> allEvents() {
+        return List.copyOf(store);
     }
 }

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/InMemoryTicketRepository.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/InMemoryTicketRepository.java
@@ -10,9 +10,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 public final class InMemoryTicketRepository implements TicketRepository {
     private final Map<TicketId, Ticket> store = new HashMap<>();
@@ -30,11 +33,62 @@ public final class InMemoryTicketRepository implements TicketRepository {
 
     @Override
     public Page<Ticket> findMyTickets(UserId createdBy, TicketStatus status, String q, Pageable pageable) {
-        return new PageImpl<>(store.values().stream().toList(), pageable, store.size());
+        List<Ticket> filtered = sortedTickets()
+                .filter(ticket -> ticket.createdBy().equals(createdBy))
+                .filter(ticket -> status == null || ticket.status() == status)
+                .filter(ticket -> matchesQuery(ticket, q))
+                .toList();
+
+        return toPage(filtered, pageable);
     }
 
     @Override
     public Page<Ticket> findAgentTickets(UserId actorId, TicketQueueScope scope, TicketStatus status, String q, Pageable pageable) {
-        return new PageImpl<>(store.values().stream().toList(), pageable, store.size());
+        List<Ticket> filtered = sortedTickets()
+                .filter(ticket -> matchesScope(ticket, actorId, scope))
+                .filter(ticket -> status == null || ticket.status() == status)
+                .filter(ticket -> matchesQuery(ticket, q))
+                .toList();
+
+        return toPage(filtered, pageable);
+    }
+
+    private Stream<Ticket> sortedTickets() {
+        return store.values().stream()
+                .sorted(Comparator.comparing(Ticket::createdAt).thenComparing(ticket -> ticket.id().value()));
+    }
+
+    private boolean matchesScope(Ticket ticket, UserId actorId, TicketQueueScope scope) {
+        TicketQueueScope effectiveScope = scope == null ? TicketQueueScope.ALL : scope;
+        return switch (effectiveScope) {
+            case UNASSIGNED -> ticket.assignedTo() == null;
+            case MINE -> actorId.equals(ticket.assignedTo());
+            case OTHERS -> ticket.assignedTo() != null && !actorId.equals(ticket.assignedTo());
+            case ALL -> true;
+        };
+    }
+
+    private boolean matchesQuery(Ticket ticket, String q) {
+        if (q == null || q.isBlank()) {
+            return true;
+        }
+
+        String normalizedQuery = q.trim().toLowerCase();
+        return ticket.title().toLowerCase().contains(normalizedQuery)
+                || ticket.description().toLowerCase().contains(normalizedQuery);
+    }
+
+    private Page<Ticket> toPage(List<Ticket> filtered, Pageable pageable) {
+        if (pageable == null || pageable.isUnpaged()) {
+            return new PageImpl<>(filtered, Pageable.unpaged(), filtered.size());
+        }
+
+        int start = (int) pageable.getOffset();
+        if (start >= filtered.size()) {
+            return new PageImpl<>(List.of(), pageable, filtered.size());
+        }
+
+        int end = Math.min(start + pageable.getPageSize(), filtered.size());
+        return new PageImpl<>(filtered.subList(start, end), pageable, filtered.size());
     }
 }

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/builders/CategoryTestDataBuilder.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/builders/CategoryTestDataBuilder.java
@@ -1,0 +1,42 @@
+package com.aperdigon.ticketing_backend.test_support.builders;
+
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.CategoryJpaEntity;
+
+import java.util.UUID;
+
+public final class CategoryTestDataBuilder {
+    private UUID id = UUID.randomUUID();
+    private String name = "General";
+    private boolean active = true;
+
+    private CategoryTestDataBuilder() {
+    }
+
+    public static CategoryTestDataBuilder aCategory() {
+        return new CategoryTestDataBuilder();
+    }
+
+    public CategoryTestDataBuilder withId(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    public CategoryTestDataBuilder withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public CategoryTestDataBuilder active() {
+        this.active = true;
+        return this;
+    }
+
+    public CategoryTestDataBuilder inactive() {
+        this.active = false;
+        return this;
+    }
+
+    public CategoryJpaEntity build() {
+        return new CategoryJpaEntity(id, name, active);
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/builders/TicketTestDataBuilder.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/builders/TicketTestDataBuilder.java
@@ -1,0 +1,102 @@
+package com.aperdigon.ticketing_backend.test_support.builders;
+
+import com.aperdigon.ticketing_backend.domain.ticket.TicketPriority;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.CategoryJpaEntity;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.TicketJpaEntity;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.UserJpaEntity;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public final class TicketTestDataBuilder {
+    private UUID id = UUID.randomUUID();
+    private String title = "Test ticket";
+    private String description = "Test ticket description";
+    private TicketStatus status = TicketStatus.OPEN;
+    private TicketPriority priority = TicketPriority.MEDIUM;
+    private Instant createdAt = Instant.now();
+    private Instant updatedAt = createdAt;
+    private UserJpaEntity createdBy;
+    private CategoryJpaEntity category;
+    private UserJpaEntity assignedTo;
+
+    private TicketTestDataBuilder() {
+    }
+
+    public static TicketTestDataBuilder aTicket() {
+        return new TicketTestDataBuilder();
+    }
+
+    public TicketTestDataBuilder withId(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    public TicketTestDataBuilder withTitle(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public TicketTestDataBuilder withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public TicketTestDataBuilder withStatus(TicketStatus status) {
+        this.status = status;
+        return this;
+    }
+
+    public TicketTestDataBuilder withPriority(TicketPriority priority) {
+        this.priority = priority;
+        return this;
+    }
+
+    public TicketTestDataBuilder createdBy(UserJpaEntity createdBy) {
+        this.createdBy = createdBy;
+        return this;
+    }
+
+    public TicketTestDataBuilder inCategory(CategoryJpaEntity category) {
+        this.category = category;
+        return this;
+    }
+
+    public TicketTestDataBuilder assignedTo(UserJpaEntity assignedTo) {
+        this.assignedTo = assignedTo;
+        return this;
+    }
+
+    public TicketTestDataBuilder createdAt(Instant createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+
+    public TicketTestDataBuilder updatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+        return this;
+    }
+
+    public TicketJpaEntity build() {
+        if (createdBy == null) {
+            throw new IllegalStateException("createdBy is required");
+        }
+        if (category == null) {
+            throw new IllegalStateException("category is required");
+        }
+
+        return new TicketJpaEntity(
+                id,
+                title,
+                description,
+                status,
+                priority,
+                createdAt,
+                updatedAt,
+                createdBy,
+                category,
+                assignedTo
+        );
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/builders/UserTestDataBuilder.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/builders/UserTestDataBuilder.java
@@ -1,0 +1,69 @@
+package com.aperdigon.ticketing_backend.test_support.builders;
+
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.UserJpaEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.UUID;
+
+public final class UserTestDataBuilder {
+    private UUID id = UUID.randomUUID();
+    private String email = "user@test.com";
+    private String displayName = "User";
+    private String rawPassword = "secret123";
+    private UserRole role = UserRole.USER;
+    private boolean active = true;
+
+    private UserTestDataBuilder() {
+    }
+
+    public static UserTestDataBuilder aUser() {
+        return new UserTestDataBuilder();
+    }
+
+    public UserTestDataBuilder withId(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    public UserTestDataBuilder withEmail(String email) {
+        this.email = email;
+        return this;
+    }
+
+    public UserTestDataBuilder withDisplayName(String displayName) {
+        this.displayName = displayName;
+        return this;
+    }
+
+    public UserTestDataBuilder withPassword(String rawPassword) {
+        this.rawPassword = rawPassword;
+        return this;
+    }
+
+    public UserTestDataBuilder withRole(UserRole role) {
+        this.role = role;
+        return this;
+    }
+
+    public UserTestDataBuilder active() {
+        this.active = true;
+        return this;
+    }
+
+    public UserTestDataBuilder inactive() {
+        this.active = false;
+        return this;
+    }
+
+    public UserJpaEntity build(PasswordEncoder passwordEncoder) {
+        return new UserJpaEntity(
+                id,
+                email,
+                displayName,
+                passwordEncoder.encode(rawPassword),
+                role,
+                active
+        );
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/integration/AbstractAuthenticatedApiIntegrationTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/integration/AbstractAuthenticatedApiIntegrationTest.java
@@ -1,0 +1,51 @@
+package com.aperdigon.ticketing_backend.test_support.integration;
+
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.UserJpaEntity;
+import com.aperdigon.ticketing_backend.test_support.builders.UserTestDataBuilder;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public abstract class AbstractAuthenticatedApiIntegrationTest extends AbstractIntegrationTest {
+
+    protected UserJpaEntity persistActiveUser(String email, String displayName, String password, UserRole role) {
+        return persistUser(UserTestDataBuilder.aUser()
+                .withEmail(email)
+                .withDisplayName(displayName)
+                .withPassword(password)
+                .withRole(role)
+                .active());
+    }
+
+    protected String loginAndExtractAccessToken(String email, String password) throws Exception {
+        MvcResult mvcResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(Map.of(
+                                "email", email,
+                                "password", password
+                        ))))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode json = objectMapper.readTree(mvcResult.getResponse().getContentAsString());
+        return json.get("accessToken").asText();
+    }
+
+    protected RequestPostProcessor bearerToken(String token) {
+        return request -> {
+            request.addHeader("Authorization", "Bearer " + token);
+            return request;
+        };
+    }
+
+    protected RequestPostProcessor authenticatedAs(String email, String password) throws Exception {
+        return bearerToken(loginAndExtractAccessToken(email, password));
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/integration/AbstractIntegrationTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/integration/AbstractIntegrationTest.java
@@ -1,0 +1,89 @@
+package com.aperdigon.ticketing_backend.test_support.integration;
+
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.CategoryJpaEntity;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.TicketJpaEntity;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.UserJpaEntity;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.CategorySpringDataRepository;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.TicketSpringDataRepository;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.UserSpringDataRepository;
+import com.aperdigon.ticketing_backend.test_support.builders.CategoryTestDataBuilder;
+import com.aperdigon.ticketing_backend.test_support.builders.TicketTestDataBuilder;
+import com.aperdigon.ticketing_backend.test_support.builders.UserTestDataBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+public abstract class AbstractIntegrationTest {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected PasswordEncoder passwordEncoder;
+
+    @Autowired
+    protected UserSpringDataRepository userRepository;
+
+    @Autowired
+    protected CategorySpringDataRepository categoryRepository;
+
+    @Autowired
+    protected TicketSpringDataRepository ticketRepository;
+
+    @DynamicPropertySource
+    static void configureDatasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+    }
+
+    protected void clearPersistedData() {
+        ticketRepository.deleteAll();
+        categoryRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    protected UserJpaEntity persistUser(UserTestDataBuilder builder) {
+        return userRepository.save(builder.build(passwordEncoder));
+    }
+
+    protected CategoryJpaEntity persistCategory(CategoryTestDataBuilder builder) {
+        return categoryRepository.save(builder.build());
+    }
+
+    protected TicketJpaEntity persistTicket(TicketTestDataBuilder builder) {
+        return ticketRepository.save(builder.build());
+    }
+
+    protected String toJson(Object value) throws Exception {
+        return objectMapper.writeValueAsString(value);
+    }
+
+    protected ResultActions postJson(String urlTemplate, Object body, Object... uriVariables) throws Exception {
+        return mockMvc.perform(post(urlTemplate, uriVariables)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(body)));
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/integration/AbstractIntegrationTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/integration/AbstractIntegrationTest.java
@@ -21,18 +21,18 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@Testcontainers
 public abstract class AbstractIntegrationTest {
 
-    @Container
     private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    static {
+        POSTGRES.start();
+    }
 
     @Autowired
     protected MockMvc mockMvc;

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/integration/AbstractIntegrationTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/integration/AbstractIntegrationTest.java
@@ -5,6 +5,7 @@ import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.Tic
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.UserJpaEntity;
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.CategorySpringDataRepository;
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.TicketSpringDataRepository;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.TicketEventSpringDataRepository;
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.UserSpringDataRepository;
 import com.aperdigon.ticketing_backend.test_support.builders.CategoryTestDataBuilder;
 import com.aperdigon.ticketing_backend.test_support.builders.TicketTestDataBuilder;
@@ -51,6 +52,9 @@ public abstract class AbstractIntegrationTest {
     @Autowired
     protected TicketSpringDataRepository ticketRepository;
 
+    @Autowired
+    protected TicketEventSpringDataRepository ticketEventRepository;
+
     @DynamicPropertySource
     static void configureDatasource(DynamicPropertyRegistry registry) {
         registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
@@ -60,6 +64,7 @@ public abstract class AbstractIntegrationTest {
     }
 
     protected void clearPersistedData() {
+        ticketEventRepository.deleteAll();
         ticketRepository.deleteAll();
         categoryRepository.deleteAll();
         userRepository.deleteAll();

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/auth/LoginUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/auth/LoginUseCaseTest.java
@@ -2,20 +2,21 @@ package com.aperdigon.ticketing_backend.unit.auth;
 
 import com.aperdigon.ticketing_backend.application.auth.login.LoginCommand;
 import com.aperdigon.ticketing_backend.application.auth.login.LoginUseCase;
-import com.aperdigon.ticketing_backend.application.auth.login.TokenIssuer;
 import com.aperdigon.ticketing_backend.application.shared.exception.UnauthorizedException;
-import com.aperdigon.ticketing_backend.domain.user.User;
-import com.aperdigon.ticketing_backend.domain.user.UserId;
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
 import com.aperdigon.ticketing_backend.specification.SpecificationRef;
 import com.aperdigon.ticketing_backend.specification.TestLevel;
+import com.aperdigon.ticketing_backend.test_support.DomainTestDataFactory;
 import com.aperdigon.ticketing_backend.test_support.InMemoryUserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
-import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class LoginUseCaseTest {
 
@@ -23,43 +24,106 @@ class LoginUseCaseTest {
 
     @Test
     @SpecificationRef(value = "AUTH-01", level = TestLevel.UNIT, feature = "authentication.feature")
-    void returns_token_when_credentials_are_valid() {
-        var repo = new InMemoryUserRepository();
-        User user = new User(UserId.of(UUID.randomUUID()), "user@test.com", "User", encoder.encode("secret"), UserRole.USER, true);
-        repo.put(user);
+    void authenticates_active_user_and_issues_token_using_normalized_email() {
+        var users = new InMemoryUserRepository();
+        var registeredUser = DomainTestDataFactory.activeUser("user@test.com", "User", UserRole.USER);
+        users.put(new com.aperdigon.ticketing_backend.domain.user.User(
+                registeredUser.id(),
+                registeredUser.email(),
+                registeredUser.displayName(),
+                encoder.encode("secret123"),
+                registeredUser.role(),
+                registeredUser.isActive()
+        ));
 
-        TokenIssuer tokenIssuer = u -> "jwt-token";
-        var useCase = new LoginUseCase(repo, encoder, tokenIssuer);
+        AtomicReference<String> issuedTokenForEmail = new AtomicReference<>();
+        var useCase = new LoginUseCase(users, encoder, user -> {
+            issuedTokenForEmail.set(user.email());
+            return "jwt-token";
+        });
 
-        var result = useCase.execute(new LoginCommand("user@test.com", "secret"));
+        var result = useCase.execute(new LoginCommand("  USER@Test.com  ", "secret123"));
 
         assertEquals("jwt-token", result.accessToken());
+        assertEquals("user@test.com", issuedTokenForEmail.get());
     }
 
     @Test
     @SpecificationRef(value = "AUTH-02", level = TestLevel.UNIT, feature = "authentication.feature", note = "Covers invalid login with unknown email.")
-    void throws_when_email_does_not_exist() {
-        var useCase = new LoginUseCase(new InMemoryUserRepository(), encoder, u -> "token");
-        assertThrows(UnauthorizedException.class, () -> useCase.execute(new LoginCommand("missing@test.com", "secret")));
+    void rejects_login_when_email_does_not_exist() {
+        AtomicBoolean tokenIssued = new AtomicBoolean(false);
+        var useCase = new LoginUseCase(new InMemoryUserRepository(), encoder, user -> {
+            tokenIssued.set(true);
+            return "token";
+        });
+
+        assertThrows(UnauthorizedException.class, () -> useCase.execute(new LoginCommand("missing@test.com", "secret123")));
+        assertFalse(tokenIssued.get());
     }
 
     @Test
     @SpecificationRef(value = "AUTH-02", level = TestLevel.UNIT, feature = "authentication.feature", note = "Covers invalid login with wrong password.")
-    void throws_when_password_is_invalid() {
-        var repo = new InMemoryUserRepository();
-        repo.put(new User(UserId.of(UUID.randomUUID()), "user@test.com", "User", encoder.encode("secret"), UserRole.USER, true));
+    void rejects_login_when_password_is_invalid() {
+        var users = new InMemoryUserRepository();
+        var registeredUser = DomainTestDataFactory.activeUser("user@test.com", "User", UserRole.USER);
+        users.put(new com.aperdigon.ticketing_backend.domain.user.User(
+                registeredUser.id(),
+                registeredUser.email(),
+                registeredUser.displayName(),
+                encoder.encode("secret123"),
+                registeredUser.role(),
+                registeredUser.isActive()
+        ));
 
-        var useCase = new LoginUseCase(repo, encoder, u -> "token");
-        assertThrows(UnauthorizedException.class, () -> useCase.execute(new LoginCommand("user@test.com", "wrong")));
+        AtomicBoolean tokenIssued = new AtomicBoolean(false);
+        var useCase = new LoginUseCase(users, encoder, user -> {
+            tokenIssued.set(true);
+            return "token";
+        });
+
+        assertThrows(UnauthorizedException.class, () -> useCase.execute(new LoginCommand("user@test.com", "wrong-password")));
+        assertFalse(tokenIssued.get());
     }
 
     @Test
     @SpecificationRef(value = "AUTH-03", level = TestLevel.UNIT, feature = "authentication.feature")
-    void throws_when_user_is_inactive() {
-        var repo = new InMemoryUserRepository();
-        repo.put(new User(UserId.of(UUID.randomUUID()), "user@test.com", "User", encoder.encode("secret"), UserRole.USER, false));
+    void rejects_login_when_user_is_inactive_even_with_correct_password() {
+        var users = new InMemoryUserRepository();
+        var inactiveUser = DomainTestDataFactory.inactiveUser("inactive@test.com", "Inactive User", UserRole.USER);
+        users.put(new com.aperdigon.ticketing_backend.domain.user.User(
+                inactiveUser.id(),
+                inactiveUser.email(),
+                inactiveUser.displayName(),
+                encoder.encode("secret123"),
+                inactiveUser.role(),
+                inactiveUser.isActive()
+        ));
 
-        var useCase = new LoginUseCase(repo, encoder, u -> "token");
-        assertThrows(UnauthorizedException.class, () -> useCase.execute(new LoginCommand("user@test.com", "secret")));
+        AtomicBoolean tokenIssued = new AtomicBoolean(false);
+        var useCase = new LoginUseCase(users, encoder, user -> {
+            tokenIssued.set(true);
+            return "token";
+        });
+
+        assertThrows(UnauthorizedException.class, () -> useCase.execute(new LoginCommand("inactive@test.com", "secret123")));
+        assertFalse(tokenIssued.get());
+    }
+
+    @Test
+    void rejects_login_when_password_is_null() {
+        var users = new InMemoryUserRepository();
+        var registeredUser = DomainTestDataFactory.activeUser("user@test.com", "User", UserRole.USER);
+        users.put(new com.aperdigon.ticketing_backend.domain.user.User(
+                registeredUser.id(),
+                registeredUser.email(),
+                registeredUser.displayName(),
+                encoder.encode("secret123"),
+                registeredUser.role(),
+                registeredUser.isActive()
+        ));
+
+        var useCase = new LoginUseCase(users, encoder, user -> "token");
+
+        assertThrows(UnauthorizedException.class, () -> useCase.execute(new LoginCommand("user@test.com", null)));
     }
 }

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/auth/RegisterUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/auth/RegisterUseCaseTest.java
@@ -6,11 +6,19 @@ import com.aperdigon.ticketing_backend.domain.shared.exception.InvalidArgumentEx
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
 import com.aperdigon.ticketing_backend.specification.SpecificationRef;
 import com.aperdigon.ticketing_backend.specification.TestLevel;
+import com.aperdigon.ticketing_backend.test_support.DomainTestDataFactory;
 import com.aperdigon.ticketing_backend.test_support.InMemoryUserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RegisterUseCaseTest {
 
@@ -18,28 +26,40 @@ class RegisterUseCaseTest {
 
     @Test
     @SpecificationRef(value = "AUTH-04", level = TestLevel.UNIT, feature = "authentication.feature")
-    void creates_user_and_returns_token_when_payload_is_valid() {
-        var repo = new InMemoryUserRepository();
-        var useCase = new RegisterUseCase(repo, encoder, u -> "jwt-token");
+    void registers_user_with_default_role_and_returns_token_for_saved_user() {
+        var users = new InMemoryUserRepository();
+        AtomicReference<String> issuedForEmail = new AtomicReference<>();
+        var useCase = new RegisterUseCase(users, encoder, user -> {
+            issuedForEmail.set(user.email());
+            return "jwt-token";
+        });
 
         var result = useCase.execute(new RegisterCommand(
-                "user@test.com",
-                "User",
+                "  USER@Test.com  ",
+                "  New User  ",
                 "Secret123!",
                 "Secret123!"
         ));
 
+        var savedUser = users.findByEmail("user@test.com").orElseThrow();
         assertEquals("jwt-token", result.accessToken());
-        var savedUser = repo.findByEmail("user@test.com").orElseThrow();
+        assertEquals("user@test.com", savedUser.email());
+        assertEquals("New User", savedUser.displayName());
         assertEquals(UserRole.USER, savedUser.role());
         assertTrue(savedUser.isActive());
         assertNotEquals("Secret123!", savedUser.passwordHash());
         assertTrue(encoder.matches("Secret123!", savedUser.passwordHash()));
+        assertEquals("user@test.com", issuedForEmail.get());
     }
 
     @Test
-    void throws_when_passwords_do_not_match() {
-        var useCase = new RegisterUseCase(new InMemoryUserRepository(), encoder, u -> "token");
+    void rejects_registration_when_passwords_do_not_match() {
+        var users = new InMemoryUserRepository();
+        AtomicBoolean tokenIssued = new AtomicBoolean(false);
+        var useCase = new RegisterUseCase(users, encoder, user -> {
+            tokenIssued.set(true);
+            return "token";
+        });
 
         assertThrows(InvalidArgumentException.class, () -> useCase.execute(new RegisterCommand(
                 "user@test.com",
@@ -47,35 +67,41 @@ class RegisterUseCaseTest {
                 "Secret123!",
                 "Different123!"
         )));
+        assertTrue(users.findAll().isEmpty());
+        assertFalse(tokenIssued.get());
     }
 
     @Test
-    void throws_when_password_does_not_meet_policy() {
-        var useCase = new RegisterUseCase(new InMemoryUserRepository(), encoder, u -> "token");
+    void rejects_registration_when_password_does_not_meet_policy() {
+        var users = new InMemoryUserRepository();
+        var useCase = new RegisterUseCase(users, encoder, user -> "token");
 
-        assertThrows(InvalidArgumentException.class, () -> useCase.execute(new RegisterCommand(
+        var exception = assertThrows(InvalidArgumentException.class, () -> useCase.execute(new RegisterCommand(
                 "user@test.com",
                 "User",
                 "weakpass",
                 "weakpass"
         )));
+
+        assertEquals("Password must have at least 8 characters, including uppercase, lowercase, number and symbol", exception.getMessage());
+        assertTrue(users.findAll().isEmpty());
     }
 
     @Test
     @SpecificationRef(value = "AUTH-05", level = TestLevel.UNIT, feature = "authentication.feature")
-    void throws_generic_error_when_email_already_exists() {
-        var repo = new InMemoryUserRepository();
-        var useCase = new RegisterUseCase(repo, encoder, u -> "token");
+    void rejects_registration_when_email_already_exists_case_insensitively() {
+        var users = new InMemoryUserRepository();
+        users.put(DomainTestDataFactory.activeUser("user@test.com", "Existing User", UserRole.USER));
+        var useCase = new RegisterUseCase(users, encoder, user -> "token");
 
-        useCase.execute(new RegisterCommand("user@test.com", "User", "Secret123!", "Secret123!"));
-
-        var ex = assertThrows(InvalidArgumentException.class, () -> useCase.execute(new RegisterCommand(
-                "user@test.com",
-                "User 2",
+        var exception = assertThrows(InvalidArgumentException.class, () -> useCase.execute(new RegisterCommand(
+                "USER@Test.com",
+                "Duplicate User",
                 "Secret123!",
                 "Secret123!"
         )));
 
-        assertEquals("Registration failed", ex.getMessage());
+        assertEquals("Registration failed", exception.getMessage());
+        assertEquals(1, users.findAll().size());
     }
 }

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/AssignTicketToMeUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/AssignTicketToMeUseCaseTest.java
@@ -5,87 +5,115 @@ import com.aperdigon.ticketing_backend.application.shared.exception.ForbiddenExc
 import com.aperdigon.ticketing_backend.application.shared.exception.NotFoundException;
 import com.aperdigon.ticketing_backend.application.tickets.assign.AssignTicketToMeCommand;
 import com.aperdigon.ticketing_backend.application.tickets.assign.AssignTicketToMeUseCase;
-import com.aperdigon.ticketing_backend.domain.category.Category;
-import com.aperdigon.ticketing_backend.domain.category.CategoryId;
-import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
-import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
 import com.aperdigon.ticketing_backend.domain.ticket.exceptions.TicketAlreadyAssigned;
-import com.aperdigon.ticketing_backend.domain.user.User;
+import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEventType;
 import com.aperdigon.ticketing_backend.domain.user.UserId;
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
 import com.aperdigon.ticketing_backend.specification.SpecificationRef;
 import com.aperdigon.ticketing_backend.specification.TestLevel;
-import com.aperdigon.ticketing_backend.test_support.InMemoryTicketRepository;
+import com.aperdigon.ticketing_backend.test_support.DomainTestDataFactory;
 import com.aperdigon.ticketing_backend.test_support.InMemoryTicketEventRepository;
+import com.aperdigon.ticketing_backend.test_support.InMemoryTicketRepository;
 import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class AssignTicketToMeUseCaseTest {
+public final class AssignTicketToMeUseCaseTest {
 
     @Test
     @SpecificationRef(value = "TICKET-AGENT-04", level = TestLevel.UNIT, feature = "tickets-agent.feature")
-    void agent_can_assign_ticket_to_self() {
+    void agent_can_assign_ticket_to_self_and_event_is_recorded() {
         Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
 
-        var ticketRepo = new InMemoryTicketRepository();
-        var eventRepo = new InMemoryTicketEventRepository();
-        var useCase = new AssignTicketToMeUseCase(ticketRepo, eventRepo, clock);
+        var ticketRepository = new InMemoryTicketRepository();
+        var eventRepository = new InMemoryTicketEventRepository();
+        var useCase = new AssignTicketToMeUseCase(ticketRepository, eventRepository, clock);
 
-        User creator = new User(UserId.of(UUID.randomUUID()), "u@test.com", "U", "$2a$10$abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG", UserRole.USER, true);
-        Category category = new Category(CategoryId.of(UUID.randomUUID()), "General", true);
-        Ticket ticket = Ticket.openNew("T", "D", category, creator, clock);
-        ticketRepo.save(ticket);
+        var creator = DomainTestDataFactory.activeUser("user@test.com", "User", UserRole.USER);
+        var category = DomainTestDataFactory.activeCategory("General");
+        var ticket = DomainTestDataFactory.openTicket("T", "D", category, creator, clock);
+        ticketRepository.save(ticket);
 
         UserId agentId = UserId.of(UUID.randomUUID());
 
-        useCase.execute(new AssignTicketToMeCommand(ticket.id(), new CurrentUser(agentId, UserRole.AGENT)));
+        var result = useCase.execute(new AssignTicketToMeCommand(ticket.id(), new CurrentUser(agentId, UserRole.AGENT)));
+        var events = eventRepository.findByTicketId(ticket.id());
 
-        assertEquals(agentId, ticketRepo.findById(ticket.id()).orElseThrow().assignedTo());
+        assertEquals(ticket.id(), result.ticketId());
+        assertEquals(agentId, result.assignedTo());
+        assertEquals(agentId, ticketRepository.findById(ticket.id()).orElseThrow().assignedTo());
+        assertEquals(1, events.size());
+        assertEquals(TicketEventType.ASSIGNED_TO_ME, events.get(0).type());
+        assertEquals(Map.of("assignedToUserId", agentId.value().toString()), events.get(0).payload());
+        assertEquals(Instant.parse("2026-02-14T10:00:00Z"), events.get(0).createdAt());
+    }
+
+    @Test
+    void admin_can_assign_ticket_to_self() {
+        Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
+
+        var ticketRepository = new InMemoryTicketRepository();
+        var eventRepository = new InMemoryTicketEventRepository();
+        var useCase = new AssignTicketToMeUseCase(ticketRepository, eventRepository, clock);
+
+        var creator = DomainTestDataFactory.activeUser("user@test.com", "User", UserRole.USER);
+        var category = DomainTestDataFactory.activeCategory("General");
+        var ticket = DomainTestDataFactory.openTicket("T", "D", category, creator, clock);
+        ticketRepository.save(ticket);
+
+        UserId adminId = UserId.of(UUID.randomUUID());
+
+        var result = useCase.execute(new AssignTicketToMeCommand(ticket.id(), new CurrentUser(adminId, UserRole.ADMIN)));
+
+        assertEquals(adminId, result.assignedTo());
+        assertEquals(adminId, ticketRepository.findById(ticket.id()).orElseThrow().assignedTo());
     }
 
     @Test
     void user_cannot_assign_ticket() {
-        var ticketRepo = new InMemoryTicketRepository();
-        var eventRepo = new InMemoryTicketEventRepository();
-        var useCase = new AssignTicketToMeUseCase(ticketRepo, eventRepo, Clock.systemUTC());
+        var ticketRepository = new InMemoryTicketRepository();
+        var eventRepository = new InMemoryTicketEventRepository();
+        var useCase = new AssignTicketToMeUseCase(ticketRepository, eventRepository, Clock.systemUTC());
 
         assertThrows(ForbiddenException.class, () -> useCase.execute(new AssignTicketToMeCommand(
-                TicketId.of(UUID.randomUUID()),
+                com.aperdigon.ticketing_backend.domain.ticket.TicketId.of(UUID.randomUUID()),
                 new CurrentUser(UserId.of(UUID.randomUUID()), UserRole.USER)
         )));
+        assertEquals(0, eventRepository.allEvents().size());
     }
 
     @Test
     void throws_not_found_if_ticket_does_not_exist() {
-        var ticketRepo = new InMemoryTicketRepository();
-        var eventRepo = new InMemoryTicketEventRepository();
-        var useCase = new AssignTicketToMeUseCase(ticketRepo, eventRepo, Clock.systemUTC());
+        var ticketRepository = new InMemoryTicketRepository();
+        var eventRepository = new InMemoryTicketEventRepository();
+        var useCase = new AssignTicketToMeUseCase(ticketRepository, eventRepository, Clock.systemUTC());
 
         assertThrows(NotFoundException.class, () -> useCase.execute(new AssignTicketToMeCommand(
-                TicketId.of(UUID.randomUUID()),
+                com.aperdigon.ticketing_backend.domain.ticket.TicketId.of(UUID.randomUUID()),
                 new CurrentUser(UserId.of(UUID.randomUUID()), UserRole.ADMIN)
         )));
+        assertEquals(0, eventRepository.allEvents().size());
     }
 
     @Test
-    void cannot_assign_ticket_twice() {
+    void rejects_assignment_when_ticket_is_already_assigned() {
         Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
 
-        var ticketRepo = new InMemoryTicketRepository();
-        var eventRepo = new InMemoryTicketEventRepository();
-        var useCase = new AssignTicketToMeUseCase(ticketRepo, eventRepo, clock);
+        var ticketRepository = new InMemoryTicketRepository();
+        var eventRepository = new InMemoryTicketEventRepository();
+        var useCase = new AssignTicketToMeUseCase(ticketRepository, eventRepository, clock);
 
-        User creator = new User(UserId.of(UUID.randomUUID()), "u@test.com", "U", "$2a$10$abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG", UserRole.USER, true);
-        Category category = new Category(CategoryId.of(UUID.randomUUID()), "General", true);
-        Ticket ticket = Ticket.openNew("T", "D", category, creator, clock);
-        ticketRepo.save(ticket);
+        var creator = DomainTestDataFactory.activeUser("user@test.com", "User", UserRole.USER);
+        var category = DomainTestDataFactory.activeCategory("General");
+        var ticket = DomainTestDataFactory.openTicket("T", "D", category, creator, clock);
+        ticketRepository.save(ticket);
 
         UserId firstAgent = UserId.of(UUID.randomUUID());
         useCase.execute(new AssignTicketToMeCommand(ticket.id(), new CurrentUser(firstAgent, UserRole.AGENT)));
@@ -94,5 +122,6 @@ public class AssignTicketToMeUseCaseTest {
         assertThrows(TicketAlreadyAssigned.class, () ->
                 useCase.execute(new AssignTicketToMeCommand(ticket.id(), new CurrentUser(secondAgent, UserRole.AGENT)))
         );
+        assertEquals(1, eventRepository.findByTicketId(ticket.id()).size());
     }
 }

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/ChangeTicketStatusUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/ChangeTicketStatusUseCaseTest.java
@@ -1,122 +1,137 @@
 package com.aperdigon.ticketing_backend.unit.ticket;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.util.UUID;
-
 import com.aperdigon.ticketing_backend.application.shared.CurrentUser;
 import com.aperdigon.ticketing_backend.application.shared.exception.ForbiddenException;
 import com.aperdigon.ticketing_backend.application.shared.exception.NotFoundException;
 import com.aperdigon.ticketing_backend.application.tickets.change_status.ChangeTicketStatusCommand;
 import com.aperdigon.ticketing_backend.application.tickets.change_status.ChangeTicketStatusResult;
 import com.aperdigon.ticketing_backend.application.tickets.change_status.ChangeTicketStatusUseCase;
-import com.aperdigon.ticketing_backend.domain.category.Category;
-import com.aperdigon.ticketing_backend.domain.category.CategoryId;
-import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
-import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
 import com.aperdigon.ticketing_backend.domain.ticket.exceptions.TicketInvalidStatusTransition;
-import com.aperdigon.ticketing_backend.domain.user.User;
+import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEventType;
 import com.aperdigon.ticketing_backend.domain.user.UserId;
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
 import com.aperdigon.ticketing_backend.specification.SpecificationRef;
 import com.aperdigon.ticketing_backend.specification.TestLevel;
-import com.aperdigon.ticketing_backend.test_support.InMemoryTicketRepository;
+import com.aperdigon.ticketing_backend.test_support.DomainTestDataFactory;
 import com.aperdigon.ticketing_backend.test_support.InMemoryTicketEventRepository;
+import com.aperdigon.ticketing_backend.test_support.InMemoryTicketRepository;
 import org.junit.jupiter.api.Test;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class ChangeTicketStatusUseCaseTest {
 
     @Test
     @SpecificationRef(value = "TICKET-AGENT-01", level = TestLevel.UNIT, feature = "tickets-agent.feature", note = "Valid transition from OPEN to IN_PROGRESS.")
-    void agent_can_change_status_open_to_in_progress() {
+    void agent_can_change_status_and_event_is_recorded() {
         Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
 
-        var ticketRepo = new InMemoryTicketRepository();
-        var eventRepo = new InMemoryTicketEventRepository();
-        var useCase = new ChangeTicketStatusUseCase(ticketRepo, eventRepo, clock);
+        var ticketRepository = new InMemoryTicketRepository();
+        var eventRepository = new InMemoryTicketEventRepository();
+        var useCase = new ChangeTicketStatusUseCase(ticketRepository, eventRepository, clock);
 
-        User creator = new User(UserId.of(UUID.randomUUID()), "u@test.com", "U", "$2a$10$abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG", UserRole.USER, true);
-        Category category = new Category(CategoryId.of(UUID.randomUUID()), "General", true);
+        var creator = DomainTestDataFactory.activeUser("user@test.com", "User", UserRole.USER);
+        var category = DomainTestDataFactory.activeCategory("General");
+        var ticket = DomainTestDataFactory.openTicket("T", "D", category, creator, clock);
+        ticketRepository.save(ticket);
 
-        Ticket ticket = Ticket.openNew("T", "D", category, creator, clock);
-        ticketRepo.save(ticket);
-
-        var cmd = new ChangeTicketStatusCommand(
+        ChangeTicketStatusResult result = useCase.execute(new ChangeTicketStatusCommand(
                 ticket.id(),
                 TicketStatus.IN_PROGRESS,
                 new CurrentUser(UserId.of(UUID.randomUUID()), UserRole.AGENT)
-        );
+        ));
 
-        ChangeTicketStatusResult result = useCase.execute(cmd);
-
+        var events = eventRepository.findByTicketId(ticket.id());
         assertEquals(ticket.id(), result.ticketId());
         assertEquals(TicketStatus.IN_PROGRESS, result.status());
-        assertEquals(TicketStatus.IN_PROGRESS, ticketRepo.findById(ticket.id()).orElseThrow().status());
+        assertEquals(TicketStatus.IN_PROGRESS, ticketRepository.findById(ticket.id()).orElseThrow().status());
+        assertEquals(1, events.size());
+        assertEquals(TicketEventType.STATUS_CHANGED, events.get(0).type());
+        assertEquals(Map.of("from", "OPEN", "to", "IN_PROGRESS"), events.get(0).payload());
+        assertEquals(Instant.parse("2026-02-14T10:00:00Z"), events.get(0).createdAt());
+    }
+
+    @Test
+    void admin_can_change_status_of_ticket() {
+        Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
+
+        var ticketRepository = new InMemoryTicketRepository();
+        var eventRepository = new InMemoryTicketEventRepository();
+        var useCase = new ChangeTicketStatusUseCase(ticketRepository, eventRepository, clock);
+
+        var creator = DomainTestDataFactory.activeUser("user@test.com", "User", UserRole.USER);
+        var category = DomainTestDataFactory.activeCategory("General");
+        var ticket = DomainTestDataFactory.openTicket("T", "D", category, creator, clock);
+        ticketRepository.save(ticket);
+
+        var result = useCase.execute(new ChangeTicketStatusCommand(
+                ticket.id(),
+                TicketStatus.IN_PROGRESS,
+                new CurrentUser(UserId.of(UUID.randomUUID()), UserRole.ADMIN)
+        ));
+
+        assertEquals(TicketStatus.IN_PROGRESS, result.status());
     }
 
     @Test
     @SpecificationRef(value = "TICKET-USER-05", level = TestLevel.UNIT, feature = "tickets-user.feature")
     void user_cannot_change_status() {
-        Clock clock = Clock.systemUTC();
+        var ticketRepository = new InMemoryTicketRepository();
+        var eventRepository = new InMemoryTicketEventRepository();
+        var useCase = new ChangeTicketStatusUseCase(ticketRepository, eventRepository, Clock.systemUTC());
 
-        var ticketRepo = new InMemoryTicketRepository();
-        var eventRepo = new InMemoryTicketEventRepository();
-        var useCase = new ChangeTicketStatusUseCase(ticketRepo, eventRepo, clock);
-
-        var cmd = new ChangeTicketStatusCommand(
-                TicketId.of(UUID.randomUUID()),
+        assertThrows(ForbiddenException.class, () -> useCase.execute(new ChangeTicketStatusCommand(
+                com.aperdigon.ticketing_backend.domain.ticket.TicketId.of(UUID.randomUUID()),
                 TicketStatus.IN_PROGRESS,
                 new CurrentUser(UserId.of(UUID.randomUUID()), UserRole.USER)
-        );
-
-        assertThrows(ForbiddenException.class, () -> useCase.execute(cmd));
+        )));
+        assertEquals(0, eventRepository.allEvents().size());
     }
 
     @Test
     void throws_not_found_if_ticket_does_not_exist() {
-        Clock clock = Clock.systemUTC();
+        var ticketRepository = new InMemoryTicketRepository();
+        var eventRepository = new InMemoryTicketEventRepository();
+        var useCase = new ChangeTicketStatusUseCase(ticketRepository, eventRepository, Clock.systemUTC());
 
-        var ticketRepo = new InMemoryTicketRepository();
-        var eventRepo = new InMemoryTicketEventRepository();
-        var useCase = new ChangeTicketStatusUseCase(ticketRepo, eventRepo, clock);
-
-        var cmd = new ChangeTicketStatusCommand(
-                TicketId.of(UUID.randomUUID()),
+        assertThrows(NotFoundException.class, () -> useCase.execute(new ChangeTicketStatusCommand(
+                com.aperdigon.ticketing_backend.domain.ticket.TicketId.of(UUID.randomUUID()),
                 TicketStatus.IN_PROGRESS,
                 new CurrentUser(UserId.of(UUID.randomUUID()), UserRole.AGENT)
-        );
-
-        assertThrows(NotFoundException.class, () -> useCase.execute(cmd));
+        )));
+        assertEquals(0, eventRepository.allEvents().size());
     }
 
     @Test
     @SpecificationRef(value = "TICKET-AGENT-02", level = TestLevel.UNIT, feature = "tickets-agent.feature")
-    void invalid_transition_in_progress_to_open_is_rejected_by_domain() {
+    void invalid_transition_is_rejected_and_no_new_event_is_recorded() {
         Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
 
-        var ticketRepo = new InMemoryTicketRepository();
-        var eventRepo = new InMemoryTicketEventRepository();
-        var useCase = new ChangeTicketStatusUseCase(ticketRepo, eventRepo, clock);
+        var ticketRepository = new InMemoryTicketRepository();
+        var eventRepository = new InMemoryTicketEventRepository();
+        var useCase = new ChangeTicketStatusUseCase(ticketRepository, eventRepository, clock);
 
-        User creator = new User(UserId.of(UUID.randomUUID()), "u@test.com", "U", "$2a$10$abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG", UserRole.USER, true);
-        Category category = new Category(CategoryId.of(UUID.randomUUID()), "General", true);
-
-        Ticket ticket = Ticket.openNew("T", "D", category, creator, clock);
+        var creator = DomainTestDataFactory.activeUser("user@test.com", "User", UserRole.USER);
+        var category = DomainTestDataFactory.activeCategory("General");
+        var ticket = DomainTestDataFactory.openTicket("T", "D", category, creator, clock);
         ticket.changeStatus(TicketStatus.IN_PROGRESS, clock);
-        ticketRepo.save(ticket);
+        ticketRepository.save(ticket);
 
-        var cmd = new ChangeTicketStatusCommand(
+        assertThrows(TicketInvalidStatusTransition.class, () -> useCase.execute(new ChangeTicketStatusCommand(
                 ticket.id(),
                 TicketStatus.OPEN,
                 new CurrentUser(UserId.of(UUID.randomUUID()), UserRole.AGENT)
-        );
-
-        assertThrows(TicketInvalidStatusTransition.class, () -> useCase.execute(cmd));
+        )));
+        assertEquals(TicketStatus.IN_PROGRESS, ticketRepository.findById(ticket.id()).orElseThrow().status());
+        assertEquals(0, eventRepository.findByTicketId(ticket.id()).size());
     }
 
     @Test
@@ -124,24 +139,21 @@ public final class ChangeTicketStatusUseCaseTest {
     void can_move_from_in_progress_to_on_hold() {
         Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
 
-        var ticketRepo = new InMemoryTicketRepository();
-        var eventRepo = new InMemoryTicketEventRepository();
-        var useCase = new ChangeTicketStatusUseCase(ticketRepo, eventRepo, clock);
+        var ticketRepository = new InMemoryTicketRepository();
+        var eventRepository = new InMemoryTicketEventRepository();
+        var useCase = new ChangeTicketStatusUseCase(ticketRepository, eventRepository, clock);
 
-        User creator = new User(UserId.of(UUID.randomUUID()), "u@test.com", "U", "$2a$10$abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG", UserRole.USER, true);
-        Category category = new Category(CategoryId.of(UUID.randomUUID()), "General", true);
-
-        Ticket ticket = Ticket.openNew("T", "D", category, creator, clock);
+        var creator = DomainTestDataFactory.activeUser("user@test.com", "User", UserRole.USER);
+        var category = DomainTestDataFactory.activeCategory("General");
+        var ticket = DomainTestDataFactory.openTicket("T", "D", category, creator, clock);
         ticket.changeStatus(TicketStatus.IN_PROGRESS, clock);
-        ticketRepo.save(ticket);
+        ticketRepository.save(ticket);
 
-        var cmd = new ChangeTicketStatusCommand(
+        ChangeTicketStatusResult result = useCase.execute(new ChangeTicketStatusCommand(
                 ticket.id(),
                 TicketStatus.ON_HOLD,
                 new CurrentUser(UserId.of(UUID.randomUUID()), UserRole.AGENT)
-        );
-
-        ChangeTicketStatusResult result = useCase.execute(cmd);
+        ));
 
         assertEquals(TicketStatus.ON_HOLD, result.status());
     }

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/CreateTicketUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/CreateTicketUseCaseTest.java
@@ -1,61 +1,54 @@
 package com.aperdigon.ticketing_backend.unit.ticket;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.util.UUID;
-
 import com.aperdigon.ticketing_backend.application.shared.CurrentUser;
 import com.aperdigon.ticketing_backend.application.shared.exception.NotFoundException;
 import com.aperdigon.ticketing_backend.application.tickets.create.CreateTicketCommand;
 import com.aperdigon.ticketing_backend.application.tickets.create.CreateTicketResult;
 import com.aperdigon.ticketing_backend.application.tickets.create.CreateTicketUseCase;
-import com.aperdigon.ticketing_backend.domain.category.Category;
-import com.aperdigon.ticketing_backend.domain.category.CategoryId;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketPriority;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
-import com.aperdigon.ticketing_backend.domain.user.User;
-import com.aperdigon.ticketing_backend.domain.user.UserId;
+import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEventType;
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
 import com.aperdigon.ticketing_backend.specification.SpecificationRef;
 import com.aperdigon.ticketing_backend.specification.TestLevel;
+import com.aperdigon.ticketing_backend.test_support.DomainTestDataFactory;
 import com.aperdigon.ticketing_backend.test_support.InMemoryCategoryRepository;
-import com.aperdigon.ticketing_backend.test_support.InMemoryTicketRepository;
 import com.aperdigon.ticketing_backend.test_support.InMemoryTicketEventRepository;
+import com.aperdigon.ticketing_backend.test_support.InMemoryTicketRepository;
 import com.aperdigon.ticketing_backend.test_support.InMemoryUserRepository;
 import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class CreateTicketUseCaseTest {
 
     @Test
     @SpecificationRef(value = "TICKET-USER-01", level = TestLevel.UNIT, feature = "tickets-user.feature")
-    void creates_ticket_in_open_status_and_persists_it() {
+    void creates_open_ticket_and_records_creation_event() {
         Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
 
-        var ticketRepo = new InMemoryTicketRepository();
-        var categoryRepo = new InMemoryCategoryRepository();
-        var userRepo = new InMemoryUserRepository();
-        var eventRepo = new InMemoryTicketEventRepository();
+        var ticketRepository = new InMemoryTicketRepository();
+        var categoryRepository = new InMemoryCategoryRepository();
+        var userRepository = new InMemoryUserRepository();
+        var ticketEventRepository = new InMemoryTicketEventRepository();
 
-        User creator = new User(
-                UserId.of(UUID.randomUUID()),
-                "user@test.com",
-                "User",
-                "$2a$10$abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG",
-                UserRole.USER,
-                true
-        );
-        userRepo.put(creator);
+        var creator = DomainTestDataFactory.activeUser("user@test.com", "User", UserRole.USER);
+        var category = DomainTestDataFactory.activeCategory("General");
+        userRepository.put(creator);
+        categoryRepository.put(category);
 
-        Category category = new Category(CategoryId.of(UUID.randomUUID()), "General", true);
-        categoryRepo.put(category);
+        var useCase = new CreateTicketUseCase(ticketRepository, categoryRepository, userRepository, ticketEventRepository, clock);
 
-        var useCase = new CreateTicketUseCase(ticketRepo, categoryRepo, userRepo, eventRepo, clock);
-
-        var cmd = new CreateTicketCommand(
+        var command = new CreateTicketCommand(
                 "Printer not working",
                 "The printer shows error E23",
                 category.id(),
@@ -63,46 +56,67 @@ public final class CreateTicketUseCaseTest {
                 new CurrentUser(creator.id(), creator.role())
         );
 
-        CreateTicketResult result = useCase.execute(cmd);
+        CreateTicketResult result = useCase.execute(command);
 
-        Ticket saved = ticketRepo.findById(result.ticketId()).orElseThrow();
+        Ticket saved = ticketRepository.findById(result.ticketId()).orElseThrow();
+        var events = ticketEventRepository.findByTicketId(saved.id());
+
         assertEquals(TicketStatus.OPEN, saved.status());
         assertEquals(TicketPriority.HIGH, saved.priority());
         assertEquals(creator.id(), saved.createdBy());
         assertEquals(category.id(), saved.categoryId());
         assertEquals(Instant.parse("2026-02-14T10:00:00Z"), saved.createdAt());
         assertEquals(saved.createdAt(), saved.updatedAt());
+        assertEquals(1, events.size());
+        assertEquals(TicketEventType.TICKET_CREATED, events.get(0).type());
+        assertEquals(creator.id(), events.get(0).actorUserId());
+        assertEquals(Map.of(), events.get(0).payload());
+        assertEquals(Instant.parse("2026-02-14T10:00:00Z"), events.get(0).createdAt());
     }
 
     @Test
-    void fails_if_category_not_found() {
-        Clock clock = Clock.systemUTC();
-
-        var ticketRepo = new InMemoryTicketRepository();
-        var categoryRepo = new InMemoryCategoryRepository();
-        var userRepo = new InMemoryUserRepository();
-        var eventRepo = new InMemoryTicketEventRepository();
-
-        User creator = new User(
-                UserId.of(UUID.randomUUID()),
-                "user@test.com",
-                "User",
-                "$2a$10$abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG",
-                UserRole.USER,
-                true
+    void rejects_ticket_creation_when_actor_user_does_not_exist() {
+        var useCase = new CreateTicketUseCase(
+                new InMemoryTicketRepository(),
+                new InMemoryCategoryRepository(),
+                new InMemoryUserRepository(),
+                new InMemoryTicketEventRepository(),
+                Clock.systemUTC()
         );
-        userRepo.put(creator);
 
-        var useCase = new CreateTicketUseCase(ticketRepo, categoryRepo, userRepo, eventRepo, clock);
-
-        var cmd = new CreateTicketCommand(
+        var exception = assertThrows(NotFoundException.class, () -> useCase.execute(new CreateTicketCommand(
                 "Title",
                 "Description",
-                CategoryId.of(UUID.randomUUID()),
+                com.aperdigon.ticketing_backend.domain.category.CategoryId.of(UUID.randomUUID()),
+                TicketPriority.MEDIUM,
+                new CurrentUser(com.aperdigon.ticketing_backend.domain.user.UserId.of(UUID.randomUUID()), UserRole.USER)
+        )));
+
+        assertTrue(exception.getMessage().startsWith("User not found:"));
+    }
+
+    @Test
+    void rejects_ticket_creation_when_category_does_not_exist() {
+        Clock clock = Clock.systemUTC();
+
+        var ticketRepository = new InMemoryTicketRepository();
+        var categoryRepository = new InMemoryCategoryRepository();
+        var userRepository = new InMemoryUserRepository();
+        var eventRepository = new InMemoryTicketEventRepository();
+        var creator = DomainTestDataFactory.activeUser("user@test.com", "User", UserRole.USER);
+        userRepository.put(creator);
+
+        var useCase = new CreateTicketUseCase(ticketRepository, categoryRepository, userRepository, eventRepository, clock);
+
+        var exception = assertThrows(NotFoundException.class, () -> useCase.execute(new CreateTicketCommand(
+                "Title",
+                "Description",
+                com.aperdigon.ticketing_backend.domain.category.CategoryId.of(UUID.randomUUID()),
                 TicketPriority.MEDIUM,
                 new CurrentUser(creator.id(), creator.role())
-        );
+        )));
 
-        assertThrows(NotFoundException.class, () -> useCase.execute(cmd));
+        assertTrue(exception.getMessage().startsWith("Category not found:"));
+        assertEquals(0, eventRepository.allEvents().size());
     }
 }

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/GetTicketUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/GetTicketUseCaseTest.java
@@ -1,0 +1,83 @@
+package com.aperdigon.ticketing_backend.unit.ticket;
+
+import com.aperdigon.ticketing_backend.application.shared.CurrentUser;
+import com.aperdigon.ticketing_backend.application.shared.exception.ForbiddenException;
+import com.aperdigon.ticketing_backend.application.shared.exception.NotFoundException;
+import com.aperdigon.ticketing_backend.application.tickets.get.GetTicketUseCase;
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import com.aperdigon.ticketing_backend.specification.SpecificationRef;
+import com.aperdigon.ticketing_backend.specification.TestLevel;
+import com.aperdigon.ticketing_backend.test_support.DomainTestDataFactory;
+import com.aperdigon.ticketing_backend.test_support.InMemoryTicketRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class GetTicketUseCaseTest {
+
+    @Test
+    @SpecificationRef(value = "TICKET-USER-04", level = TestLevel.UNIT, feature = "tickets-user.feature")
+    void owner_can_get_their_own_ticket_detail() {
+        Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
+        var ticketRepository = new InMemoryTicketRepository();
+        var useCase = new GetTicketUseCase(ticketRepository);
+
+        var owner = DomainTestDataFactory.activeUser("owner@test.com", "Owner", UserRole.USER);
+        var category = DomainTestDataFactory.activeCategory("General");
+        var ticket = DomainTestDataFactory.openTicket("Printer issue", "Paper jam", category, owner, clock);
+        ticketRepository.save(ticket);
+
+        var result = useCase.execute(ticket.id(), new CurrentUser(owner.id(), owner.role()));
+
+        assertSame(ticket, result);
+    }
+
+    @Test
+    void non_owner_user_cannot_get_ticket_detail_from_another_user() {
+        Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
+        var ticketRepository = new InMemoryTicketRepository();
+        var useCase = new GetTicketUseCase(ticketRepository);
+
+        var owner = DomainTestDataFactory.activeUser("owner@test.com", "Owner", UserRole.USER);
+        var otherUser = DomainTestDataFactory.activeUser("other@test.com", "Other", UserRole.USER);
+        var category = DomainTestDataFactory.activeCategory("General");
+        var ticket = DomainTestDataFactory.openTicket("Printer issue", "Paper jam", category, owner, clock);
+        ticketRepository.save(ticket);
+
+        assertThrows(ForbiddenException.class, () -> useCase.execute(ticket.id(), new CurrentUser(otherUser.id(), otherUser.role())));
+    }
+
+    @Test
+    void agent_can_get_ticket_detail_created_by_another_user() {
+        Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
+        var ticketRepository = new InMemoryTicketRepository();
+        var useCase = new GetTicketUseCase(ticketRepository);
+
+        var owner = DomainTestDataFactory.activeUser("owner@test.com", "Owner", UserRole.USER);
+        var agent = DomainTestDataFactory.activeUser("agent@test.com", "Agent", UserRole.AGENT);
+        var category = DomainTestDataFactory.activeCategory("General");
+        var ticket = DomainTestDataFactory.openTicket("Printer issue", "Paper jam", category, owner, clock);
+        ticketRepository.save(ticket);
+
+        var result = useCase.execute(ticket.id(), new CurrentUser(agent.id(), agent.role()));
+
+        assertEquals(ticket.id(), result.id());
+    }
+
+    @Test
+    void throws_not_found_when_ticket_does_not_exist() {
+        var useCase = new GetTicketUseCase(new InMemoryTicketRepository());
+
+        assertThrows(NotFoundException.class, () -> useCase.execute(
+                com.aperdigon.ticketing_backend.domain.ticket.TicketId.of(UUID.randomUUID()),
+                new CurrentUser(com.aperdigon.ticketing_backend.domain.user.UserId.of(UUID.randomUUID()), UserRole.USER)
+        ));
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/ListMyTicketsUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/ListMyTicketsUseCaseTest.java
@@ -1,0 +1,53 @@
+package com.aperdigon.ticketing_backend.unit.ticket;
+
+import com.aperdigon.ticketing_backend.application.shared.CurrentUser;
+import com.aperdigon.ticketing_backend.application.tickets.list.ListMyTicketsQuery;
+import com.aperdigon.ticketing_backend.application.tickets.list.ListMyTicketsUseCase;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import com.aperdigon.ticketing_backend.specification.SpecificationRef;
+import com.aperdigon.ticketing_backend.specification.TestLevel;
+import com.aperdigon.ticketing_backend.test_support.DomainTestDataFactory;
+import com.aperdigon.ticketing_backend.test_support.InMemoryTicketRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class ListMyTicketsUseCaseTest {
+
+    @Test
+    @SpecificationRef(value = "TICKET-USER-03", level = TestLevel.UNIT, feature = "tickets-user.feature")
+    void returns_only_tickets_created_by_actor_and_applies_status_and_text_filters() {
+        Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
+        var ticketRepository = new InMemoryTicketRepository();
+        var useCase = new ListMyTicketsUseCase(ticketRepository);
+
+        var actor = DomainTestDataFactory.activeUser("actor@test.com", "Actor", UserRole.USER);
+        var otherUser = DomainTestDataFactory.activeUser("other@test.com", "Other", UserRole.USER);
+        var category = DomainTestDataFactory.activeCategory("General");
+
+        var matchingTicket = DomainTestDataFactory.openTicket("Printer issue", "Needs toner", category, actor, clock);
+        var otherStatusTicket = DomainTestDataFactory.openTicket("Laptop issue", "Battery warning", category, actor, clock);
+        otherStatusTicket.changeStatus(TicketStatus.IN_PROGRESS, clock);
+        var foreignTicket = DomainTestDataFactory.openTicket("Printer issue", "Other user's ticket", category, otherUser, clock);
+
+        ticketRepository.save(matchingTicket);
+        ticketRepository.save(otherStatusTicket);
+        ticketRepository.save(foreignTicket);
+
+        var result = useCase.execute(new ListMyTicketsQuery(
+                new CurrentUser(actor.id(), actor.role()),
+                TicketStatus.OPEN,
+                "printer",
+                PageRequest.of(0, 10)
+        ));
+
+        assertEquals(1, result.getTotalElements());
+        assertEquals(matchingTicket.id(), result.getContent().get(0).id());
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/ListTicketsUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/ListTicketsUseCaseTest.java
@@ -1,0 +1,76 @@
+package com.aperdigon.ticketing_backend.unit.ticket;
+
+import com.aperdigon.ticketing_backend.application.shared.CurrentUser;
+import com.aperdigon.ticketing_backend.application.shared.exception.ForbiddenException;
+import com.aperdigon.ticketing_backend.application.tickets.list.ListTicketsQuery;
+import com.aperdigon.ticketing_backend.application.tickets.list.ListTicketsUseCase;
+import com.aperdigon.ticketing_backend.application.tickets.list.TicketQueueScope;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import com.aperdigon.ticketing_backend.specification.SpecificationRef;
+import com.aperdigon.ticketing_backend.specification.TestLevel;
+import com.aperdigon.ticketing_backend.test_support.DomainTestDataFactory;
+import com.aperdigon.ticketing_backend.test_support.InMemoryTicketRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class ListTicketsUseCaseTest {
+
+    @Test
+    @SpecificationRef(value = "TICKET-AGENT-03", level = TestLevel.UNIT, feature = "tickets-agent.feature")
+    void agent_can_list_manageable_tickets_filtered_by_scope_status_and_query() {
+        Clock clock = Clock.fixed(Instant.parse("2026-02-14T10:00:00Z"), ZoneOffset.UTC);
+        var ticketRepository = new InMemoryTicketRepository();
+        var useCase = new ListTicketsUseCase(ticketRepository);
+
+        var creator = DomainTestDataFactory.activeUser("creator@test.com", "Creator", UserRole.USER);
+        var agent = DomainTestDataFactory.activeUser("agent@test.com", "Agent", UserRole.AGENT);
+        var anotherAgent = DomainTestDataFactory.activeUser("another@test.com", "Another Agent", UserRole.AGENT);
+        var category = DomainTestDataFactory.activeCategory("General");
+
+        var myAssignedTicket = DomainTestDataFactory.openTicket("Printer issue", "Needs onsite review", category, creator, clock);
+        myAssignedTicket.assignTo(agent.id(), clock);
+        myAssignedTicket.changeStatus(TicketStatus.IN_PROGRESS, clock);
+
+        var otherAgentsTicket = DomainTestDataFactory.openTicket("Network issue", "Router offline", category, creator, clock);
+        otherAgentsTicket.assignTo(anotherAgent.id(), clock);
+        otherAgentsTicket.changeStatus(TicketStatus.IN_PROGRESS, clock);
+
+        var unassignedTicket = DomainTestDataFactory.openTicket("Printer toner", "Need toner replacement", category, creator, clock);
+
+        ticketRepository.save(myAssignedTicket);
+        ticketRepository.save(otherAgentsTicket);
+        ticketRepository.save(unassignedTicket);
+
+        var result = useCase.execute(new ListTicketsQuery(
+                new CurrentUser(agent.id(), agent.role()),
+                TicketQueueScope.MINE,
+                TicketStatus.IN_PROGRESS,
+                "printer",
+                PageRequest.of(0, 10)
+        ));
+
+        assertEquals(1, result.getTotalElements());
+        assertEquals(myAssignedTicket.id(), result.getContent().get(0).id());
+    }
+
+    @Test
+    void non_operational_user_cannot_list_manageable_tickets() {
+        var useCase = new ListTicketsUseCase(new InMemoryTicketRepository());
+
+        assertThrows(ForbiddenException.class, () -> useCase.execute(new ListTicketsQuery(
+                new CurrentUser(com.aperdigon.ticketing_backend.domain.user.UserId.of(java.util.UUID.randomUUID()), UserRole.USER),
+                TicketQueueScope.ALL,
+                null,
+                null,
+                PageRequest.of(0, 10)
+        )));
+    }
+}


### PR DESCRIPTION
### Motivation
- Reducir la duplicación entre integration tests del backend y centralizar el bootstrap común (SpringBootTest, MockMvc, Testcontainers, propiedades dinámicas) para que la suite pueda crecer de forma mantenible. 
- Proveer utilidades y builders reutilizables (usuarios, categorías, tickets) y helpers de autenticación para evitar código frágil y repetido en cada test de integración.

### Description
- Se añadió la infraestructura compartida de tests en `ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/integration/AbstractIntegrationTest.java` que centraliza `@SpringBootTest`, `@AutoConfigureMockMvc`, `@Testcontainers`, el `PostgreSQLContainer`, `@DynamicPropertySource`, `MockMvc`, `ObjectMapper`, `PasswordEncoder` y repositorios JPA, además de helpers `clearPersistedData()`, `persistUser(...)`, `persistCategory(...)`, `persistTicket(...)`, `toJson(...)` y `postJson(...)`.
- Se añadió `AbstractAuthenticatedApiIntegrationTest` en el mismo paquete para encapsular creación de usuarios autenticables, `loginAndExtractAccessToken(...)` y `bearerToken(...)` para adjuntar autenticación a requests MockMvc.
- Se añadieron builders reutilizables bajo `test_support/builders`: `UserTestDataBuilder`, `CategoryTestDataBuilder` y `TicketTestDataBuilder` para crear entidades JPA con mínima repetición.
- Se refactorizaron los integration tests existentes `AuthLoginIntegrationTest` y `AdminIntegrationTest` para usar la nueva infraestructura y builders, manteniendo escenarios, endpoints y aserciones funcionales originales.
