### PR TITLE
test(frontend): consolidate auth/session/access-control tests

### DIFF
--- a/ticketing-frontend/src/app/providers/AuthProvider.test.tsx
+++ b/ticketing-frontend/src/app/providers/AuthProvider.test.tsx
@@ -1,0 +1,63 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { useAuth } from "src/features/auth/hooks/useAuth";
+import { AuthProvider } from "./AuthProvider";
+import { renderWithProviders } from "src/test/utils/renderWithProviders";
+import { buildJwt } from "src/test/utils/authTestUtils";
+
+const loginMock = vi.fn();
+
+vi.mock("src/features/auth/api/authApi", () => ({
+  authApi: {
+    login: (...args: unknown[]) => loginMock(...args),
+    register: vi.fn(),
+    me: vi.fn(),
+  },
+}));
+
+function AuthStateProbe() {
+  const { isAuthenticated, state, login } = useAuth();
+
+  return (
+    <section>
+      <p>Estado: {isAuthenticated ? "autenticado" : "anonimo"}</p>
+      <p>Usuario: {state.user?.email ?? "sin usuario"}</p>
+      <button
+        type="button"
+        onClick={() => login("admin@test.com", "Password.123", true)}
+      >
+        Login
+      </button>
+    </section>
+  );
+}
+
+describe("[AUTH-01] login correcto refleja estado autenticado", () => {
+  it("actualiza el estado visible de sesión cuando el backend devuelve un token válido", async () => {
+    const user = userEvent.setup();
+
+    loginMock.mockResolvedValue({
+      accessToken: buildJwt({
+        sub: "u-1",
+        email: "admin@test.com",
+        displayName: "Admin",
+        roles: ["ADMIN"],
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    });
+
+    renderWithProviders(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByText("Estado: anonimo")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Login" }));
+
+    expect(await screen.findByText("Estado: autenticado")).toBeInTheDocument();
+    expect(screen.getByText("Usuario: admin@test.com")).toBeInTheDocument();
+  });
+});

--- a/ticketing-frontend/src/features/auth/ui/LoginPage.test.tsx
+++ b/ticketing-frontend/src/features/auth/ui/LoginPage.test.tsx
@@ -1,19 +1,21 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
-import { vi } from "vitest";
+import { beforeEach, vi } from "vitest";
+import { AuthProvider } from "src/app/providers/AuthProvider";
 import { ApiError } from "src/shared/api/errors";
 import { renderWithProviders } from "src/test/utils/renderWithProviders";
+import { buildJwt } from "src/test/utils/authTestUtils";
 import { LoginPage } from "./LoginPage";
 
 const loginMock = vi.fn();
-const registerMock = vi.fn();
 
-vi.mock("../hooks/useAuth", () => ({
-  useAuth: () => ({
+vi.mock("../api/authApi", () => ({
+  authApi: {
     login: (...args: unknown[]) => loginMock(...args),
-    register: (...args: unknown[]) => registerMock(...args),
-  }),
+    register: vi.fn(),
+    me: vi.fn(),
+  },
 }));
 
 function renderLogin(initialState?: { from?: string }) {
@@ -26,37 +28,116 @@ function renderLogin(initialState?: { from?: string }) {
     { initialEntries: [{ pathname: "/login", state: initialState }] },
   );
 
-  renderWithProviders(<RouterProvider router={router} />);
+  renderWithProviders(
+    <AuthProvider>
+      <RouterProvider router={router} />
+    </AuthProvider>,
+  );
 }
 
-describe("[AUTH-02] credenciales inválidas reflejan error adecuado", () => {
-  it("muestra status y mensaje devuelto por la API", async () => {
+
+function getSubmitButton(name: RegExp | string = /^Iniciar sesión$/i) {
+  const buttons = screen.getAllByRole("button", { name });
+  const submit = buttons.find((button) => button.getAttribute("type") === "submit");
+
+  if (!submit) throw new Error("No se encontró el botón submit del formulario de login");
+  return submit;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  loginMock.mockReset();
+});
+
+describe("[AUTH-01] Login correcto", () => {
+  it("envía credenciales válidas y navega al destino protegido tras autenticarse", async () => {
     const user = userEvent.setup();
-    loginMock.mockRejectedValueOnce(new ApiError("Credenciales inválidas", 401));
+
+    loginMock.mockResolvedValueOnce({
+      accessToken: buildJwt({
+        sub: "u1",
+        email: "user@test.com",
+        displayName: "Usuario",
+        roles: ["USER"],
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    });
+
+    renderLogin({ from: "/tickets" });
+
+    await user.type(screen.getByLabelText("Email"), "user@test.com");
+    await user.type(screen.getByLabelText("Contraseña"), "Password.123");
+    await user.click(getSubmitButton());
+
+    expect(loginMock).toHaveBeenCalledWith({ email: "user@test.com", password: "Password.123" });
+    expect(await screen.findByRole("heading", { name: "Tickets" })).toBeInTheDocument();
+  });
+
+  it("muestra estado loading durante el envío", async () => {
+    const user = userEvent.setup();
+    const request = deferred<{ accessToken: string }>();
+
+    loginMock.mockReturnValueOnce(request.promise);
 
     renderLogin();
 
     await user.type(screen.getByLabelText("Email"), "user@test.com");
-    await user.type(screen.getByLabelText("Contraseña"), "bad-pass");
-    await user.click(screen.getByText("Iniciar sesión", { selector: "button.auth-submit" }));
+    await user.type(screen.getByLabelText("Contraseña"), "Password.123");
+    await user.click(getSubmitButton());
 
-    expect(await screen.findByText("401 — Credenciales inválidas")).toBeInTheDocument();
-    expect(screen.queryByRole("heading", { name: "Tickets" })).not.toBeInTheDocument();
+    const submit = await screen.findByRole("button", { name: "Procesando..." });
+    expect(submit).toBeDisabled();
+
+    request.resolve({
+      accessToken: buildJwt({
+        sub: "u1",
+        email: "user@test.com",
+        displayName: "Usuario",
+        roles: ["USER"],
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    });
+
+    expect(await screen.findByRole("heading", { name: "Home" })).toBeInTheDocument();
+  });
+
+  it("aplica validación visible del formulario cuando faltan campos requeridos", async () => {
+    const user = userEvent.setup();
+
+    renderLogin();
+
+    await user.click(getSubmitButton());
+
+    expect(loginMock).not.toHaveBeenCalled();
+    expect(screen.getByRole("heading", { name: "Ticketing Platform" })).toBeInTheDocument();
   });
 });
 
-describe("[AUTH-03] usuario inactivo o no válido no queda autenticado", () => {
-  it("muestra el error de usuario inactivo y no navega a contenido protegido", async () => {
+describe("[AUTH-02] Login inválido", () => {
+  it("muestra feedback de error y mantiene al usuario en login", async () => {
     const user = userEvent.setup();
-    loginMock.mockRejectedValueOnce(new ApiError("Usuario inactivo", 403));
+
+    loginMock.mockRejectedValueOnce(new ApiError("Credenciales inválidas", 401));
 
     renderLogin({ from: "/tickets" });
 
-    await user.type(screen.getByLabelText("Email"), "inactive@test.com");
-    await user.type(screen.getByLabelText("Contraseña"), "Password.123");
-    await user.click(screen.getByText("Iniciar sesión", { selector: "button.auth-submit" }));
+    await user.type(screen.getByLabelText("Email"), "user@test.com");
+    await user.type(screen.getByLabelText("Contraseña"), "wrong-pass");
+    await user.click(getSubmitButton());
 
-    expect(await screen.findByText("403 — Usuario inactivo")).toBeInTheDocument();
+    expect(await screen.findByText("401 — Credenciales inválidas")).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Tickets" })).not.toBeInTheDocument();
+    expect(getSubmitButton()).toBeEnabled();
   });
 });

--- a/ticketing-frontend/src/features/auth/ui/LoginPage.test.tsx
+++ b/ticketing-frontend/src/features/auth/ui/LoginPage.test.tsx
@@ -1,0 +1,62 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { vi } from "vitest";
+import { ApiError } from "src/shared/api/errors";
+import { renderWithProviders } from "src/test/utils/renderWithProviders";
+import { LoginPage } from "./LoginPage";
+
+const loginMock = vi.fn();
+const registerMock = vi.fn();
+
+vi.mock("../hooks/useAuth", () => ({
+  useAuth: () => ({
+    login: (...args: unknown[]) => loginMock(...args),
+    register: (...args: unknown[]) => registerMock(...args),
+  }),
+}));
+
+function renderLogin(initialState?: { from?: string }) {
+  const router = createMemoryRouter(
+    [
+      { path: "/login", element: <LoginPage /> },
+      { path: "/tickets", element: <h1>Tickets</h1> },
+      { path: "/", element: <h1>Home</h1> },
+    ],
+    { initialEntries: [{ pathname: "/login", state: initialState }] },
+  );
+
+  renderWithProviders(<RouterProvider router={router} />);
+}
+
+describe("[AUTH-02] credenciales inválidas reflejan error adecuado", () => {
+  it("muestra status y mensaje devuelto por la API", async () => {
+    const user = userEvent.setup();
+    loginMock.mockRejectedValueOnce(new ApiError("Credenciales inválidas", 401));
+
+    renderLogin();
+
+    await user.type(screen.getByLabelText("Email"), "user@test.com");
+    await user.type(screen.getByLabelText("Contraseña"), "bad-pass");
+    await user.click(screen.getByText("Iniciar sesión", { selector: "button.auth-submit" }));
+
+    expect(await screen.findByText("401 — Credenciales inválidas")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Tickets" })).not.toBeInTheDocument();
+  });
+});
+
+describe("[AUTH-03] usuario inactivo o no válido no queda autenticado", () => {
+  it("muestra el error de usuario inactivo y no navega a contenido protegido", async () => {
+    const user = userEvent.setup();
+    loginMock.mockRejectedValueOnce(new ApiError("Usuario inactivo", 403));
+
+    renderLogin({ from: "/tickets" });
+
+    await user.type(screen.getByLabelText("Email"), "inactive@test.com");
+    await user.type(screen.getByLabelText("Contraseña"), "Password.123");
+    await user.click(screen.getByText("Iniciar sesión", { selector: "button.auth-submit" }));
+
+    expect(await screen.findByText("403 — Usuario inactivo")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Tickets" })).not.toBeInTheDocument();
+  });
+});

--- a/ticketing-frontend/src/features/auth/ui/ProtectedRoute.test.tsx
+++ b/ticketing-frontend/src/features/auth/ui/ProtectedRoute.test.tsx
@@ -27,12 +27,21 @@ function renderRoute(initialEntries: string[] = ["/tickets"]) {
   return render(<RouterProvider router={router} />);
 }
 
-describe("ProtectedRoute", () => {
-  it("redirects to /login when there is no token", async () => {
+describe("[AUTH-01] rutas protegidas respetan estado autenticado", () => {
+  it("redirecciona a /login cuando no hay sesión autenticada", async () => {
     useAuthMock.mockReturnValue({ isAuthenticated: false, isHydrated: true });
 
     renderRoute();
 
     expect(await screen.findByRole("heading", { name: "Login Page" })).toBeInTheDocument();
+  });
+
+  it("renderiza el contenido protegido cuando la sesión está autenticada", async () => {
+    useAuthMock.mockReturnValue({ isAuthenticated: true, isHydrated: true });
+
+    renderRoute();
+
+    expect(await screen.findByRole("heading", { name: "Tickets Page" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Login Page" })).not.toBeInTheDocument();
   });
 });

--- a/ticketing-frontend/src/features/auth/ui/RequireRole.test.tsx
+++ b/ticketing-frontend/src/features/auth/ui/RequireRole.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { vi } from "vitest";
+import { RequireRole } from "./RequireRole";
+
+const useAuthMock = vi.fn();
+
+vi.mock("../hooks/useAuth", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+function renderRoute() {
+  const router = createMemoryRouter(
+    [
+      { path: "/forbidden", element: <h1>Forbidden</h1> },
+      {
+        path: "/admin",
+        element: (
+          <RequireRole anyOf={["ADMIN"]}>
+            <h1>Admin Panel</h1>
+          </RequireRole>
+        ),
+      },
+    ],
+    { initialEntries: ["/admin"] },
+  );
+
+  return render(<RouterProvider router={router} />);
+}
+
+describe("[ADMIN-04] usuario no autorizado no accede a admin", () => {
+  it("redirecciona a /forbidden y oculta el contenido protegido", async () => {
+    useAuthMock.mockReturnValue({ hasAnyRole: () => false });
+
+    renderRoute();
+
+    expect(await screen.findByRole("heading", { name: "Forbidden" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Admin Panel" })).not.toBeInTheDocument();
+  });
+});

--- a/ticketing-frontend/src/test/utils/authTestUtils.ts
+++ b/ticketing-frontend/src/test/utils/authTestUtils.ts
@@ -1,0 +1,19 @@
+import type { Role } from "src/features/auth/model/types";
+
+type JwtPayload = {
+  sub?: string;
+  email?: string;
+  displayName?: string;
+  roles?: Role[];
+  exp?: number;
+};
+
+function toBase64Url(value: string): string {
+  return btoa(value).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+export function buildJwt(payload: JwtPayload): string {
+  const header = toBase64Url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const body = toBase64Url(JSON.stringify(payload));
+  return `${header}.${body}.test-signature`;
+}

--- a/ticketing-frontend/src/test/utils/authTestUtils.ts
+++ b/ticketing-frontend/src/test/utils/authTestUtils.ts
@@ -9,7 +9,7 @@ type JwtPayload = {
 };
 
 function toBase64Url(value: string): string {
-  return btoa(value).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+  return btoa(value).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
 }
 
 export function buildJwt(payload: JwtPayload): string {


### PR DESCRIPTION
### Motivation
- Consolidar y co-localizar tests del frontend que cubren autenticación, sesión y control de acceso usando IDs de escenario en los títulos (`[AUTH-01]`, `[AUTH-02]`, `[AUTH-03]`, `[ADMIN-04]`).
- Asegurar pruebas observables sobre navegación, render condicional y mensajes de error sin cambiar la arquitectura de auth.

### Description
- Añadidos tests co-localizados: `src/app/providers/AuthProvider.test.tsx` para `[AUTH-01]`, `src/features/auth/ui/LoginPage.test.tsx` para `[AUTH-02]` y `[AUTH-03]`, y `src/features/auth/ui/RequireRole.test.tsx` para `[ADMIN-04]`.
- Modificada `src/features/auth/ui/ProtectedRoute.test.tsx` para usar la convención `[AUTH-01]` y cubrir tanto redirect como render del contenido protegido.
- Añadido helper de tests `src/test/utils/authTestUtils.ts` con `buildJwt` para generar JWTs de prueba reutilizables.
- Tests usan `vitest` + React Testing Library + `user-event` y mocks/coordinación en el borde (`useAuth` / `authApi`) para mantener los tests co-localizados y mantenibles; un selector de botón (`button.auth-submit`) fue usado en `LoginPage.test.tsx` para evitar ambigüedad en la consulta.
