### PR TITLE
test(frontend): ampliar cobertura funcional de pantallas de tickets

### DIFF
--- a/ticketing-frontend/src/app/pages/TicketsPage.test.tsx
+++ b/ticketing-frontend/src/app/pages/TicketsPage.test.tsx
@@ -11,11 +11,11 @@ vi.mock("../../features/auth/hooks/useAuth", () => ({
   }),
 }));
 
-vi.mock("../../features/tickets/ui/UserTicketsHomePage", () => ({
+vi.mock("src/features/tickets/ui/ticketsPage/UserTicketsHomePage", () => ({
   UserTicketsHomePage: () => <h1>Mis tickets</h1>,
 }));
 
-vi.mock("../../features/tickets/ui/AgentAdminTicketsPage", () => ({
+vi.mock("src/features/tickets/ui/ticketsPage/AgentAdminTicketsPage", () => ({
   AgentAdminTicketsPage: () => <h1>Gestión de tickets</h1>,
 }));
 
@@ -24,7 +24,7 @@ describe("TicketsPage", () => {
     hasAnyRoleMock.mockReset();
   });
 
-  it("shows USER tickets page for normal users", () => {
+  it("renderiza vista USER cuando no tiene rol agent/admin", () => {
     hasAnyRoleMock.mockReturnValue(false);
 
     renderWithProviders(<TicketsPage />, { router: {} });
@@ -32,7 +32,7 @@ describe("TicketsPage", () => {
     expect(screen.getByRole("heading", { name: "Mis tickets" })).toBeInTheDocument();
   });
 
-  it("shows AGENT/ADMIN tickets page", () => {
+  it("renderiza vista de gestión cuando tiene rol AGENT/ADMIN", () => {
     hasAnyRoleMock.mockReturnValue(true);
 
     renderWithProviders(<TicketsPage />, { router: {} });

--- a/ticketing-frontend/src/features/tickets/ui/create/CreateTicketPage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/create/CreateTicketPage.test.tsx
@@ -59,8 +59,8 @@ describe("CreateTicketPage", () => {
 
     renderWithProviders(<CreateTicketPage />, { router: {} });
 
-    await user.type(await screen.findByLabelText("Título"), "  Impresora bloqueada  ");
-    await user.type(screen.getByLabelText("Descripción"), "  Error E23 al imprimir PDF  ");
+    fireEvent.change(await screen.findByLabelText("Título"), { target: { value: "  Impresora bloqueada  " } });
+    fireEvent.change(screen.getByLabelText("Descripción"), { target: { value: "  Error E23 al imprimir PDF  " } });
 
     const categoryCombobox = screen.getByRole("combobox", { name: "Categoría" });
     fireEvent.mouseDown(categoryCombobox);

--- a/ticketing-frontend/src/features/tickets/ui/create/CreateTicketPage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/create/CreateTicketPage.test.tsx
@@ -1,11 +1,12 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
-import { renderWithProviders } from "src/test/utils/renderWithProviders";
 import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "src/test/utils/renderWithProviders";
+import { jsonResponse } from "src/test/msw/handlers";
+import { http } from "src/test/msw/http";
+import { server } from "src/test/msw/server";
 import { vi } from "vitest";
 import { CreateTicketPage } from "./CreateTicketPage";
 
-const getCategoriesMock = vi.fn();
-const createTicketMock = vi.fn();
 const navigateMock = vi.fn();
 
 vi.mock("react-router-dom", async () => {
@@ -16,22 +17,13 @@ vi.mock("react-router-dom", async () => {
   };
 });
 
-vi.mock("../../api/ticketsApi", () => ({
-  ticketsApi: {
-    getCategories: () => getCategoriesMock(),
-    createTicket: (payload: unknown) => createTicketMock(payload),
-  },
-}));
-
 describe("CreateTicketPage", () => {
   beforeEach(() => {
-    getCategoriesMock.mockReset();
-    createTicketMock.mockReset();
     navigateMock.mockReset();
   });
 
-  it("keeps submit disabled while required fields are empty", async () => {
-    getCategoriesMock.mockResolvedValueOnce([{ id: "cat-1", name: "General" }]);
+  it("mantiene submit deshabilitado mientras faltan campos requeridos", async () => {
+    server.use(http.get("/api/categories", () => jsonResponse([{ id: "cat-1", name: "General" }])));
 
     renderWithProviders(<CreateTicketPage />, { router: {} });
 
@@ -39,16 +31,37 @@ describe("CreateTicketPage", () => {
     expect(submitButton).toBeDisabled();
   });
 
-  it("submits form and redirects to ticket detail", async () => {
-    const user = userEvent.setup();
-
-    getCategoriesMock.mockResolvedValueOnce([{ id: "cat-1", name: "General" }]);
-    createTicketMock.mockResolvedValueOnce({ ticketId: "t-100" });
+  it("deshabilita envío mientras carga categorías", async () => {
+    server.use(
+      http.get("/api/categories", async () => {
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        return jsonResponse([{ id: "cat-1", name: "General" }]);
+      }),
+    );
 
     renderWithProviders(<CreateTicketPage />, { router: {} });
 
-    await user.type(await screen.findByLabelText("Título"), "Impresora bloqueada");
-    await user.type(screen.getByLabelText("Descripción"), "Da error E23 cuando intento imprimir un PDF.");
+    const submitButton = screen.getByRole("button", { name: "Crear ticket" });
+    expect(submitButton).toBeDisabled();
+  });
+
+  it("[TICKET-USER-01] Usuario crea ticket correctamente", async () => {
+    const user = userEvent.setup();
+    let payload: unknown;
+
+    server.use(
+      http.get("/api/categories", () => jsonResponse([{ id: "cat-1", name: "General" }])),
+      http.post("/api/tickets", (request) => {
+        payload = request.body;
+        return jsonResponse({ ticketId: "t-100" }, { status: 201 });
+      }),
+    );
+
+    renderWithProviders(<CreateTicketPage />, { router: {} });
+
+    await user.type(await screen.findByLabelText("Título"), "  Impresora bloqueada  ");
+    await user.type(screen.getByLabelText("Descripción"), "  Error E23 al imprimir PDF  ");
+
     const categoryCombobox = screen.getByRole("combobox", { name: "Categoría" });
     fireEvent.mouseDown(categoryCombobox);
     await user.click(await screen.findByText("General"));
@@ -59,12 +72,59 @@ describe("CreateTicketPage", () => {
 
     await user.click(screen.getByRole("button", { name: "Crear ticket" }));
 
-    expect(createTicketMock).toHaveBeenCalledWith({
-      title: "Impresora bloqueada",
-      description: "Da error E23 cuando intento imprimir un PDF.",
-      categoryId: "cat-1",
-      priority: "MEDIUM",
+    await waitFor(() => {
+      expect(payload).toEqual({
+        title: "Impresora bloqueada",
+        description: "Error E23 al imprimir PDF",
+        categoryId: "cat-1",
+        priority: "MEDIUM",
+      });
+      expect(navigateMock).toHaveBeenCalledWith("/tickets/t-100");
     });
-    expect(navigateMock).toHaveBeenCalledWith("/tickets/t-100");
+  });
+
+
+  it("deshabilita botón durante el envío para evitar doble submit", async () => {
+    const user = userEvent.setup();
+
+    server.use(
+      http.get("/api/categories", () => jsonResponse([{ id: "cat-1", name: "General" }])),
+      http.post("/api/tickets", async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        return jsonResponse({ ticketId: "t-777" }, { status: 201 });
+      }),
+    );
+
+    renderWithProviders(<CreateTicketPage />, { router: {} });
+
+    await user.type(await screen.findByLabelText("Título"), "Ticket en cola");
+    await user.type(screen.getByLabelText("Descripción"), "Descripción completa");
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Categoría" }));
+    await user.click(await screen.findByText("General"));
+
+    const submitButton = screen.getByRole("button", { name: "Crear ticket" });
+    await user.click(submitButton);
+
+    expect(submitButton).toHaveClass("ant-btn-loading");
+  });
+
+  it("muestra error visible cuando falla el envío", async () => {
+    const user = userEvent.setup();
+
+    server.use(
+      http.get("/api/categories", () => jsonResponse([{ id: "cat-1", name: "General" }])),
+      http.post("/api/tickets", () => jsonResponse({ message: "No autorizado" }, { status: 403 })),
+    );
+
+    renderWithProviders(<CreateTicketPage />, { router: {} });
+
+    await user.type(await screen.findByLabelText("Título"), "No imprime");
+    await user.type(screen.getByLabelText("Descripción"), "Error de cola de impresión");
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Categoría" }));
+    await user.click(await screen.findByText("General"));
+    await user.click(screen.getByRole("button", { name: "Crear ticket" }));
+
+    expect(await screen.findByText("Error al crear ticket")).toBeInTheDocument();
   });
 });

--- a/ticketing-frontend/src/features/tickets/ui/dashboard/AgentAdminDashboardPage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/dashboard/AgentAdminDashboardPage.tsx
@@ -3,8 +3,9 @@ import type { TableProps } from "antd";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ticketsApi } from "../../api/ticketsApi";
-import { ticketPriorityLabel, ticketStatusColor, ticketStatusLabel } from "../../model/presentation";
+import { ticketPriorityLabel } from "../../model/presentation";
 import type { TicketPriority, TicketStatus, TicketSummary } from "../../model/types";
+import { TicketStatusBadge } from "../shared/TicketStatusBadge";
 
 type LoadState = "loading" | "ready" | "error";
 
@@ -97,7 +98,7 @@ export function AgentAdminDashboardPage() {
         key: "status",
         width: 140,
         render: (statusValue: unknown) => (
-          <Tag color={ticketStatusColor[statusValue as TicketStatus]}>{ticketStatusLabel[statusValue as TicketStatus]}</Tag>
+          <TicketStatusBadge status={statusValue as TicketStatus} />
         ),
       },
       {

--- a/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.tsx
@@ -3,8 +3,9 @@ import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useAuth } from "../../../auth/hooks/useAuth";
 import { ticketsApi } from "../../api/ticketsApi";
-import { ticketPriorityLabel, ticketStatusColor, ticketStatusLabel } from "../../model/presentation";
+import { ticketPriorityLabel, ticketStatusLabel } from "../../model/presentation";
 import type { TicketDetail, TicketStatus, TimelineEntry } from "../../model/types";
+import { TicketStatusBadge } from "../shared/TicketStatusBadge";
 
 type LoadState = "loading" | "ready" | "error";
 
@@ -156,7 +157,7 @@ export function TicketDetailPage() {
           <Card>
             <Space direction="vertical" size={12} style={{ width: "100%" }}>
               <Typography.Title level={4} style={{ margin: 0 }}>{ticket.title}</Typography.Title>
-              <Tag color={ticketStatusColor[ticket.status]}>{ticketStatusLabel[ticket.status]}</Tag>
+              <TicketStatusBadge status={ticket.status} />
               <Tag>{ticketPriorityLabel[ticket.priority]}</Tag>
               <Typography.Title level={5} style={{ margin: 0 }}>Metadata</Typography.Title>
               <Typography.Text>ID: {ticket.id}</Typography.Text>

--- a/ticketing-frontend/src/features/tickets/ui/shared/TicketStatusBadge.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/shared/TicketStatusBadge.test.tsx
@@ -1,0 +1,19 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "src/test/utils/renderWithProviders";
+import { TicketStatusBadge } from "./TicketStatusBadge";
+
+describe("TicketStatusBadge", () => {
+  it("renderiza el texto de estado en español para estados críticos", () => {
+    const { rerender } = renderWithProviders(<TicketStatusBadge status="OPEN" />);
+    expect(screen.getByText("Abierto")).toBeInTheDocument();
+
+    rerender(<TicketStatusBadge status="IN_PROGRESS" />);
+    expect(screen.getByText("En progreso")).toBeInTheDocument();
+
+    rerender(<TicketStatusBadge status="ON_HOLD" />);
+    expect(screen.getByText("En espera")).toBeInTheDocument();
+
+    rerender(<TicketStatusBadge status="RESOLVED" />);
+    expect(screen.getByText("Resuelto")).toBeInTheDocument();
+  });
+});

--- a/ticketing-frontend/src/features/tickets/ui/shared/TicketStatusBadge.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/shared/TicketStatusBadge.tsx
@@ -1,0 +1,15 @@
+import { Tag } from "antd";
+import { ticketStatusColor, ticketStatusLabel } from "../../model/presentation";
+import type { TicketStatus } from "../../model/types";
+
+type TicketStatusBadgeProps = {
+  status: TicketStatus;
+};
+
+export function TicketStatusBadge({ status }: TicketStatusBadgeProps) {
+  return (
+    <Tag color={ticketStatusColor[status]} data-testid={`ticket-status-${status}`}>
+      {ticketStatusLabel[status]}
+    </Tag>
+  );
+}

--- a/ticketing-frontend/src/features/tickets/ui/ticketsPage/AgentAdminTicketsPage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/ticketsPage/AgentAdminTicketsPage.test.tsx
@@ -1,46 +1,104 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { renderWithProviders } from "src/test/utils/renderWithProviders";
+import { jsonResponse } from "src/test/msw/handlers";
+import { http } from "src/test/msw/http";
+import { server } from "src/test/msw/server";
 import { AgentAdminTicketsPage } from "./AgentAdminTicketsPage";
 
-const getQueueTicketsMock = vi.fn();
-
-vi.mock("../../api/ticketsApi", () => ({
-  ticketsApi: {
-    getQueueTickets: (...args: unknown[]) => getQueueTicketsMock(...args),
-  },
-}));
+const queueTicket = {
+  id: "TCK-200",
+  title: "Impresora bloqueada",
+  status: "IN_PROGRESS",
+  priority: "MEDIUM",
+  createdAt: "2026-03-01T10:00:00.000Z",
+  updatedAt: "2026-03-02T12:00:00.000Z",
+  createdByUserId: "user-77",
+  assignedToUserId: "agent-1",
+} as const;
 
 describe("AgentAdminTicketsPage", () => {
-  beforeEach(() => {
-    getQueueTicketsMock.mockReset();
-    getQueueTicketsMock.mockResolvedValue({
-      items: [],
-      page: 0,
-      size: 20,
-      total: 0,
-    });
-  });
-
-  it("reads queue filters from url params", async () => {
-    render(
-      <MemoryRouter initialEntries={["/tickets?view=mine&status=IN_PROGRESS&q=printer"]}>
-        <Routes>
-          <Route path="/tickets" element={<AgentAdminTicketsPage />} />
-        </Routes>
-      </MemoryRouter>,
+  it("[TICKET-AGENT-03] muestra tickets gestionables para agent/admin", async () => {
+    server.use(
+      http.get("/api/tickets", () =>
+        jsonResponse({
+          items: [queueTicket],
+          page: 0,
+          size: 20,
+          total: 1,
+        }),
+      ),
     );
 
+    renderWithProviders(<AgentAdminTicketsPage />, { router: { initialEntries: ["/tickets"] } });
+
+    expect(await screen.findByRole("cell", { name: "TCK-200" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Impresora bloqueada" })).toBeInTheDocument();
+  });
+
+  it("lee filtros desde query params y los aplica al backend", async () => {
+    let capturedSearch = "";
+
+    server.use(
+      http.get("/api/tickets", (request) => {
+        capturedSearch = request.url.search;
+        return jsonResponse({ items: [], page: 0, size: 20, total: 0 });
+      }),
+    );
+
+    renderWithProviders(<AgentAdminTicketsPage />, {
+      router: { initialEntries: ["/tickets?view=mine&status=IN_PROGRESS&q=printer"] },
+    });
+
     await waitFor(() => {
-      expect(getQueueTicketsMock).toHaveBeenCalledWith({
-        scope: "MINE",
-        status: "IN_PROGRESS",
-        q: "printer",
-        page: 0,
-        size: 20,
-      });
+      expect(capturedSearch).toContain("scope=MINE");
+      expect(capturedSearch).toContain("status=IN_PROGRESS");
+      expect(capturedSearch).toContain("q=printer");
     });
 
     expect(screen.getByRole("heading", { name: "Tickets asignados a mí" })).toBeInTheDocument();
+  });
+
+  it("muestra loading y empty state", async () => {
+    server.use(
+      http.get("/api/tickets", async () => {
+        await new Promise((resolve) => setTimeout(resolve, 120));
+        return jsonResponse({ items: [], page: 0, size: 20, total: 0 });
+      }),
+    );
+
+    const { container } = renderWithProviders(<AgentAdminTicketsPage />, {
+      router: { initialEntries: ["/tickets"] },
+    });
+
+    expect(container.querySelector(".ant-skeleton")).toBeInTheDocument();
+    expect(await screen.findByText("No hay tickets para mostrar con los filtros actuales")).toBeInTheDocument();
+  });
+
+  it("muestra error state cuando falla la cola", async () => {
+    server.use(http.get("/api/tickets", () => jsonResponse({ message: "fail" }, { status: 500 })));
+
+    renderWithProviders(<AgentAdminTicketsPage />, { router: { initialEntries: ["/tickets"] } });
+
+    expect(await screen.findByText("No se ha podido cargar la cola de tickets")).toBeInTheDocument();
+  });
+
+  it("[TICKET-AGENT-01] muestra acciones de UI para gestión de estado si existen", async () => {
+    server.use(
+      http.get("/api/tickets", () =>
+        jsonResponse({
+          items: [queueTicket],
+          page: 0,
+          size: 20,
+          total: 1,
+        }),
+      ),
+    );
+
+    renderWithProviders(<AgentAdminTicketsPage />, { router: { initialEntries: ["/tickets"] } });
+
+    await screen.findByRole("cell", { name: "TCK-200" });
+
+    // En esta pantalla actualmente solo existe acción "Ver".
+    expect(screen.getByRole("button", { name: "Ver" })).toBeInTheDocument();
   });
 });

--- a/ticketing-frontend/src/features/tickets/ui/ticketsPage/AgentAdminTicketsPage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/ticketsPage/AgentAdminTicketsPage.tsx
@@ -3,8 +3,9 @@ import type { TableProps } from "antd";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { ticketsApi } from "../../api/ticketsApi";
-import { ticketPriorityLabel, ticketStatusColor, ticketStatusLabel } from "../../model/presentation";
+import { ticketPriorityLabel } from "../../model/presentation";
 import type { TicketPriority, TicketQueueScope, TicketStatus, TicketSummary } from "../../model/types";
+import { TicketStatusBadge } from "../shared/TicketStatusBadge";
 
 type QueueView = "unassigned" | "mine" | "all";
 type LoadState = "loading" | "ready" | "error";
@@ -114,7 +115,7 @@ export function AgentAdminTicketsPage() {
         key: "status",
         width: 140,
         render: (statusValue: unknown) => (
-          <Tag color={ticketStatusColor[statusValue as TicketStatus]}>{ticketStatusLabel[statusValue as TicketStatus]}</Tag>
+          <TicketStatusBadge status={statusValue as TicketStatus} />
         ),
       },
       {

--- a/ticketing-frontend/src/features/tickets/ui/ticketsPage/UserTicketsHomePage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/ticketsPage/UserTicketsHomePage.test.tsx
@@ -1,23 +1,89 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "src/test/utils/renderWithProviders";
-import { vi } from "vitest";
+import { http } from "src/test/msw/http";
+import { jsonResponse } from "src/test/msw/handlers";
+import { server } from "src/test/msw/server";
 import { UserTicketsHomePage } from "./UserTicketsHomePage";
 
-const getMyTicketsMock = vi.fn();
-
-vi.mock("../../api/ticketsApi", () => ({
-  ticketsApi: {
-    getMyTickets: () => getMyTicketsMock(),
-  },
-}));
+const baseTicket = {
+  id: "TCK-001",
+  title: "No funciona la VPN",
+  status: "OPEN",
+  priority: "HIGH",
+  createdAt: "2026-03-01T10:00:00.000Z",
+  updatedAt: "2026-03-01T10:00:00.000Z",
+  createdByUserId: "user-1",
+  assignedToUserId: null,
+} as const;
 
 describe("UserTicketsHomePage", () => {
-  it("renders empty state when user has no tickets", async () => {
-    getMyTicketsMock.mockResolvedValueOnce({ items: [], page: 0, size: 20, total: 0 });
+  it("[TICKET-USER-03] muestra solo los tickets del usuario autenticado", async () => {
+    server.use(
+      http.get("/api/tickets/me", () =>
+        jsonResponse({
+          items: [baseTicket],
+          page: 0,
+          size: 20,
+          total: 1,
+        }),
+      ),
+    );
+
+    renderWithProviders(<UserTicketsHomePage />, { router: {} });
+
+    expect(await screen.findByRole("cell", { name: "TCK-001" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "No funciona la VPN" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Ver" })).toBeInTheDocument();
+  });
+
+  it("muestra loading state mientras la petición está en curso", async () => {
+    server.use(
+      http.get("/api/tickets/me", async () => {
+        await new Promise((resolve) => setTimeout(resolve, 120));
+        return jsonResponse({ items: [], page: 0, size: 20, total: 0 });
+      }),
+    );
+
+    const { container } = renderWithProviders(<UserTicketsHomePage />, { router: {} });
+
+    expect(container.querySelector(".ant-skeleton")).toBeInTheDocument();
+    expect(await screen.findByText("Aún no tienes tickets creados")).toBeInTheDocument();
+  });
+
+  it("muestra empty state cuando el usuario no tiene tickets", async () => {
+    server.use(
+      http.get("/api/tickets/me", () => jsonResponse({ items: [], page: 0, size: 20, total: 0 })),
+    );
 
     renderWithProviders(<UserTicketsHomePage />, { router: {} });
 
     expect(await screen.findByText("Aún no tienes tickets creados")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Crear ticket" })).toBeInTheDocument();
+  });
+
+  it("muestra error state cuando falla la carga", async () => {
+    server.use(http.get("/api/tickets/me", () => jsonResponse({ message: "boom" }, { status: 500 })));
+
+    renderWithProviders(<UserTicketsHomePage />, { router: {} });
+
+    expect(await screen.findByText("No hemos podido cargar tus tickets")).toBeInTheDocument();
+  });
+
+  it("[TICKET-USER-05] no muestra acciones de cambio de estado", async () => {
+    server.use(
+      http.get("/api/tickets/me", () =>
+        jsonResponse({
+          items: [baseTicket],
+          page: 0,
+          size: 20,
+          total: 1,
+        }),
+      ),
+    );
+
+    renderWithProviders(<UserTicketsHomePage />, { router: {} });
+
+    await screen.findByRole("cell", { name: "TCK-001" });
+    expect(screen.queryByRole("button", { name: /cambiar estado/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /resolver/i })).not.toBeInTheDocument();
   });
 });

--- a/ticketing-frontend/src/features/tickets/ui/ticketsPage/UserTicketsHomePage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/ticketsPage/UserTicketsHomePage.tsx
@@ -3,8 +3,9 @@ import { Alert, Button, Empty, Skeleton, Space, Table, Tag, Typography } from "a
 import type { TableProps } from "antd";
 import { useNavigate } from "react-router-dom";
 import { ticketsApi } from "../../api/ticketsApi";
-import { ticketPriorityLabel, ticketStatusColor, ticketStatusLabel } from "../../model/presentation";
+import { ticketPriorityLabel } from "../../model/presentation";
 import type { TicketPriority, TicketStatus, TicketSummary } from "../../model/types";
+import { TicketStatusBadge } from "../shared/TicketStatusBadge";
 
 type LoadState = "loading" | "ready" | "error";
 
@@ -71,7 +72,7 @@ export function UserTicketsHomePage() {
         width: 140,
         render: (statusValue: unknown) => {
           const status = statusValue as TicketStatus;
-          return <Tag color={ticketStatusColor[status]}>{ticketStatusLabel[status]}</Tag>;
+          return <TicketStatusBadge status={status} />;
         },
       },
       {

--- a/ticketing-frontend/src/shared/api/config.ts
+++ b/ticketing-frontend/src/shared/api/config.ts
@@ -1,4 +1,4 @@
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string;
+export const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? "";
 
 if (!API_BASE_URL) {
   // eslint-disable-next-line no-console

--- a/ticketing-frontend/src/test/msw/handlers.ts
+++ b/ticketing-frontend/src/test/msw/handlers.ts
@@ -1,5 +1,27 @@
-export type TestRequestHandler = {
-  name: string;
+export type MockedRequest = {
+  url: URL;
+  method: string;
+  headers: Headers;
+  body: unknown;
 };
 
-export const handlers: TestRequestHandler[] = [];
+export type MockedResponse = {
+  status?: number;
+  headers?: HeadersInit;
+  body?: BodyInit | null;
+};
+
+export type RequestHandler = (request: MockedRequest) => MockedResponse | undefined | Promise<MockedResponse | undefined>;
+
+export const handlers: RequestHandler[] = [];
+
+export function jsonResponse(body: unknown, init: Omit<MockedResponse, "body"> = {}): MockedResponse {
+  return {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+    body: JSON.stringify(body),
+  };
+}

--- a/ticketing-frontend/src/test/msw/http.ts
+++ b/ticketing-frontend/src/test/msw/http.ts
@@ -1,0 +1,17 @@
+import type { MockedRequest, MockedResponse, RequestHandler } from "./handlers";
+
+function createMethodHandler(method: string) {
+  return (path: string, resolver: (request: MockedRequest) => MockedResponse | undefined | Promise<MockedResponse | undefined>): RequestHandler => {
+    return (request) => {
+      if (request.method !== method) return undefined;
+      if (request.url.pathname !== path) return undefined;
+      return resolver(request);
+    };
+  };
+}
+
+export const http = {
+  get: createMethodHandler("GET"),
+  post: createMethodHandler("POST"),
+  patch: createMethodHandler("PATCH"),
+};

--- a/ticketing-frontend/src/test/msw/server.ts
+++ b/ticketing-frontend/src/test/msw/server.ts
@@ -4,7 +4,7 @@ type UnhandledRequestPolicy = "error" | "warn" | "bypass";
 
 const runtimeHandlers: RequestHandler[] = [];
 let initialHandlers: RequestHandler[] = [...handlers];
-let originalFetch: typeof global.fetch | undefined;
+let originalFetch: typeof globalThis.fetch | undefined;
 let onUnhandledRequest: UnhandledRequestPolicy = "error";
 
 async function toMockedRequest(input: RequestInfo | URL, init?: RequestInit): Promise<MockedRequest> {
@@ -32,9 +32,9 @@ export const server = {
     initialHandlers = [...handlers];
     runtimeHandlers.splice(0, runtimeHandlers.length, ...initialHandlers);
 
-    originalFetch = global.fetch.bind(global);
+    originalFetch = globalThis.fetch.bind(globalThis);
 
-    global.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
       const request = await toMockedRequest(input, init);
 
       for (const handler of runtimeHandlers) {
@@ -72,7 +72,7 @@ export const server = {
 
   close: () => {
     if (originalFetch) {
-      global.fetch = originalFetch;
+      globalThis.fetch = originalFetch;
     }
   },
 };

--- a/ticketing-frontend/src/test/msw/server.ts
+++ b/ticketing-frontend/src/test/msw/server.ts
@@ -1,15 +1,78 @@
-import { handlers } from "./handlers";
+import { handlers, type MockedRequest, type RequestHandler } from "./handlers";
 
 type UnhandledRequestPolicy = "error" | "warn" | "bypass";
 
+const runtimeHandlers: RequestHandler[] = [];
+let initialHandlers: RequestHandler[] = [...handlers];
+let originalFetch: typeof global.fetch | undefined;
+let onUnhandledRequest: UnhandledRequestPolicy = "error";
+
+async function toMockedRequest(input: RequestInfo | URL, init?: RequestInit): Promise<MockedRequest> {
+  const request = input instanceof Request ? input : new Request(input, init);
+  const contentType = request.headers.get("content-type");
+
+  let body: unknown = undefined;
+  if (contentType?.includes("application/json")) {
+    body = await request.clone().json();
+  } else if (request.method !== "GET" && request.method !== "HEAD") {
+    body = await request.clone().text();
+  }
+
+  return {
+    url: new URL(request.url),
+    method: request.method,
+    headers: request.headers,
+    body,
+  };
+}
+
 export const server = {
-  listen: (_options?: { onUnhandledRequest?: UnhandledRequestPolicy }) => {
-    void handlers;
+  listen: (options?: { onUnhandledRequest?: UnhandledRequestPolicy }) => {
+    onUnhandledRequest = options?.onUnhandledRequest ?? "error";
+    initialHandlers = [...handlers];
+    runtimeHandlers.splice(0, runtimeHandlers.length, ...initialHandlers);
+
+    originalFetch = global.fetch.bind(global);
+
+    global.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const request = await toMockedRequest(input, init);
+
+      for (const handler of runtimeHandlers) {
+        const mockedResponse = await handler(request);
+        if (mockedResponse) {
+          return new Response(mockedResponse.body, {
+            status: mockedResponse.status ?? 200,
+            headers: mockedResponse.headers,
+          });
+        }
+      }
+
+      if (onUnhandledRequest === "bypass") {
+        return originalFetch!(input, init);
+      }
+
+      const message = `Unhandled request: ${request.method} ${request.url.toString()}`;
+      if (onUnhandledRequest === "warn") {
+        // eslint-disable-next-line no-console
+        console.warn(message);
+        return originalFetch!(input, init);
+      }
+
+      throw new Error(message);
+    };
   },
+
+  use: (...nextHandlers: RequestHandler[]) => {
+    runtimeHandlers.unshift(...nextHandlers);
+  },
+
   resetHandlers: () => {
-    void handlers;
+    runtimeHandlers.splice(0, runtimeHandlers.length, ...initialHandlers);
   },
+
   close: () => {
-    void handlers;
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    }
   },
 };


### PR DESCRIPTION
### Motivation
- Añadir y consolidar tests co-localizados para las vistas principales de tickets para cubrir los escenarios de negocio señalados (usuario vs agent/admin) y los estados observables de la UI (loading/empty/error). 
- Usar un enfoque de mocks tipo MSW dentro de los tests para simular respuestas backend de forma mantenible sin convertirlo en E2E. 
- Aplicar pequeños ajustes de testabilidad cuando fuese necesario sin cambiar la estructura del frontend.

### Description
- Se añadió una capa de mocks inspirada en MSW para tests: `src/test/msw/handlers.ts`, `src/test/msw/server.ts` y `src/test/msw/http.ts`, con contratos `jsonResponse`, `server.use/resetHandlers/close` y helpers por método (`http.get|post|patch`).
- Se ampliaron y reescribieron los tests co-localizados de tickets: `UserTicketsHomePage.test.tsx` cubre `[TICKET-USER-03]`, loading/empty/error y `[TICKET-USER-05]`, y `AgentAdminTicketsPage.test.tsx` cubre `[TICKET-AGENT-03]`, lectura de query params/filtros, loading/empty/error y validación parcial de `[TICKET-AGENT-01]` (acciones actuales en UI). 
- Se mantuvo la validación del renderizado condicional por rol en `TicketsPage.test.tsx` y se adecuaron imports y utilidades de renderizado a `renderWithProviders` para mantener tests co-localizados. 
- Pequeño ajuste de configuración: `API_BASE_URL` ahora tiene fallback a `""` en `src/shared/api/config.ts` para evitar URLs inválidas en entorno de test.

