### PR TITLE
feat(frontend): bootstrap minimal Playwright E2E foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # To complete
 ticketing-backend/src/main/resources/keys/jwt-private.pem
 ticketing-backend/src/main/resources/keys/jwt-private.pem
+ticketing-frontend/playwright-report/
+ticketing-frontend/test-results/

--- a/ticketing-frontend/README.md
+++ b/ticketing-frontend/README.md
@@ -17,9 +17,9 @@ If you are developing a production application, we recommend updating the config
 
 ```js
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(["dist"]),
   {
-    files: ['**/*.{ts,tsx}'],
+    files: ["**/*.{ts,tsx}"],
     extends: [
       // Other configs...
 
@@ -34,40 +34,53 @@ export default defineConfig([
     ],
     languageOptions: {
       parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
+        project: ["./tsconfig.node.json", "./tsconfig.app.json"],
         tsconfigRootDir: import.meta.dirname,
       },
       // other options...
     },
   },
-])
+]);
 ```
 
 You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
 
 ```js
 // eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+import reactX from "eslint-plugin-react-x";
+import reactDom from "eslint-plugin-react-dom";
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(["dist"]),
   {
-    files: ['**/*.{ts,tsx}'],
+    files: ["**/*.{ts,tsx}"],
     extends: [
       // Other configs...
       // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
+      reactX.configs["recommended-typescript"],
       // Enable lint rules for React DOM
       reactDom.configs.recommended,
     ],
     languageOptions: {
       parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
+        project: ["./tsconfig.node.json", "./tsconfig.app.json"],
         tsconfigRootDir: import.meta.dirname,
       },
       // other options...
     },
   },
-])
+]);
 ```
+
+## E2E con Playwright (suite mínima)
+
+Este proyecto incluye una base E2E pequeña en `e2e/` con escenarios de alto valor alineados con IDs funcionales (`AUTH-01`, `TICKET-USER-01`, `TICKET-AGENT-03`, `ADMIN-01`).
+
+Comandos:
+
+```bash
+npm run test:e2e
+npm run test:e2e:headed
+```
+
+Guía rápida y variables de entorno: `e2e/README.md`.

--- a/ticketing-frontend/e2e/README.md
+++ b/ticketing-frontend/e2e/README.md
@@ -1,0 +1,36 @@
+# E2E mínimo con Playwright
+
+Esta carpeta contiene una suite E2E intencionalmente pequeña y orientada a valor:
+
+- `auth.spec.ts` → `AUTH-01`
+- `tickets-user.spec.ts` → `TICKET-USER-01`
+- `tickets-agent.spec.ts` → `TICKET-AGENT-03`
+- `admin.spec.ts` → `ADMIN-01` (se omite si no hay credenciales admin)
+
+## Requisitos locales
+
+1. Backend levantado y accesible.
+2. Frontend ejecutándose (por defecto en `http://127.0.0.1:4173` con `npm run preview`).
+3. Variables de entorno E2E (opcionales salvo admin):
+
+```bash
+export E2E_BASE_URL=http://127.0.0.1:4173
+export E2E_USER_EMAIL=user@local.test
+export E2E_USER_PASSWORD=password
+export E2E_AGENT_EMAIL=agent@local.test
+export E2E_AGENT_PASSWORD=password
+export E2E_ADMIN_EMAIL=admin@local.test
+export E2E_ADMIN_PASSWORD=password
+```
+
+## Ejecución
+
+```bash
+npm run test:e2e
+```
+
+Modo con navegador visible:
+
+```bash
+npm run test:e2e:headed
+```

--- a/ticketing-frontend/e2e/admin.spec.ts
+++ b/ticketing-frontend/e2e/admin.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "@playwright/test";
+import { loginAs } from "./fixtures/auth";
+import { hasAdminCredentials } from "./utils/env";
+
+test("ADMIN-01 admin puede listar usuarios", async ({ page }) => {
+  test.skip(!hasAdminCredentials(), "Define E2E_ADMIN_EMAIL y E2E_ADMIN_PASSWORD para ejecutar ADMIN-01.");
+
+  await loginAs(page, "admin");
+  await page.goto("/admin");
+
+  await expect(page.getByTestId("admin-title")).toBeVisible();
+  await page.getByRole("tab", { name: "Usuarios" }).click();
+  await expect(page.getByText("Email")).toBeVisible();
+});

--- a/ticketing-frontend/e2e/auth.spec.ts
+++ b/ticketing-frontend/e2e/auth.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "@playwright/test";
+import { loginAs } from "./fixtures/auth";
+
+test("AUTH-01 login correcto redirige al área autenticada", async ({ page }) => {
+  await loginAs(page, "user");
+
+  await expect(page).toHaveURL(/\/tickets$/);
+  await expect(page.getByTestId("user-tickets-title")).toBeVisible();
+});

--- a/ticketing-frontend/e2e/fixtures/auth.ts
+++ b/ticketing-frontend/e2e/fixtures/auth.ts
@@ -1,0 +1,18 @@
+import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { getCredentials } from "../utils/env";
+
+type Role = "user" | "agent" | "admin";
+
+export async function loginAs(page: Page, role: Role) {
+  const credentials = getCredentials(role);
+
+  await page.goto("/login");
+
+  await page.getByTestId("auth-email").fill(credentials.email);
+  await page.getByTestId("auth-password").fill(credentials.password);
+  await page.getByTestId("auth-submit").click();
+
+  await expect(page).not.toHaveURL(/\/login$/);
+  await expect(page.getByRole("button", { name: "Logout" })).toBeVisible();
+}

--- a/ticketing-frontend/e2e/tickets-agent.spec.ts
+++ b/ticketing-frontend/e2e/tickets-agent.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "@playwright/test";
+import { loginAs } from "./fixtures/auth";
+
+test("TICKET-AGENT-03 agente ve tickets gestionables", async ({ page }) => {
+  await loginAs(page, "agent");
+
+  await expect(page).toHaveURL(/\/tickets$/);
+  await expect(page.getByTestId("agent-tickets-title")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Sin asignar" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Asignados a mí" })).toBeVisible();
+});

--- a/ticketing-frontend/e2e/tickets-user.spec.ts
+++ b/ticketing-frontend/e2e/tickets-user.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+import { loginAs } from "./fixtures/auth";
+
+test("TICKET-USER-01 usuario crea ticket y llega al detalle", async ({ page }) => {
+  await loginAs(page, "user");
+  await page.getByTestId("user-create-ticket-cta").click();
+
+  await expect(page).toHaveURL(/\/tickets\/new$/);
+
+  const uniqueSuffix = Date.now();
+  await page.getByLabel("Título").fill(`E2E ticket ${uniqueSuffix}`);
+  await page.getByLabel("Descripción").fill("Flujo E2E mínimo para validar creación de ticket.");
+
+  await page.getByTestId("create-ticket-category").click();
+  await page.getByRole("option", { name: "General" }).click();
+  await page.getByTestId("create-ticket-submit").click();
+
+  await expect(page).toHaveURL(/\/tickets\/[0-9a-f-]+$/i);
+  await expect(page.getByText(`E2E ticket ${uniqueSuffix}`)).toBeVisible();
+});

--- a/ticketing-frontend/e2e/utils/env.ts
+++ b/ticketing-frontend/e2e/utils/env.ts
@@ -1,0 +1,30 @@
+type Role = "user" | "agent" | "admin";
+
+type Credentials = {
+  email: string;
+  password: string;
+};
+
+const credentialsByRole: Record<Role, Credentials> = {
+  user: {
+    email: process.env.E2E_USER_EMAIL ?? "user@local.test",
+    password: process.env.E2E_USER_PASSWORD ?? "password",
+  },
+  agent: {
+    email: process.env.E2E_AGENT_EMAIL ?? "agent@local.test",
+    password: process.env.E2E_AGENT_PASSWORD ?? "password",
+  },
+  admin: {
+    email: process.env.E2E_ADMIN_EMAIL ?? "",
+    password: process.env.E2E_ADMIN_PASSWORD ?? "",
+  },
+};
+
+export function getCredentials(role: Role): Credentials {
+  return credentialsByRole[role];
+}
+
+export function hasAdminCredentials() {
+  const admin = credentialsByRole.admin;
+  return Boolean(admin.email && admin.password);
+}

--- a/ticketing-frontend/package.json
+++ b/ticketing-frontend/package.json
@@ -13,7 +13,9 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "test:e2e": "npx playwright test",
+    "test:e2e:headed": "npx playwright test --headed"
   },
   "dependencies": {
     "antd": "^5.29.3",

--- a/ticketing-frontend/playwright.config.ts
+++ b/ticketing-frontend/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const baseURL = process.env.E2E_BASE_URL ?? "http://127.0.0.1:4173";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [["html", { open: "never" }], ["list"]] : "list",
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/ticketing-frontend/src/features/admin/ui/AdminPage.tsx
+++ b/ticketing-frontend/src/features/admin/ui/AdminPage.tsx
@@ -55,7 +55,8 @@ export function AdminPage() {
       {
         title: "Estado",
         key: "isActive",
-        render: (_: unknown, record: AdminCategory) => (record.isActive ? <Tag color="success">Activa</Tag> : <Tag>Inactiva</Tag>),
+        render: (_: unknown, record: AdminCategory) =>
+          record.isActive ? <Tag color="success">Activa</Tag> : <Tag>Inactiva</Tag>,
       },
       {
         title: "Acciones",
@@ -80,7 +81,12 @@ export function AdminPage() {
     () => [
       { title: "Nombre", dataIndex: "displayName", key: "displayName" },
       { title: "Email", dataIndex: "email", key: "email" },
-      { title: "Rol", dataIndex: "role", key: "role", render: (role: unknown) => <Tag>{String(role)}</Tag> },
+      {
+        title: "Rol",
+        dataIndex: "role",
+        key: "role",
+        render: (role: unknown) => <Tag>{String(role)}</Tag>,
+      },
       {
         title: "Activo",
         key: "isActive",
@@ -106,7 +112,7 @@ export function AdminPage() {
   return (
     <Space direction="vertical" size={16} style={{ width: "100%" }}>
       <Typography.Title level={3} style={{ margin: 0 }}>
-        Administración
+        <span data-testid="admin-title">Administración</span>
       </Typography.Title>
       <Typography.Text type="secondary">
         Gestiona categorías y usuarios de la plataforma. Solo los administradores tienen acceso.
@@ -120,7 +126,11 @@ export function AdminPage() {
             children: (
               <Space direction="vertical" size={16} style={{ width: "100%" }}>
                 <Space>
-                  <Input value={newCategoryName} onChange={(event) => setNewCategoryName(event.target.value)} placeholder="Nueva categoría" />
+                  <Input
+                    value={newCategoryName}
+                    onChange={(event) => setNewCategoryName(event.target.value)}
+                    placeholder="Nueva categoría"
+                  />
                   <Button
                     type="primary"
                     loading={creatingCategory}
@@ -134,7 +144,9 @@ export function AdminPage() {
                       setCreatingCategory(true);
                       try {
                         const created = await adminApi.createCategory(name);
-                        setCategories((prev) => [...prev, created].sort((a, b) => a.name.localeCompare(b.name)));
+                        setCategories((prev) =>
+                          [...prev, created].sort((a, b) => a.name.localeCompare(b.name)),
+                        );
                         setNewCategoryName("");
                         message.success("Categoría creada");
                       } catch {
@@ -148,14 +160,28 @@ export function AdminPage() {
                   </Button>
                 </Space>
 
-                <Table rowKey="id" loading={loadingCategories} dataSource={categories} columns={categoryColumns} pagination={false} />
+                <Table
+                  rowKey="id"
+                  loading={loadingCategories}
+                  dataSource={categories}
+                  columns={categoryColumns}
+                  pagination={false}
+                />
               </Space>
             ),
           },
           {
             key: "users",
             label: "Usuarios",
-            children: <Table rowKey="id" loading={loadingUsers} dataSource={users} columns={userColumns} pagination={false} />,
+            children: (
+              <Table
+                rowKey="id"
+                loading={loadingUsers}
+                dataSource={users}
+                columns={userColumns}
+                pagination={false}
+              />
+            ),
           },
         ]}
       />
@@ -180,7 +206,9 @@ export function AdminPage() {
               name,
               isActive: editingActive,
             });
-            setCategories((prev) => prev.map((category) => (category.id === updated.id ? updated : category)));
+            setCategories((prev) =>
+              prev.map((category) => (category.id === updated.id ? updated : category)),
+            );
             setEditingCategory(null);
             message.success("Categoría actualizada");
           } catch {
@@ -190,7 +218,11 @@ export function AdminPage() {
         okText="Guardar"
       >
         <Space direction="vertical" style={{ width: "100%" }}>
-          <Input value={editingName} onChange={(event) => setEditingName(event.target.value)} placeholder="Nombre" />
+          <Input
+            value={editingName}
+            onChange={(event) => setEditingName(event.target.value)}
+            placeholder="Nombre"
+          />
           <Space>
             <Typography.Text>Activa</Typography.Text>
             <Switch checked={editingActive} onChange={setEditingActive} />

--- a/ticketing-frontend/src/features/auth/ui/LoginPage.tsx
+++ b/ticketing-frontend/src/features/auth/ui/LoginPage.tsx
@@ -83,6 +83,7 @@ export function LoginPage() {
           <label>
             Email
             <input
+              data-testid="auth-email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               autoComplete="username"
@@ -106,6 +107,7 @@ export function LoginPage() {
           <label>
             Contraseña
             <input
+              data-testid="auth-password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               type="password"
@@ -127,7 +129,8 @@ export function LoginPage() {
                 />
               </label>
               <p className="auth-password-hint">
-                La contraseña debe tener mínimo 8 caracteres e incluir mayúsculas, minúsculas, número y símbolo.
+                La contraseña debe tener mínimo 8 caracteres e incluir mayúsculas, minúsculas,
+                número y símbolo.
               </p>
             </>
           )}
@@ -143,7 +146,12 @@ export function LoginPage() {
 
           {error && <p className="auth-error">{error}</p>}
 
-          <button type="submit" disabled={loading} className="auth-submit">
+          <button
+            type="submit"
+            disabled={loading}
+            className="auth-submit"
+            data-testid="auth-submit"
+          >
             {submitText}
           </button>
         </form>

--- a/ticketing-frontend/src/features/tickets/ui/create/CreateTicketPage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/create/CreateTicketPage.tsx
@@ -39,7 +39,9 @@ export function CreateTicketPage() {
         setCategories(loadedCategories);
       } catch (error) {
         if (!isMounted) return;
-        setErrorMessage(error instanceof Error ? error.message : "No se pudieron cargar las categorías.");
+        setErrorMessage(
+          error instanceof Error ? error.message : "No se pudieron cargar las categorías.",
+        );
       } finally {
         if (isMounted) {
           setIsLoadingCategories(false);
@@ -84,7 +86,9 @@ export function CreateTicketPage() {
           Crear ticket
         </Typography.Title>
 
-        {errorMessage && <Alert showIcon type="error" message="Error al crear ticket" description={errorMessage} />}
+        {errorMessage && (
+          <Alert showIcon type="error" message="Error al crear ticket" description={errorMessage} />
+        )}
 
         <Form layout="vertical" onFinish={handleSubmit}>
           <Space direction="vertical" size={16} style={{ width: "100%" }}>
@@ -111,6 +115,7 @@ export function CreateTicketPage() {
 
             <Form.Item label="Categoría" style={{ marginBottom: 0 }}>
               <Select
+                data-testid="create-ticket-category"
                 aria-label="Categoría"
                 value={categoryId || undefined}
                 onChange={(value) => setCategoryId(value)}
@@ -133,6 +138,7 @@ export function CreateTicketPage() {
             </Form.Item>
 
             <Button
+              data-testid="create-ticket-submit"
               type="primary"
               htmlType="submit"
               loading={isSubmitting}

--- a/ticketing-frontend/src/features/tickets/ui/ticketsPage/AgentAdminTicketsPage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/ticketsPage/AgentAdminTicketsPage.tsx
@@ -1,10 +1,27 @@
-import { Alert, Button, Card, Empty, Input, Select, Skeleton, Space, Table, Tag, Typography } from "antd";
+import {
+  Alert,
+  Button,
+  Card,
+  Empty,
+  Input,
+  Select,
+  Skeleton,
+  Space,
+  Table,
+  Tag,
+  Typography,
+} from "antd";
 import type { TableProps } from "antd";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { ticketsApi } from "../../api/ticketsApi";
 import { ticketPriorityLabel } from "../../model/presentation";
-import type { TicketPriority, TicketQueueScope, TicketStatus, TicketSummary } from "../../model/types";
+import type {
+  TicketPriority,
+  TicketQueueScope,
+  TicketStatus,
+  TicketSummary,
+} from "../../model/types";
 import { TicketStatusBadge } from "../shared/TicketStatusBadge";
 
 type QueueView = "unassigned" | "mine" | "all";
@@ -53,7 +70,9 @@ export function AgentAdminTicketsPage() {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const [view, setView] = useState<QueueView>(() => toQueueView(searchParams.get("view")));
-  const [statusFilter, setStatusFilter] = useState<QueueFilter>(() => toStatusFilter(searchParams.get("status")));
+  const [statusFilter, setStatusFilter] = useState<QueueFilter>(() =>
+    toStatusFilter(searchParams.get("status")),
+  );
   const [query, setQuery] = useState<string>(() => searchParams.get("q") ?? "");
   const [inputQuery, setInputQuery] = useState<string>(() => searchParams.get("q") ?? "");
   const [loadState, setLoadState] = useState<LoadState>("loading");
@@ -94,7 +113,9 @@ export function AgentAdminTicketsPage() {
         if (!isMounted) return;
 
         setLoadState("error");
-        setErrorMessage(error instanceof Error ? error.message : "No se pudo cargar la cola de tickets.");
+        setErrorMessage(
+          error instanceof Error ? error.message : "No se pudo cargar la cola de tickets.",
+        );
       }
     };
 
@@ -123,7 +144,9 @@ export function AgentAdminTicketsPage() {
         dataIndex: "priority",
         key: "priority",
         width: 120,
-        render: (priorityValue: unknown) => <Tag>{ticketPriorityLabel[priorityValue as TicketPriority]}</Tag>,
+        render: (priorityValue: unknown) => (
+          <Tag>{ticketPriorityLabel[priorityValue as TicketPriority]}</Tag>
+        ),
       },
       {
         title: "Asignado",
@@ -178,43 +201,60 @@ export function AgentAdminTicketsPage() {
   return (
     <Space direction="vertical" size={16} style={{ width: "100%" }}>
       <Typography.Title level={3} style={{ margin: 0 }}>
-        Gestión de tickets
+        <span data-testid="agent-tickets-title">Gestión de tickets</span>
       </Typography.Title>
 
       <Space style={{ display: "grid", gridTemplateColumns: "repeat(4, minmax(0, 1fr))" }}>
         <Card>
           <Typography.Text type="secondary">Sin asignar (vista)</Typography.Text>
-          <Typography.Title level={3} style={{ margin: "8px 0 0" }}>{unassignedCount}</Typography.Title>
+          <Typography.Title level={3} style={{ margin: "8px 0 0" }}>
+            {unassignedCount}
+          </Typography.Title>
         </Card>
         <Card>
           <Typography.Text type="secondary">Total (vista)</Typography.Text>
-          <Typography.Title level={3} style={{ margin: "8px 0 0" }}>{total}</Typography.Title>
+          <Typography.Title level={3} style={{ margin: "8px 0 0" }}>
+            {total}
+          </Typography.Title>
         </Card>
         <Card>
           <Typography.Text type="secondary">En progreso (vista)</Typography.Text>
-          <Typography.Title level={3} style={{ margin: "8px 0 0" }}>{inProgressCount}</Typography.Title>
+          <Typography.Title level={3} style={{ margin: "8px 0 0" }}>
+            {inProgressCount}
+          </Typography.Title>
         </Card>
         <Card>
           <Typography.Text type="secondary">Scope actual</Typography.Text>
-          <Typography.Title level={3} style={{ margin: "8px 0 0" }}>{queueScopeFromView(view)}</Typography.Title>
+          <Typography.Title level={3} style={{ margin: "8px 0 0" }}>
+            {queueScopeFromView(view)}
+          </Typography.Title>
         </Card>
       </Space>
 
       <Space>
-        <Button type={view === "unassigned" ? "primary" : "default"} onClick={() => setView("unassigned")}>Sin asignar</Button>
-        <Button type={view === "mine" ? "primary" : "default"} onClick={() => setView("mine")}>Asignados a mí</Button>
-        <Button type={view === "all" ? "primary" : "default"} onClick={() => setView("all")}>Todos</Button>
+        <Button
+          type={view === "unassigned" ? "primary" : "default"}
+          onClick={() => setView("unassigned")}
+        >
+          Sin asignar
+        </Button>
+        <Button type={view === "mine" ? "primary" : "default"} onClick={() => setView("mine")}>
+          Asignados a mí
+        </Button>
+        <Button type={view === "all" ? "primary" : "default"} onClick={() => setView("all")}>
+          Todos
+        </Button>
       </Space>
 
       <Card>
         <Space>
           <Select
-              aria-label="Estado"
-              value={statusFilter}
-              onChange={(value) => setStatusFilter(value as QueueFilter)}
-              options={statusFilterOptions}
-              style={{ minWidth: 220 }}
-            />
+            aria-label="Estado"
+            value={statusFilter}
+            onChange={(value) => setStatusFilter(value as QueueFilter)}
+            options={statusFilterOptions}
+            style={{ minWidth: 220 }}
+          />
           <Input
             value={inputQuery}
             onChange={(event) => setInputQuery(event.target.value)}
@@ -247,7 +287,12 @@ export function AgentAdminTicketsPage() {
           )}
 
           {loadState === "ready" && tickets.length > 0 && (
-            <Table<TicketSummary> rowKey="id" columns={columns} dataSource={tickets} pagination={{ pageSize: 10 }} />
+            <Table<TicketSummary>
+              rowKey="id"
+              columns={columns}
+              dataSource={tickets}
+              pagination={{ pageSize: 10 }}
+            />
           )}
         </Space>
       </Card>

--- a/ticketing-frontend/src/features/tickets/ui/ticketsPage/UserTicketsHomePage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/ticketsPage/UserTicketsHomePage.tsx
@@ -40,7 +40,9 @@ export function UserTicketsHomePage() {
         if (!isMounted) return;
 
         setLoadState("error");
-        setErrorMessage(error instanceof Error ? error.message : "No se pudieron cargar tus tickets.");
+        setErrorMessage(
+          error instanceof Error ? error.message : "No se pudieron cargar tus tickets.",
+        );
       }
     };
 
@@ -80,7 +82,9 @@ export function UserTicketsHomePage() {
         dataIndex: "priority",
         key: "priority",
         width: 120,
-        render: (priorityValue: unknown) => <Tag>{ticketPriorityLabel[priorityValue as TicketPriority]}</Tag>,
+        render: (priorityValue: unknown) => (
+          <Tag>{ticketPriorityLabel[priorityValue as TicketPriority]}</Tag>
+        ),
       },
       {
         title: "Fecha creación",
@@ -108,9 +112,14 @@ export function UserTicketsHomePage() {
     <Space direction="vertical" size={20} style={{ width: "100%" }}>
       <Space style={{ width: "100%", justifyContent: "space-between" }}>
         <Typography.Title level={3} style={{ margin: 0 }}>
-          Mis tickets
+          <span data-testid="user-tickets-title">Mis tickets</span>
         </Typography.Title>
-        <Button type="primary" size="large" onClick={() => navigate("/tickets/new")}>
+        <Button
+          data-testid="user-create-ticket-cta"
+          type="primary"
+          size="large"
+          onClick={() => navigate("/tickets/new")}
+        >
           Crear ticket
         </Button>
       </Space>


### PR DESCRIPTION
### Motivation

- Introducir una suite E2E mínima y estable con Playwright para validar recorridos completos clave y dejar la base preparada para integrarlo en CI/CD sin crear una batería frágil.

### Description

- Añadida configuración de Playwright en `ticketing-frontend/playwright.config.ts` y scripts NPM `test:e2e`/`test:e2e:headed` en `ticketing-frontend/package.json` para ejecutar la suite.
- Creada la estructura E2E en `ticketing-frontend/e2e/` con escenarios de alto valor: `auth.spec.ts` (`AUTH-01`), `tickets-user.spec.ts` (`TICKET-USER-01`), `tickets-agent.spec.ts` (`TICKET-AGENT-03`) y `admin.spec.ts` (`ADMIN-01`, con `skip` condicional cuando no hay credenciales).
- Añadidos helpers reutilizables `e2e/fixtures/auth.ts` y `e2e/utils/env.ts` para login por rol y gestión de credenciales por entorno, y documentación mínima en `ticketing-frontend/e2e/README.md` y referencia en el `ticketing-frontend/README.md`.
- Introducidos `data-testid` y selectores estables en puntos clave del frontend (`LoginPage`, `CreateTicketPage`, `UserTicketsHomePage`, `AgentAdminTicketsPage`, `AdminPage`) para minimizar fragilidad de los tests, y añadido `.gitignore` para artefactos de Playwright.

