### PR TITLE
chore(devops): establish initial CI/CD and traceability foundations

### DIFF
--- a/docs/devops/cicd-strategy.md
+++ b/docs/devops/cicd-strategy.md
@@ -1,0 +1,134 @@
+# Estrategia CI/CD del proyecto Ticketing (TFG)
+
+## 1. Propósito del documento
+Este documento define la estrategia base de **Integración Continua (CI)** y **Entrega/Despliegue Continuo (CD)** para el monorepo del TFG (`ticketing-backend` + `ticketing-frontend`). Su objetivo es dejar criterios técnicos claros, reproducibles y auditables antes de implementar los workflows completos.
+
+## 2. CI vs CD aplicado a este proyecto
+
+### CI (Integración Continua)
+En este TFG, CI valida automáticamente la calidad técnica de cada cambio antes de integrar código en `main`:
+- ejecución de tests,
+- control de calidad estática,
+- verificación de build,
+- y trazabilidad funcional mínima entre escenarios y pruebas.
+
+### CD (Entrega/Despliegue Continuo)
+CD automatizará el despliegue a un entorno ejecutable tras superar CI. En esta fase inicial se deja definida la estrategia, pero la automatización se implementará en un lote posterior.
+
+## 3. Justificación de la fase DevOps después de la fase de testing
+Se prioriza primero la fase de testing porque CI/CD solo aporta valor si existe una base de validación fiable.
+
+En este proyecto ya existen pruebas en backend y frontend, por lo que la fase DevOps se aborda ahora para:
+1. convertir validaciones manuales en validaciones automáticas,
+2. mantener consistencia de calidad por PR,
+3. y generar evidencia defendible en la memoria del TFG (qué se valida, cuándo y con qué herramientas).
+
+## 4. Validaciones objetivo para CI
+La CI del monorepo debe automatizar, como mínimo, las siguientes comprobaciones:
+
+1. **Backend unit tests**
+   - Ejecución de pruebas unitarias de Spring Boot/Maven.
+   - Validan lógica de dominio y casos de uso.
+
+2. **Backend integration tests**
+   - Ejecución de pruebas de integración API/infra en backend.
+   - Confirman contratos principales y comportamiento extremo a extremo dentro del servicio.
+
+3. **Frontend lint / format**
+   - Linting y validación de formato en React + TypeScript.
+   - Previene deuda técnica y divergencias de estilo.
+
+4. **Frontend unit/UI tests**
+   - Ejecución de pruebas unitarias y de componentes.
+   - Asegura comportamiento funcional de UI y flujos críticos.
+
+5. **Frontend build**
+   - Compilación de producción con Vite.
+   - Detecta roturas de tipado, bundling o dependencias.
+
+6. **Trazabilidad**
+   - Comprobación automática de referencias a IDs funcionales (`AUTH-*`, `TICKET-*`, `ADMIN-*`) en pruebas backend/frontend/E2E.
+   - No bloqueante en el primer lote (modo scaffold), pero con reporte persistente para auditoría.
+
+7. **SonarCloud**
+   - Análisis estático y calidad global del monorepo desde CI.
+   - Integración de cobertura backend (JaCoCo fusionado) y extensión futura para cobertura frontend.
+
+## 5. Automatizaciones objetivo para CD
+
+### 5.1 Staging desde `main`
+- Despliegue automático a `staging` tras merge en `main` y superación de validaciones previas.
+- Entorno pensado para validar integración real de frontend + backend ya desplegados.
+
+### 5.2 Smoke checks post-deploy
+- Comprobaciones básicas de disponibilidad y sanidad funcional tras despliegue (por ejemplo, health endpoints y carga mínima de frontend).
+- Objetivo: detectar fallos de despliegue antes de considerar el entorno estable.
+
+### 5.3 Producción (fase posterior)
+- La promoción a `production` se aplaza a una fase siguiente.
+- Se recomienda enfoque progresivo: primero estabilizar staging y observabilidad, luego formalizar puertas de promoción a producción.
+
+## 6. Filosofía de quality gates
+Los quality gates del proyecto deben ser **pragmáticos pero exigentes**:
+
+1. **Tests significativos**: no solo cantidad; priorizar cobertura de reglas de negocio y flujos críticos.
+2. **Trazabilidad ligera**: enlazar escenarios funcionales con evidencia de test sin añadir burocracia excesiva.
+3. **Análisis estático**: mantener estándares consistentes de mantenibilidad y detectar issues temprano.
+4. **Seguridad básica**: análisis automatizado de dependencias y código para reducir riesgos evidentes.
+
+## 7. Estrategia de ramas recomendada
+
+- **`main` protegida**
+  - Sin pushes directos.
+  - Integración únicamente vía Pull Request.
+
+- **Feature branches**
+  - Trabajo aislado por cambio (`feature/*`, `fix/*`, etc.).
+  - Permiten CI por rama antes de proponer merge.
+
+- **PR obligatoria**
+  - Revisión mínima + checks automáticos obligatorios para merge.
+  - Garantiza trazabilidad técnica de decisiones y cambios.
+
+## 8. Papel de cada herramienta
+
+1. **GitHub Actions**
+   - Orquestador de CI/CD.
+   - Ejecuta jobs de tests, build, calidad y despliegue.
+
+2. **SonarCloud**
+   - Calidad estática centralizada y quality gate global.
+   - Aporta métricas comparables a lo largo del TFG.
+
+3. **Dependabot**
+   - Actualización automatizada de dependencias.
+   - Reduce riesgo de vulnerabilidades por librerías obsoletas.
+
+4. **CodeQL**
+   - Análisis de seguridad del código en repositorio.
+   - Complementa SonarCloud con foco específico en patrones de vulnerabilidad.
+
+5. **GitHub Environments (`staging`, `production`)**
+   - Separación explícita de secretos, reglas y aprobaciones por entorno.
+   - Base para despliegues controlados.
+
+## 9. Por qué separar workflows en varios ficheros
+Se recomienda dividir workflows por responsabilidad en lugar de concentrarlo todo en un único YAML:
+
+- `ci-*`: validación de código y tests,
+- `quality-*`: análisis estático/seguridad,
+- `deploy-*`: despliegues por entorno.
+
+Ventajas para el TFG:
+- menor acoplamiento y mayor mantenibilidad,
+- tiempos de ejecución más previsibles,
+- diagnóstico de fallos más rápido,
+- y explicación académica más clara de cada fase.
+
+## 10. Enfoque pragmático para un TFG
+Esta estrategia prioriza:
+1. **Sencillez**: diseño entendible y operable por una sola persona.
+2. **Reproducibilidad**: mismas validaciones en local y CI cuando sea posible.
+3. **Valor académico**: evidencias objetivas de calidad, trazabilidad y control de cambios.
+
+Con este enfoque, el TFG evita tanto la infra-automatización (manual, frágil) como la sobre-ingeniería (complejidad innecesaria para su alcance).

--- a/docs/devops/environments-and-secrets.md
+++ b/docs/devops/environments-and-secrets.md
@@ -1,0 +1,91 @@
+# Entornos y gestión de secretos (GitHub)
+
+## 1. Objetivo del documento
+Definir una estrategia operativa, simple y segura para gestionar **entornos** y **secrets** en la fase DevOps del TFG, minimizando errores de configuración y preparando la futura automatización de CI/CD.
+
+## 2. Entornos propuestos
+
+## `staging`
+Entorno de validación continua:
+- destino inicial de despliegues automáticos desde `main`,
+- usado para comprobaciones funcionales básicas post-deploy,
+- permite detectar problemas de integración antes de producción.
+
+## `production`
+Entorno final de servicio:
+- reservado para una fase posterior,
+- requiere mayor control (aprobaciones, ventanas de despliegue y smoke checks más estrictos).
+
+## 3. Papel de cada entorno
+- **staging**: validar que la versión integrada funciona fuera de local y recoger incidencias tempranas.
+- **production**: servir versión estable con controles de riesgo superiores.
+
+Separar ambos entornos evita mezclar secretos, URLs y políticas de despliegue.
+
+## 4. Secretos a nivel repositorio vs nivel environment
+
+## Secretos de repositorio (Repository secrets)
+Usar este nivel para secretos realmente globales al repositorio y no dependientes del entorno.
+
+Recomendado inicialmente:
+- `SONAR_TOKEN` (si el mismo token aplica a todo el repositorio y no cambia por entorno).
+
+## Secretos de entorno (Environment secrets)
+Usar `staging` y `production` para todo valor que cambie según destino.
+
+Recomendado:
+- `BACKEND_DEPLOY_HOOK_URL`
+- `FRONTEND_DEPLOY_HOOK_URL`
+- `BACKEND_BASE_URL`
+- `FRONTEND_BASE_URL`
+
+## 5. Convención de nombres
+Mantener **la misma clave en ambos entornos** y cambiar solo el valor por environment.
+
+Ejemplo correcto:
+- `staging.BACKEND_BASE_URL = https://staging-api...`
+- `production.BACKEND_BASE_URL = https://api...`
+
+Evitar sufijos como `_STAGING` / `_PROD` porque incrementan complejidad, duplican variables y dificultan el mantenimiento de workflows.
+
+## 6. Lista inicial sugerida de secrets
+
+### Base (arranque CI/CD)
+- `SONAR_TOKEN`
+- `BACKEND_DEPLOY_HOOK_URL`
+- `FRONTEND_DEPLOY_HOOK_URL`
+- `BACKEND_BASE_URL`
+- `FRONTEND_BASE_URL`
+
+### Opcionales futuros para E2E
+Cuando se automaticen pruebas E2E contra entornos desplegados, se pueden añadir credenciales de usuarios de prueba por rol:
+- `E2E_USER_EMAIL` / `E2E_USER_PASSWORD`
+- `E2E_AGENT_EMAIL` / `E2E_AGENT_PASSWORD`
+- `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD`
+
+(Usar cuentas no personales, con permisos mínimos y datos de prueba.)
+
+## 7. Buenas prácticas operativas
+1. **No commitear secretos** en código, `.env` versionados o documentación pública.
+2. **No duplicar valores sin necesidad**: si un valor es igual para ambos entornos, justificar su nivel (repo o environment).
+3. **No almacenar credenciales de base de datos en GitHub** si ya están gestionadas por la plataforma de despliegue.
+4. **Usar GitHub Environments** para separar claramente `staging` y `production` (secretos, protección y auditoría).
+5. **Aplicar mínimo privilegio** a tokens y cuentas técnicas.
+6. **Rotar secretos** cuando haya sospecha de exposición o cambios de equipo.
+
+## 8. Checklist manual posterior
+Antes de activar workflows de despliegue, verificar:
+
+- [ ] Existe environment `staging`.
+- [ ] Existe environment `production`.
+- [ ] `SONAR_TOKEN` está configurado en el nivel acordado.
+- [ ] En `staging` están definidos:
+  - [ ] `BACKEND_DEPLOY_HOOK_URL`
+  - [ ] `FRONTEND_DEPLOY_HOOK_URL`
+  - [ ] `BACKEND_BASE_URL`
+  - [ ] `FRONTEND_BASE_URL`
+- [ ] En `production` están definidos los mismos nombres de secrets con valores de producción.
+- [ ] No hay secretos sensibles hardcodeados en el repositorio.
+- [ ] Se ha validado quién puede aprobar despliegues a `production`.
+
+Este checklist permite arrancar la siguiente fase (workflows CI/CD y deploy) con una base consistente y sin bloqueos de configuración.

--- a/scripts/traceability/check-traceability.mjs
+++ b/scripts/traceability/check-traceability.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const ROOT_DIR = process.cwd();
+const FEATURE_DIR = path.join(ROOT_DIR, 'docs', 'features');
+const OUTPUT_DIR = path.join(ROOT_DIR, 'artifacts', 'traceability');
+const OUTPUT_JSON = path.join(OUTPUT_DIR, 'traceability-report.json');
+const OUTPUT_MD = path.join(OUTPUT_DIR, 'traceability-report.md');
+
+const SEARCH_TARGETS = {
+  backend: {
+    label: 'Backend tests',
+    baseDir: path.join(ROOT_DIR, 'ticketing-backend', 'src', 'test'),
+    include: (filePath) => /\.(java|kt|groovy)$/i.test(filePath),
+  },
+  frontendUi: {
+    label: 'Frontend unit/UI tests',
+    baseDir: path.join(ROOT_DIR, 'ticketing-frontend', 'src'),
+    include: (filePath) => /\.(test|spec)\.(t|j)sx?$/i.test(filePath),
+  },
+  e2e: {
+    label: 'Frontend E2E',
+    baseDir: path.join(ROOT_DIR, 'ticketing-frontend', 'e2e'),
+    include: (filePath) => /\.spec\.(t|j)sx?$/i.test(filePath),
+  },
+};
+
+const SCENARIO_ID_REGEX = /\b[A-Z]+(?:-[A-Z]+)*-\d{2}\b/g;
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+async function safeReadDir(dir) {
+  try {
+    return await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+async function walkFiles(baseDir, includeFn) {
+  const collected = [];
+
+  async function walk(currentDir) {
+    const entries = await safeReadDir(currentDir);
+
+    for (const entry of entries) {
+      const resolved = path.join(currentDir, entry.name);
+
+      if (entry.isDirectory()) {
+        await walk(resolved);
+        continue;
+      }
+
+      if (!entry.isFile()) {
+        continue;
+      }
+
+      if (includeFn(resolved)) {
+        collected.push(resolved);
+      }
+    }
+  }
+
+  await walk(baseDir);
+  return collected;
+}
+
+async function loadFeatureScenarios() {
+  const featureFiles = (await safeReadDir(FEATURE_DIR))
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.feature'))
+    .map((entry) => path.join(FEATURE_DIR, entry.name));
+
+  const scenarios = new Map();
+
+  for (const featureFile of featureFiles) {
+    const content = await fs.readFile(featureFile, 'utf-8');
+    const matches = content.match(SCENARIO_ID_REGEX) ?? [];
+
+    for (const id of matches) {
+      if (!scenarios.has(id)) {
+        scenarios.set(id, {
+          id,
+          featureExists: true,
+          featureFile: path.relative(ROOT_DIR, featureFile),
+        });
+      }
+    }
+  }
+
+  return {
+    featureFilesCount: featureFiles.length,
+    scenarios: [...scenarios.values()].sort((a, b) => a.id.localeCompare(b.id)),
+  };
+}
+
+async function findReferencesById(ids, target) {
+  const files = await walkFiles(target.baseDir, target.include);
+  const occurrences = new Map(ids.map((id) => [id, []]));
+
+  for (const filePath of files) {
+    const text = await fs.readFile(filePath, 'utf-8').catch(() => '');
+    if (!text) continue;
+
+    for (const id of ids) {
+      const pattern = new RegExp(`\\b${escapeRegExp(id)}\\b`);
+      if (pattern.test(text)) {
+        occurrences.get(id).push(path.relative(ROOT_DIR, filePath));
+      }
+    }
+  }
+
+  return {
+    filesScanned: files.length,
+    occurrences,
+  };
+}
+
+function resolveStatus(layers) {
+  const matchedLayers = [layers.backend, layers.frontendUi, layers.e2e].filter(Boolean).length;
+
+  if (matchedLayers === 0) return 'NOT_REFERENCED';
+  if (matchedLayers === 3) return 'MULTI_LAYER';
+  return 'PARTIAL';
+}
+
+function buildMarkdown(report) {
+  const lines = [];
+  lines.push('# Traceability report');
+  lines.push('');
+  lines.push(`Generated at: ${report.timestamp}`);
+  lines.push('');
+  lines.push('| Scenario ID | Feature | Backend | Frontend UI | E2E | Status |');
+  lines.push('| --- | --- | --- | --- | --- | --- |');
+
+  for (const scenario of report.scenarios) {
+    lines.push(
+      `| ${scenario.id} | ${scenario.featureExists ? '✅' : '❌'} | ${scenario.backend ? '✅' : '❌'} | ${scenario.frontendUi ? '✅' : '❌'} | ${scenario.e2e ? '✅' : '❌'} | ${scenario.status} |`,
+    );
+  }
+
+  lines.push('');
+  lines.push('## Summary');
+  lines.push(`- Total scenarios: **${report.counters.totalScenarios}**`);
+  lines.push(`- NOT_REFERENCED: **${report.counters.NOT_REFERENCED}**`);
+  lines.push(`- PARTIAL: **${report.counters.PARTIAL}**`);
+  lines.push(`- MULTI_LAYER: **${report.counters.MULTI_LAYER}**`);
+
+  return `${lines.join('\n')}\n`;
+}
+
+async function main() {
+  const timestamp = new Date().toISOString();
+  const { featureFilesCount, scenarios } = await loadFeatureScenarios();
+  const scenarioIds = scenarios.map((scenario) => scenario.id);
+
+  const backendResult = await findReferencesById(scenarioIds, SEARCH_TARGETS.backend);
+  const frontendUiResult = await findReferencesById(scenarioIds, SEARCH_TARGETS.frontendUi);
+  const e2eResult = await findReferencesById(scenarioIds, SEARCH_TARGETS.e2e);
+
+  const enriched = scenarios.map((scenario) => {
+    const backendMatches = backendResult.occurrences.get(scenario.id) ?? [];
+    const frontendUiMatches = frontendUiResult.occurrences.get(scenario.id) ?? [];
+    const e2eMatches = e2eResult.occurrences.get(scenario.id) ?? [];
+
+    const backend = backendMatches.length > 0;
+    const frontendUi = frontendUiMatches.length > 0;
+    const e2e = e2eMatches.length > 0;
+    const status = resolveStatus({ backend, frontendUi, e2e });
+
+    return {
+      ...scenario,
+      backend,
+      frontendUi,
+      e2e,
+      status,
+      references: {
+        backend: backendMatches,
+        frontendUi: frontendUiMatches,
+        e2e: e2eMatches,
+      },
+    };
+  });
+
+  const counters = {
+    totalScenarios: enriched.length,
+    NOT_REFERENCED: enriched.filter((entry) => entry.status === 'NOT_REFERENCED').length,
+    PARTIAL: enriched.filter((entry) => entry.status === 'PARTIAL').length,
+    MULTI_LAYER: enriched.filter((entry) => entry.status === 'MULTI_LAYER').length,
+  };
+
+  const report = {
+    timestamp,
+    metadata: {
+      featureDirectory: path.relative(ROOT_DIR, FEATURE_DIR),
+      featureFilesCount,
+      scanned: {
+        backendFiles: backendResult.filesScanned,
+        frontendUiFiles: frontendUiResult.filesScanned,
+        e2eFiles: e2eResult.filesScanned,
+      },
+      mode: {
+        strict: false,
+        note: 'Scaffold mode: does not fail process on partial coverage.',
+      },
+    },
+    counters,
+    scenarios: enriched,
+  };
+
+  await fs.mkdir(OUTPUT_DIR, { recursive: true });
+  await fs.writeFile(OUTPUT_JSON, `${JSON.stringify(report, null, 2)}\n`, 'utf-8');
+  await fs.writeFile(OUTPUT_MD, buildMarkdown(report), 'utf-8');
+
+  console.log('Traceability scaffold report generated.');
+  console.log(`- Scenarios: ${report.counters.totalScenarios}`);
+  console.log(`- NOT_REFERENCED: ${report.counters.NOT_REFERENCED}`);
+  console.log(`- PARTIAL: ${report.counters.PARTIAL}`);
+  console.log(`- MULTI_LAYER: ${report.counters.MULTI_LAYER}`);
+  console.log(`- JSON: ${path.relative(ROOT_DIR, OUTPUT_JSON)}`);
+  console.log(`- Markdown: ${path.relative(ROOT_DIR, OUTPUT_MD)}`);
+}
+
+main().catch((error) => {
+  console.error('Unexpected error while generating traceability report (non-blocking scaffold):');
+  console.error(error);
+  process.exitCode = 0;
+});

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,45 @@
+# SonarCloud configuration for CI-based analysis in this monorepo.
+# Replace placeholders below with your real SonarCloud identifiers.
+sonar.organization=YOUR_SONARCLOUD_ORGANIZATION
+sonar.projectKey=YOUR_SONARCLOUD_PROJECT_KEY
+
+sonar.projectName=tfg-ticketing-devops
+sonar.sourceEncoding=UTF-8
+
+# Monorepo sources (backend + frontend)
+sonar.sources=ticketing-backend/src/main,ticketing-frontend/src
+sonar.tests=ticketing-backend/src/test,ticketing-frontend/src,ticketing-frontend/e2e
+
+# Test file patterns
+sonar.test.inclusions=\
+  ticketing-backend/src/test/**/*,\
+  ticketing-frontend/src/**/*.test.ts,\
+  ticketing-frontend/src/**/*.test.tsx,\
+  ticketing-frontend/src/**/*.spec.ts,\
+  ticketing-frontend/src/**/*.spec.tsx,\
+  ticketing-frontend/e2e/**/*.spec.ts
+
+# Backend coverage (JaCoCo merged report)
+sonar.coverage.jacoco.xmlReportPaths=ticketing-backend/target/site/jacoco-merged/jacoco.xml
+
+# Frontend coverage (future phase):
+# sonar.javascript.lcov.reportPaths=ticketing-frontend/coverage/lcov.info
+
+# Exclude generated artifacts and build outputs
+sonar.exclusions=\
+  **/node_modules/**,\
+  **/dist/**,\
+  **/playwright-report/**,\
+  **/test-results/**,\
+  **/coverage/**,\
+  ticketing-backend/target/**,\
+  ticketing-frontend/target/**
+
+# Ignore generated coverage reports and artifacts in test execution detection too
+sonar.test.exclusions=\
+  **/node_modules/**,\
+  **/dist/**,\
+  **/playwright-report/**,\
+  **/test-results/**,\
+  **/coverage/**,\
+  **/target/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,6 @@
 # SonarCloud configuration for CI-based analysis in this monorepo.
-# Replace placeholders below with your real SonarCloud identifiers.
-sonar.organization=YOUR_SONARCLOUD_ORGANIZATION
-sonar.projectKey=YOUR_SONARCLOUD_PROJECT_KEY
+sonar.organization=SONAR_PROJECT_KEY
+sonar.projectKey=SONAR_ORGANIZATION_KEY
 
 sonar.projectName=tfg-ticketing-devops
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
### Motivation
- Preparar la base mínima de configuración, documentación y trazabilidad para la fase DevOps/CI-CD del monorepo `ticketing-backend` + `ticketing-frontend`.
- Dejar SonarCloud listo para análisis CI-based en modo monorepo sin colocar valores reales de organización o projectKey.
- Proveer documentación operativa y un scaffold de trazabilidad que permita generar evidencias automáticas en la siguiente fase.

### Description
- Añadido `sonar-project.properties` en la raíz con `sonar.sources`/`sonar.tests` para backend y frontend, exclusiones de artefactos, y la ruta de JaCoCo fusionado `ticketing-backend/target/site/jacoco-merged/jacoco.xml`, dejando placeholders para `sonar.organization` y `sonar.projectKey` y un comentario para futura integración `lcov` frontend.
- Añadido `docs/devops/cicd-strategy.md` que describe propósito, diferencias CI/CD aplicadas al proyecto, validaciones CI (tests backend unit/integration, lint/build/tests frontend, trazabilidad, SonarCloud), objetivos CD (staging desde `main`, smoke checks) y decisiones de calidad y branching.
- Añadido `docs/devops/environments-and-secrets.md` con estrategia práctica de `staging`/`production`, separación de repository vs environment secrets, convención de nombres (misma clave por environment), lista inicial de secrets y checklist operativo.
- Añadido scaffold `scripts/traceability/check-traceability.mjs` (Node ESM, sin dependencias externas) que lee `docs/features/*.feature`, extrae IDs con el regex `\b[A-Z]+(?:-[A-Z]+)*-\d{2}\b`, busca referencias en `ticketing-backend/src/test`, `ticketing-frontend/src` (tests) y `ticketing-frontend/e2e`, y genera `artifacts/traceability/traceability-report.json` y `.md` en modo no bloqueante y tolerante a directorios faltantes.