### PR TITLE
Restructure backend production CD to deploy prebuilt backend jar

### DIFF
--- a/.github/workflows/deploy-backend-production.yml
+++ b/.github/workflows/deploy-backend-production.yml
@@ -23,6 +23,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Build backend JAR with Maven
+        working-directory: ticketing-backend
+        run: |
+          set -euo pipefail
+          ./mvnw -B -DskipTests clean package
+
       - name: Prepare backend deployment bundle
         env:
           DOMAIN: ${{ secrets.DOMAIN }}
@@ -38,13 +51,16 @@ jobs:
           rm -rf deploy
           mkdir -p deploy/app/secrets
 
+          APP_JAR="$(ls -1 ticketing-backend/target/*.jar | grep -v 'original' | head -n 1)"
+          if [ -z "${APP_JAR}" ]; then
+            echo "No backend jar found in ticketing-backend/target" >&2
+            exit 1
+          fi
+
+          cp "${APP_JAR}" deploy/app/app.jar
           cp ticketing-backend/docker-compose.prod.yml deploy/app/docker-compose.prod.yml
           cp ticketing-backend/Dockerfile deploy/app/Dockerfile
           cp ticketing-backend/Caddyfile deploy/app/Caddyfile
-          cp ticketing-backend/pom.xml deploy/app/pom.xml
-          cp ticketing-backend/mvnw deploy/app/mvnw
-          cp -R ticketing-backend/.mvn deploy/app/.mvn
-          cp -R ticketing-backend/src deploy/app/src
 
           {
             printf '%s\n' "SPRING_PROFILES_ACTIVE=cloud"
@@ -62,8 +78,7 @@ jobs:
 
           chmod 644 deploy/app/secrets/jwt-public.pem deploy/app/secrets/jwt-private.pem
           chmod 755 deploy/app/secrets
-          chmod 644 deploy/app/.env
-          chmod +x deploy/app/mvnw
+          chmod 644 deploy/app/.env deploy/app/app.jar
 
           tar -czf deploy/backend-production-bundle.tgz -C deploy app
 
@@ -91,6 +106,9 @@ jobs:
           SSH_PORT="${EC2_SSH_PORT:-22}"
 
           scp -P "${SSH_PORT}" \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=10 \
+            -o TCPKeepAlive=yes \
             deploy/backend-production-bundle.tgz \
             "${EC2_USER}@${EC2_HOST}:/tmp/backend-production-bundle.tgz"
 
@@ -105,7 +123,11 @@ jobs:
 
           SSH_PORT="${EC2_SSH_PORT:-22}"
 
-          ssh -p "${SSH_PORT}" "${EC2_USER}@${EC2_HOST}" \
+          ssh -p "${SSH_PORT}" \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=10 \
+            -o TCPKeepAlive=yes \
+            "${EC2_USER}@${EC2_HOST}" \
             "EC2_APP_DIR='${EC2_APP_DIR}' bash -s" <<'REMOTE_EOF'
           set -euo pipefail
 
@@ -121,7 +143,7 @@ jobs:
 
           chmod 755 "${EC2_APP_DIR}/app/secrets"
           chmod 644 "${EC2_APP_DIR}/app/secrets/jwt-public.pem" "${EC2_APP_DIR}/app/secrets/jwt-private.pem"
-          chmod 644 "${EC2_APP_DIR}/app/.env"
+          chmod 644 "${EC2_APP_DIR}/app/.env" "${EC2_APP_DIR}/app/app.jar"
 
           cd "${EC2_APP_DIR}/app"
 

--- a/docs/devops/deploy-backend-production.md
+++ b/docs/devops/deploy-backend-production.md
@@ -5,6 +5,16 @@ Automate backend production deployment to AWS EC2 from GitHub Actions using SSH 
 
 This workflow intentionally covers **backend only** (no frontend automation in this batch).
 
+## Deployment strategy
+
+Current strategy uses a **build artifact model**:
+
+- GitHub Actions compiles the Spring Boot backend with Maven.
+- The deployment bundle sent to EC2 includes a prebuilt `app.jar`.
+- EC2 keeps using Docker Compose, but performs only a lightweight Docker image build (`COPY app.jar`) and container restart.
+
+This avoids Maven compilation on small EC2 instances (for example `t3.micro`), reducing CPU/RAM pressure and making SSH-based deploys more stable.
+
 ## Workflow
 File: `.github/workflows/deploy-backend-production.yml`
 
@@ -38,15 +48,14 @@ File: `.github/workflows/deploy-backend-production.yml`
 
 ### 1) On GitHub runner
 1. Checkout repository.
-2. Prepare a deployment bundle with minimal backend files:
+2. Setup Java 17 (`actions/setup-java@v4`) with Maven cache.
+3. Build backend jar in `ticketing-backend` with Maven Wrapper (`./mvnw -B -DskipTests clean package`).
+4. Prepare a deployment bundle with runtime files only:
+   - `app.jar` (copied from `ticketing-backend/target/*.jar`)
    - `docker-compose.prod.yml`
-   - `Dockerfile`
+   - `Dockerfile` (runtime-only)
    - `Caddyfile`
-   - Maven wrapper + `.mvn`
-   - `pom.xml`
-   - `src/`
-3. Generate `.env` from `production` secrets.
-4. Generate JWT key files:
+   - `.env`
    - `secrets/jwt-public.pem`
    - `secrets/jwt-private.pem`
 5. Upload `backend-production-bundle.tgz` to EC2 via SCP.
@@ -54,7 +63,7 @@ File: `.github/workflows/deploy-backend-production.yml`
 ### 2) On EC2 via SSH
 1. Create app directory if missing (`EC2_APP_DIR`).
 2. Extract uploaded bundle.
-3. Apply minimal file permissions for secrets.
+3. Apply minimal file permissions for secrets, `.env` and `app.jar`.
 4. Detect compose command:
    - try `docker compose`
    - fallback to `docker-compose`
@@ -65,6 +74,14 @@ docker compose -f docker-compose.prod.yml --env-file .env up -d --build
 ```
 
 (or same with `docker-compose` fallback).
+
+## Keepalive configuration for SSH/SCP
+
+To improve stability during transfer and remote execution, both `scp` and `ssh` use:
+
+- `-o ServerAliveInterval=30`
+- `-o ServerAliveCountMax=10`
+- `-o TCPKeepAlive=yes`
 
 ## `.env` and JWT key handling
 
@@ -100,7 +117,7 @@ using `curl` + retries and requires JSON response with status `UP`.
 ## Current limitations (intentional)
 
 - No automated rollback yet.
-- No container registry yet (build occurs on EC2 via compose).
+- No container registry yet (no `docker pull` flow in this batch).
 - No frontend deployment automation in this workflow.
 - No Terraform/IaC in this batch.
 

--- a/ticketing-backend/Dockerfile
+++ b/ticketing-backend/Dockerfile
@@ -1,23 +1,11 @@
 # syntax=docker/dockerfile:1
 
-FROM maven:3.9.11-eclipse-temurin-17 AS builder
-WORKDIR /app
-
-COPY pom.xml ./
-COPY .mvn/ .mvn/
-COPY mvnw ./
-RUN chmod +x mvnw
-RUN ./mvnw -B -DskipTests dependency:go-offline
-
-COPY src/ src/
-RUN ./mvnw -B -DskipTests clean package
-
 FROM eclipse-temurin:17-jre-jammy AS runtime
 WORKDIR /app
 
 RUN groupadd --system spring && useradd --system --gid spring spring
 
-COPY --from=builder /app/target/*.jar app.jar
+COPY app.jar app.jar
 
 ENV SPRING_PROFILES_ACTIVE=cloud
 EXPOSE 8080


### PR DESCRIPTION
### Motivation

- Building the Spring Boot backend on small EC2 instances (e.g. `t3.micro`) causes high CPU/RAM usage that can break SSH sessions (`client_loop: send disconnect: Broken pipe`), so compilation should be moved off-instance. 
- Producing a prebuilt `app.jar` in GitHub Actions and shipping a runtime bundle keeps `docker compose` on EC2 but reduces resource pressure and makes deployments more predictable and more resilient to network/SSH interruptions. 
- Adding SSH/SCP keepalive options reduces the chance of transient connection drops during file transfer and remote execution.

