### PR TITLE
Integrar cobertura LCOV del frontend en SonarCloud y esperar Quality Gate en CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run frontend unit tests
-        run: npm run test:run -- --exclude='e2e/**'
+      - name: Install Vitest coverage provider
+        run: npm install --no-save @vitest/coverage-v8
+
+      - name: Run frontend unit tests with coverage
+        run: npm run test:coverage
+
+      - name: Upload frontend coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage-report
+          if-no-files-found: error
+          path: ticketing-frontend/coverage/lcov.info
 
   frontend-build:
     name: frontend-build
@@ -182,6 +192,12 @@ jobs:
           name: backend-test-coverage-reports
           path: .
 
+      - name: Download frontend coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-coverage-report
+          path: ticketing-frontend/coverage
+
       - name: Set up Java 17
         uses: actions/setup-java@v4
         with:
@@ -209,8 +225,12 @@ jobs:
             sleep 15
           done
 
-      - name: SonarQube Cloud scan
+      - name: SonarQube Cloud scan (wait for Quality Gate)
         uses: SonarSource/sonarqube-scan-action@v6
+        with:
+          args: >
+            -Dsonar.qualitygate.wait=true
+            -Dsonar.qualitygate.timeout=300
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/devops/cicd-strategy.md
+++ b/docs/devops/cicd-strategy.md
@@ -66,7 +66,7 @@ Minimum pipeline gates:
 
 ## 8. Tool responsibilities
 - **GitHub Actions**: CI/CD orchestration
-- **SonarCloud**: maintainability and quality insights
+- **SonarCloud**: maintainability and quality insights (backend JaCoCo XML + frontend Vitest LCOV, waiting for Quality Gate result in CI)
 - **Dependabot**: dependency update hygiene
 - **Security workflow (dependency review / CodeQL when enabled)**: early security signal
 - **GitHub Environments**: staging/production secret and policy isolation

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -22,8 +22,8 @@ sonar.test.inclusions=\
 sonar.coverage.jacoco.xmlReportPaths=ticketing-backend/target/site/jacoco-merged/jacoco.xml
 sonar.java.binaries=ticketing-backend/target/classes
 
-# Frontend coverage (future phase):
-# sonar.javascript.lcov.reportPaths=ticketing-frontend/coverage/lcov.info
+# Frontend coverage (Vitest LCOV)
+sonar.javascript.lcov.reportPaths=ticketing-frontend/coverage/lcov.info
 
 # Exclude generated artifacts and build outputs
 sonar.exclusions=\

--- a/ticketing-frontend/package.json
+++ b/ticketing-frontend/package.json
@@ -15,7 +15,8 @@
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
     "test:e2e": "playwright test",
-    "test:e2e:headed": "playwright test --headed"
+    "test:e2e:headed": "playwright test --headed",
+    "test:coverage": "vitest run --coverage --exclude='e2e/**'"
   },
   "dependencies": {
     "antd": "^5.29.3",

--- a/ticketing-frontend/vite.config.ts
+++ b/ticketing-frontend/vite.config.ts
@@ -14,5 +14,12 @@ export default defineConfig({
     setupFiles: "./src/test/setupTests.ts",
     globals: true,
     testTimeout: 15000,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      reportsDirectory: "./coverage",
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: ["src/test/**", "src/**/*.d.ts"],
+    },
   },
 });


### PR DESCRIPTION
### Motivation
- Cerrar la brecha de señal de cobertura que hace que la Quality Gate de SonarCloud marque `0.0%` en new code porque la cobertura frontend no estaba siendo exportada. 
- Mantener la política de calidad actual y hacer que el job de Sonar refleje explícitamente el resultado de la Quality Gate en CI.

### Description
- Habilita salida LCOV desde Vitest en `ticketing-frontend` añadiendo `coverage` en `vite.config.ts` y un script `test:coverage` en `ticketing-frontend/package.json` para generar `coverage/lcov.info`.
- Ajusta la pipeline en `.github/workflows/ci.yml` para instalar el provider de cobertura en runtime (`npm install --no-save @vitest/coverage-v8`), ejecutar `npm run test:coverage`, y subir `ticketing-frontend/coverage/lcov.info` como artefacto.
- Actualiza `sonar-project.properties` para importar `sonar.javascript.lcov.reportPaths=ticketing-frontend/coverage/lcov.info` manteniendo intacta la integración JaCoCo del backend.
- Modifica el job `sonarcloud` en CI para descargar el artefacto de cobertura frontend y ejecutar el escaneo con `-Dsonar.qualitygate.wait=true` (timeout configurable) para que el job falle si la Quality Gate falla.
- Breve actualización en `docs/devops/cicd-strategy.md` indicando que SonarCloud ahora consume JaCoCo (backend) + LCOV (frontend) y que CI espera la Quality Gate.