### PR TITLE
Fix SonarCloud backend JaCoCo artifact path resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: backend-test-coverage-reports
-          path: .
+          path: ticketing-backend/target
 
       - name: Download frontend coverage report
         uses: actions/download-artifact@v4
@@ -224,6 +224,20 @@ jobs:
             echo "Attempt ${attempt} failed (possible transient Maven download/network issue). Retrying in 15s..."
             sleep 15
           done
+
+
+      - name: Debug backend JaCoCo report path
+        run: |
+          set -euo pipefail
+
+          if [ -f ticketing-backend/target/site/jacoco-merged/jacoco.xml ]; then
+            echo "✅ Found backend JaCoCo XML report at expected path"
+          else
+            echo "❌ Missing backend JaCoCo XML report at ticketing-backend/target/site/jacoco-merged/jacoco.xml" >&2
+            exit 1
+          fi
+
+          find ticketing-backend -maxdepth 6 -type f | sort
 
       - name: SonarQube Cloud scan (wait for Quality Gate)
         uses: SonarSource/sonarqube-scan-action@v6


### PR DESCRIPTION
- Updated the `sonarcloud` job in `.github/workflows/ci.yml` to download the `backend-test-coverage-reports` artifact into `ticketing-backend/target` by changing the `download-artifact` `path` to `ticketing-backend/target`.
- Added a temporary debug step before the SonarCloud scan that verifies the existence of `ticketing-backend/target/site/jacoco-merged/jacoco.xml` and prints the backend file tree using `find ticketing-backend -maxdepth 6 -type f | sort`.