### PR TITLE
Add dashboard stats endpoint and frontend dashboard UI for agents/admins

### DIFF
--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/TicketController.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/TicketController.java
@@ -7,6 +7,7 @@ import com.aperdigon.ticketing_backend.api.tickets.comments.AddTicketCommentRequ
 import com.aperdigon.ticketing_backend.api.tickets.comments.AddTicketCommentResponse;
 import com.aperdigon.ticketing_backend.api.tickets.create.CreateTicketRequest;
 import com.aperdigon.ticketing_backend.api.tickets.create.CreateTicketResponse;
+import com.aperdigon.ticketing_backend.api.tickets.dashboard.DashboardStatsResponse;
 import com.aperdigon.ticketing_backend.api.tickets.detail.TicketDetailResponse;
 import com.aperdigon.ticketing_backend.api.tickets.list.TicketSummaryResponse;
 import com.aperdigon.ticketing_backend.application.tickets.change_status.ChangeTicketStatusCommand;
@@ -15,6 +16,7 @@ import com.aperdigon.ticketing_backend.application.tickets.add_comment.AddTicket
 import com.aperdigon.ticketing_backend.application.tickets.add_comment.AddTicketCommentUseCase;
 import com.aperdigon.ticketing_backend.application.tickets.assign.AssignTicketToMeCommand;
 import com.aperdigon.ticketing_backend.application.tickets.assign.AssignTicketToMeUseCase;
+import com.aperdigon.ticketing_backend.application.tickets.dashboard.GetDashboardStatsUseCase;
 import com.aperdigon.ticketing_backend.application.ports.TicketEventRepository;
 import com.aperdigon.ticketing_backend.application.ports.UserRepository;
 import com.aperdigon.ticketing_backend.application.tickets.create.CreateTicketCommand;
@@ -56,6 +58,7 @@ public class TicketController {
     private final ListTicketsUseCase listTicketsUseCase;
     private final GetTicketUseCase getTicketUseCase;
     private final AddTicketCommentUseCase addTicketCommentUseCase;
+    private final GetDashboardStatsUseCase getDashboardStatsUseCase;
     private final TicketEventRepository ticketEventRepository;
     private final UserRepository userRepository;
     private final CurrentUserProvider currentUserProvider;
@@ -68,6 +71,7 @@ public class TicketController {
             ListTicketsUseCase listTicketsUseCase,
             GetTicketUseCase getTicketUseCase,
             AddTicketCommentUseCase addTicketCommentUseCase,
+            GetDashboardStatsUseCase getDashboardStatsUseCase,
             TicketEventRepository ticketEventRepository,
             UserRepository userRepository,
             CurrentUserProvider currentUserProvider
@@ -79,6 +83,7 @@ public class TicketController {
         this.listTicketsUseCase = listTicketsUseCase;
         this.getTicketUseCase = getTicketUseCase;
         this.addTicketCommentUseCase = addTicketCommentUseCase;
+        this.getDashboardStatsUseCase = getDashboardStatsUseCase;
         this.ticketEventRepository = ticketEventRepository;
         this.userRepository = userRepository;
         this.currentUserProvider = currentUserProvider;
@@ -131,6 +136,14 @@ public class TicketController {
 
         var result = listTicketsUseCase.execute(new ListTicketsQuery(actor, scope, status, q, pageable));
         return PageResponse.from(result.map(TicketSummaryResponse::from));
+    }
+
+    @GetMapping("/dashboard/stats")
+    @Operation(summary = "Get dashboard stats for agents/admins")
+    public DashboardStatsResponse dashboardStats() {
+        var actor = currentUserProvider.getCurrentUser();
+        var result = getDashboardStatsUseCase.execute(actor);
+        return DashboardStatsResponse.from(result);
     }
 
     @GetMapping("/{id}")

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/dashboard/DashboardStatsResponse.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/dashboard/DashboardStatsResponse.java
@@ -1,0 +1,52 @@
+package com.aperdigon.ticketing_backend.api.tickets.dashboard;
+
+import com.aperdigon.ticketing_backend.application.tickets.dashboard.AgentTicketCount;
+import com.aperdigon.ticketing_backend.application.tickets.dashboard.GetDashboardStatsResult;
+
+import java.util.List;
+import java.util.UUID;
+
+public record DashboardStatsResponse(
+        DashboardCardsResponse cards,
+        DashboardChartsResponse charts
+) {
+
+    public static DashboardStatsResponse from(GetDashboardStatsResult result) {
+        return new DashboardStatsResponse(
+                new DashboardCardsResponse(
+                        result.unassigned(),
+                        result.assignedToMe(),
+                        result.inProgress(),
+                        result.onHold()
+                ),
+                new DashboardChartsResponse(
+                        result.resolvedByAssignee().stream().map(AgentCountResponse::from).toList(),
+                        result.assignedByAssignee().stream().map(AgentCountResponse::from).toList()
+                )
+        );
+    }
+
+    public record DashboardCardsResponse(
+            long unassigned,
+            long assignedToMe,
+            long inProgress,
+            long onHold
+    ) {
+    }
+
+    public record DashboardChartsResponse(
+            List<AgentCountResponse> resolvedByAgent,
+            List<AgentCountResponse> assignedByAgent
+    ) {
+    }
+
+    public record AgentCountResponse(
+            UUID assigneeUserId,
+            String assigneeDisplayName,
+            long count
+    ) {
+        public static AgentCountResponse from(AgentTicketCount source) {
+            return new AgentCountResponse(source.assigneeId().value(), source.assigneeDisplayName(), source.count());
+        }
+    }
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/ports/TicketRepository.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/ports/TicketRepository.java
@@ -1,14 +1,18 @@
 package com.aperdigon.ticketing_backend.application.ports;
 
 import com.aperdigon.ticketing_backend.application.tickets.list.TicketQueueScope;
+import com.aperdigon.ticketing_backend.application.tickets.dashboard.AgentTicketCount;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
 import com.aperdigon.ticketing_backend.domain.user.UserId;
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface TicketRepository {
     Ticket save(Ticket ticket);
@@ -17,4 +21,14 @@ public interface TicketRepository {
     Page<Ticket> findMyTickets(UserId createdBy, TicketStatus status, String q, Pageable pageable);
 
     Page<Ticket> findAgentTickets(UserId actorId, TicketQueueScope scope, TicketStatus status, String q, Pageable pageable);
+
+    long countUnassigned();
+
+    long countAssignedTo(UserId assigneeId);
+
+    long countByStatus(TicketStatus status);
+
+    List<AgentTicketCount> countAssignedByAssigneeRoles(Set<UserRole> roles);
+
+    List<AgentTicketCount> countByStatusGroupedByAssigneeRoles(TicketStatus status, Set<UserRole> roles);
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/dashboard/AgentTicketCount.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/dashboard/AgentTicketCount.java
@@ -1,0 +1,6 @@
+package com.aperdigon.ticketing_backend.application.tickets.dashboard;
+
+import com.aperdigon.ticketing_backend.domain.user.UserId;
+
+public record AgentTicketCount(UserId assigneeId, String assigneeDisplayName, long count) {
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/dashboard/GetDashboardStatsResult.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/dashboard/GetDashboardStatsResult.java
@@ -1,0 +1,13 @@
+package com.aperdigon.ticketing_backend.application.tickets.dashboard;
+
+import java.util.List;
+
+public record GetDashboardStatsResult(
+        long unassigned,
+        long assignedToMe,
+        long inProgress,
+        long onHold,
+        List<AgentTicketCount> resolvedByAssignee,
+        List<AgentTicketCount> assignedByAssignee
+) {
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/dashboard/GetDashboardStatsUseCase.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/dashboard/GetDashboardStatsUseCase.java
@@ -1,0 +1,52 @@
+package com.aperdigon.ticketing_backend.application.tickets.dashboard;
+
+import com.aperdigon.ticketing_backend.application.ports.TicketRepository;
+import com.aperdigon.ticketing_backend.application.shared.CurrentUser;
+import com.aperdigon.ticketing_backend.application.shared.exception.ForbiddenException;
+import com.aperdigon.ticketing_backend.domain.shared.validation.Guard;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+@Service
+public class GetDashboardStatsUseCase {
+
+    private static final Set<UserRole> DASHBOARD_ASSIGNEE_ROLES = Set.of(UserRole.AGENT, UserRole.ADMIN);
+
+    private final TicketRepository ticketRepository;
+
+    public GetDashboardStatsUseCase(TicketRepository ticketRepository) {
+        this.ticketRepository = Guard.notNull(ticketRepository, "ticketRepository");
+    }
+
+    public GetDashboardStatsResult execute(CurrentUser actor) {
+        Guard.notNull(actor, "actor");
+
+        if (!actor.isAgentOrAdmin()) {
+            throw new ForbiddenException("Only AGENT/ADMIN can access dashboard stats");
+        }
+
+        long unassigned = ticketRepository.countUnassigned();
+        long assignedToMe = ticketRepository.countAssignedTo(actor.id());
+        long inProgress = ticketRepository.countByStatus(TicketStatus.IN_PROGRESS);
+        long onHold = ticketRepository.countByStatus(TicketStatus.ON_HOLD);
+
+        var resolvedByAssignee = ticketRepository.countByStatusGroupedByAssigneeRoles(
+                TicketStatus.RESOLVED,
+                DASHBOARD_ASSIGNEE_ROLES
+        );
+
+        var assignedByAssignee = ticketRepository.countAssignedByAssigneeRoles(DASHBOARD_ASSIGNEE_ROLES);
+
+        return new GetDashboardStatsResult(
+                unassigned,
+                assignedToMe,
+                inProgress,
+                onHold,
+                resolvedByAssignee,
+                assignedByAssignee
+        );
+    }
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/adapter/JpaTicketRepository.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/adapter/JpaTicketRepository.java
@@ -1,11 +1,13 @@
 package com.aperdigon.ticketing_backend.infrastructure.persistence.adapter;
 
 import com.aperdigon.ticketing_backend.application.ports.TicketRepository;
+import com.aperdigon.ticketing_backend.application.tickets.dashboard.AgentTicketCount;
 import com.aperdigon.ticketing_backend.application.tickets.list.TicketQueueScope;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
 import com.aperdigon.ticketing_backend.domain.user.UserId;
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.CommentJpaEntity;
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.TicketJpaEntity;
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.mapper.TicketMapper;
@@ -22,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public class JpaTicketRepository implements TicketRepository {
@@ -145,5 +148,39 @@ public class JpaTicketRepository implements TicketRepository {
         };
 
         return ticketSpringRepo.findAll(spec, pageable).map(TicketMapper::toDomain);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long countUnassigned() {
+        return ticketSpringRepo.countByAssignedToIsNull();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long countAssignedTo(UserId assigneeId) {
+        return ticketSpringRepo.countByAssignedTo_Id(assigneeId.value());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long countByStatus(TicketStatus status) {
+        return ticketSpringRepo.countByStatus(status);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AgentTicketCount> countAssignedByAssigneeRoles(Set<UserRole> roles) {
+        return ticketSpringRepo.countAssignedByAssigneeRoles(roles).stream()
+                .map(row -> new AgentTicketCount(new UserId(row.getAssigneeId()), row.getAssigneeDisplayName(), row.getTicketCount()))
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AgentTicketCount> countByStatusGroupedByAssigneeRoles(TicketStatus status, Set<UserRole> roles) {
+        return ticketSpringRepo.countByStatusGroupedByAssigneeRoles(status, roles).stream()
+                .map(row -> new AgentTicketCount(new UserId(row.getAssigneeId()), row.getAssigneeDisplayName(), row.getTicketCount()))
+                .toList();
     }
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/repository/TicketSpringDataRepository.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/repository/TicketSpringDataRepository.java
@@ -1,10 +1,17 @@
 package com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository;
 
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.entity.TicketJpaEntity;
+import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.projection.AssigneeTicketCountProjection;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,4 +19,40 @@ public interface TicketSpringDataRepository extends JpaRepository<TicketJpaEntit
 
     @EntityGraph(attributePaths = {"comments", "createdBy", "assignedTo", "category", "comments.author"})
     Optional<TicketJpaEntity> findWithDetailsById(UUID id);
+
+    long countByAssignedToIsNull();
+
+    long countByAssignedTo_Id(UUID assigneeId);
+
+    long countByStatus(TicketStatus status);
+
+    @Query("""
+            SELECT
+                t.assignedTo.id AS assigneeId,
+                t.assignedTo.displayName AS assigneeDisplayName,
+                COUNT(t) AS ticketCount
+            FROM TicketJpaEntity t
+            WHERE t.assignedTo IS NOT NULL
+              AND t.assignedTo.role IN :roles
+            GROUP BY t.assignedTo.id, t.assignedTo.displayName
+            ORDER BY COUNT(t) DESC
+            """)
+    List<AssigneeTicketCountProjection> countAssignedByAssigneeRoles(@Param("roles") Collection<UserRole> roles);
+
+    @Query("""
+            SELECT
+                t.assignedTo.id AS assigneeId,
+                t.assignedTo.displayName AS assigneeDisplayName,
+                COUNT(t) AS ticketCount
+            FROM TicketJpaEntity t
+            WHERE t.assignedTo IS NOT NULL
+              AND t.status = :status
+              AND t.assignedTo.role IN :roles
+            GROUP BY t.assignedTo.id, t.assignedTo.displayName
+            ORDER BY COUNT(t) DESC
+            """)
+    List<AssigneeTicketCountProjection> countByStatusGroupedByAssigneeRoles(
+            @Param("status") TicketStatus status,
+            @Param("roles") Collection<UserRole> roles
+    );
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/repository/projection/AssigneeTicketCountProjection.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/jpa/repository/projection/AssigneeTicketCountProjection.java
@@ -1,0 +1,9 @@
+package com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.projection;
+
+import java.util.UUID;
+
+public interface AssigneeTicketCountProjection {
+    UUID getAssigneeId();
+    String getAssigneeDisplayName();
+    long getTicketCount();
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/security/SecurityConfig.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/security/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                         //UC1: crear ticket todos
                         .requestMatchers(HttpMethod.POST, "/api/tickets").hasAnyRole("USER","AGENT","ADMIN")
                         .requestMatchers(HttpMethod.GET, "/api/tickets/me").hasAnyRole("USER","AGENT","ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/api/tickets/dashboard/**").hasAnyRole("AGENT", "ADMIN")
                         .requestMatchers(HttpMethod.GET, "/api/tickets").hasAnyRole("AGENT", "ADMIN")
                         .requestMatchers(HttpMethod.GET, "/api/tickets/*").hasAnyRole("USER", "AGENT", "ADMIN")
 

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/InMemoryTicketRepository.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/InMemoryTicketRepository.java
@@ -80,7 +80,9 @@ public final class InMemoryTicketRepository implements TicketRepository {
 
     @Override
     public List<AgentTicketCount> countAssignedByAssigneeRoles(Set<UserRole> roles) {
-        void roles;
+        if (roles == null || roles.isEmpty()) {
+            return List.of();
+        }
         return store.values().stream()
                 .filter(ticket -> ticket.assignedTo() != null)
                 .collect(Collectors.groupingBy(Ticket::assignedTo, Collectors.counting()))
@@ -92,7 +94,9 @@ public final class InMemoryTicketRepository implements TicketRepository {
 
     @Override
     public List<AgentTicketCount> countByStatusGroupedByAssigneeRoles(TicketStatus status, Set<UserRole> roles) {
-        void roles;
+        if (roles == null || roles.isEmpty()) {
+            return List.of();
+        }
         return store.values().stream()
                 .filter(ticket -> ticket.assignedTo() != null)
                 .filter(ticket -> ticket.status() == status)

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/InMemoryTicketRepository.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/InMemoryTicketRepository.java
@@ -1,11 +1,13 @@
 package com.aperdigon.ticketing_backend.test_support;
 
 import com.aperdigon.ticketing_backend.application.ports.TicketRepository;
+import com.aperdigon.ticketing_backend.application.tickets.dashboard.AgentTicketCount;
 import com.aperdigon.ticketing_backend.application.tickets.list.TicketQueueScope;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
 import com.aperdigon.ticketing_backend.domain.user.UserId;
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -15,6 +17,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public final class InMemoryTicketRepository implements TicketRepository {
@@ -51,6 +55,52 @@ public final class InMemoryTicketRepository implements TicketRepository {
                 .toList();
 
         return toPage(filtered, pageable);
+    }
+
+    @Override
+    public long countUnassigned() {
+        return store.values().stream()
+                .filter(ticket -> ticket.assignedTo() == null)
+                .count();
+    }
+
+    @Override
+    public long countAssignedTo(UserId assigneeId) {
+        return store.values().stream()
+                .filter(ticket -> assigneeId.equals(ticket.assignedTo()))
+                .count();
+    }
+
+    @Override
+    public long countByStatus(TicketStatus status) {
+        return store.values().stream()
+                .filter(ticket -> ticket.status() == status)
+                .count();
+    }
+
+    @Override
+    public List<AgentTicketCount> countAssignedByAssigneeRoles(Set<UserRole> roles) {
+        void roles;
+        return store.values().stream()
+                .filter(ticket -> ticket.assignedTo() != null)
+                .collect(Collectors.groupingBy(Ticket::assignedTo, Collectors.counting()))
+                .entrySet().stream()
+                .map(entry -> new AgentTicketCount(entry.getKey(), entry.getKey().value().toString(), entry.getValue()))
+                .sorted(Comparator.comparingLong(AgentTicketCount::count).reversed())
+                .toList();
+    }
+
+    @Override
+    public List<AgentTicketCount> countByStatusGroupedByAssigneeRoles(TicketStatus status, Set<UserRole> roles) {
+        void roles;
+        return store.values().stream()
+                .filter(ticket -> ticket.assignedTo() != null)
+                .filter(ticket -> ticket.status() == status)
+                .collect(Collectors.groupingBy(Ticket::assignedTo, Collectors.counting()))
+                .entrySet().stream()
+                .map(entry -> new AgentTicketCount(entry.getKey(), entry.getKey().value().toString(), entry.getValue()))
+                .sorted(Comparator.comparingLong(AgentTicketCount::count).reversed())
+                .toList();
     }
 
     private Stream<Ticket> sortedTickets() {

--- a/ticketing-frontend/src/app/layout/AppShell.test.tsx
+++ b/ticketing-frontend/src/app/layout/AppShell.test.tsx
@@ -73,6 +73,14 @@ describe("AppShell", () => {
     expect(screen.getByText("Administración")).toBeInTheDocument();
   });
 
+  it("shows dashboard menu for AGENT but not admin menu", () => {
+    hasRoleMock.mockImplementation((role) => role === "AGENT");
+    renderWithRouter();
+
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.queryByText("Administración")).not.toBeInTheDocument();
+  });
+
   it("logs out and redirects to login from header button", async () => {
     hasRoleMock.mockReturnValue(false);
     const user = userEvent.setup();

--- a/ticketing-frontend/src/app/layout/AppShell.tsx
+++ b/ticketing-frontend/src/app/layout/AppShell.tsx
@@ -15,16 +15,18 @@ const baseItems: AppMenuItem[] = [
   { key: "/profile", icon: <HiBars3 fontSize={18} />, label: "Perfil" },
 ];
 
-function getMenuItems(isAdmin: boolean): AppMenuItem[] {
-  if (isAdmin) {
-    return [
-      { key: "/dashboard", icon: <MdDashboard fontSize={18} />, label: "Dashboard" },
-      ...baseItems,
-      { key: "/admin", icon: <HiUsers fontSize={18} />, label: "Administración" },
-    ];
+function getMenuItems(canSeeDashboard: boolean, isAdmin: boolean): AppMenuItem[] {
+  const items: AppMenuItem[] = [...baseItems];
+
+  if (canSeeDashboard) {
+    items.unshift({ key: "/dashboard", icon: <MdDashboard fontSize={18} />, label: "Dashboard" });
   }
 
-  return baseItems;
+  if (isAdmin) {
+    items.push({ key: "/admin", icon: <HiUsers fontSize={18} />, label: "Administración" });
+  }
+
+  return items;
 }
 
 function getSelectedKey(pathname: string, items: AppMenuItem[]) {
@@ -41,7 +43,9 @@ export function AppShell() {
   const navigate = useNavigate();
   const { hasRole, logout } = useAuth();
 
-  const menuItems = getMenuItems(hasRole("ADMIN"));
+  const isAdmin = hasRole("ADMIN");
+  const canSeeDashboard = hasRole("AGENT") || isAdmin;
+  const menuItems = getMenuItems(canSeeDashboard, isAdmin);
 
   const onLogout = () => {
     logout();

--- a/ticketing-frontend/src/features/tickets/api/ticketsApi.ts
+++ b/ticketing-frontend/src/features/tickets/api/ticketsApi.ts
@@ -3,6 +3,7 @@ import type {
   CreateTicketInput,
   AddTicketCommentResponse,
   CreateTicketResponse,
+  DashboardStats,
   PaginatedResponse,
   TicketCategory,
   TicketDetail,
@@ -57,4 +58,6 @@ export const ticketsApi = {
 
   addComment: (ticketId: string, content: string) =>
     authClient.post<AddTicketCommentResponse>(`/api/tickets/${ticketId}/comments`, { content }),
+
+  getDashboardStats: () => authClient.get<DashboardStats>("/api/tickets/dashboard/stats"),
 };

--- a/ticketing-frontend/src/features/tickets/model/types.ts
+++ b/ticketing-frontend/src/features/tickets/model/types.ts
@@ -71,6 +71,25 @@ export type CreateTicketResponse = {
   ticketId: string;
 };
 
+export type DashboardAgentCount = {
+  assigneeUserId: string;
+  assigneeDisplayName: string;
+  count: number;
+};
+
+export type DashboardStats = {
+  cards: {
+    unassigned: number;
+    assignedToMe: number;
+    inProgress: number;
+    onHold: number;
+  };
+  charts: {
+    resolvedByAgent: DashboardAgentCount[];
+    assignedByAgent: DashboardAgentCount[];
+  };
+};
+
 export type PaginatedResponse<T> = {
   items: T[];
   page: number;

--- a/ticketing-frontend/src/features/tickets/ui/dashboard/AgentAdminDashboardPage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/dashboard/AgentAdminDashboardPage.test.tsx
@@ -1,0 +1,67 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { renderWithProviders } from "src/test/utils/renderWithProviders";
+import { jsonResponse } from "src/test/msw/handlers";
+import { http } from "src/test/msw/http";
+import { server } from "src/test/msw/server";
+import { AgentAdminDashboardPage } from "./AgentAdminDashboardPage";
+
+const statsFixture = {
+  cards: {
+    unassigned: 4,
+    assignedToMe: 6,
+    inProgress: 3,
+    onHold: 2,
+  },
+  charts: {
+    resolvedByAgent: [
+      { assigneeUserId: "agent-1", assigneeDisplayName: "Agent Uno", count: 9 },
+      { assigneeUserId: "admin-1", assigneeDisplayName: "Admin Uno", count: 5 },
+    ],
+    assignedByAgent: [
+      { assigneeUserId: "admin-1", assigneeDisplayName: "Admin Uno", count: 11 },
+      { assigneeUserId: "agent-1", assigneeDisplayName: "Agent Uno", count: 8 },
+    ],
+  },
+} as const;
+
+function renderPage() {
+  const router = createMemoryRouter(
+    [
+      { path: "/dashboard", element: <AgentAdminDashboardPage /> },
+      { path: "/tickets", element: <h1>Tickets destination</h1> },
+    ],
+    { initialEntries: ["/dashboard"] },
+  );
+
+  return { ...renderWithProviders(<RouterProvider router={router} />), router };
+}
+
+describe("AgentAdminDashboardPage", () => {
+  it("muestra cards y gráficos de estadísticas", async () => {
+    server.use(http.get("/api/tickets/dashboard/stats", () => jsonResponse(statsFixture)));
+
+    renderPage();
+
+    expect(await screen.findByText("Tickets sin asignar")).toBeInTheDocument();
+    expect(screen.getByText("Tickets cerrados por agente/admin")).toBeInTheDocument();
+    expect(screen.getAllByText("Agent Uno")).toHaveLength(2);
+    expect(screen.getAllByText("Admin Uno")).toHaveLength(2);
+  });
+
+  it("navega a tickets con filtros al clicar una card", async () => {
+    server.use(http.get("/api/tickets/dashboard/stats", () => jsonResponse(statsFixture)));
+
+    const { router } = renderPage();
+    const user = userEvent.setup();
+
+    await screen.findByText("WIP (en progreso)");
+
+    await user.click(screen.getByRole("button", { name: /WIP \(en progreso\)/i }));
+
+    expect(router.state.location.pathname).toBe("/tickets");
+    expect(router.state.location.search).toContain("view=all");
+    expect(router.state.location.search).toContain("status=IN_PROGRESS");
+  });
+});

--- a/ticketing-frontend/src/features/tickets/ui/dashboard/AgentAdminDashboardPage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/dashboard/AgentAdminDashboardPage.tsx
@@ -1,4 +1,4 @@
-import { Alert, Card, Empty, Progress, Skeleton, Space, Typography } from "antd";
+import { Alert, Card, Empty, Skeleton, Space, Typography } from "antd";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ticketsApi } from "../../api/ticketsApi";
@@ -50,13 +50,26 @@ function AgentBarChart({
                 <div key={item.assigneeUserId}>
                   <Space style={{ width: "100%", justifyContent: "space-between" }}>
                     <Typography.Text>{item.assigneeDisplayName}</Typography.Text>
-                    <Typography.Text strong>{item.count}</Typography.Text>
+                    <Typography.Text style={{ fontWeight: 700 }}>{item.count}</Typography.Text>
                   </Space>
-                  <Progress
-                    percent={Number(percentage.toFixed(2))}
-                    showInfo={false}
-                    strokeColor="#389e0d"
-                  />
+                  <div
+                    aria-label={`chart-bar-${item.assigneeUserId}`}
+                    style={{
+                      width: "100%",
+                      background: "#f3f4f6",
+                      borderRadius: 999,
+                      height: 10,
+                      overflow: "hidden",
+                    }}
+                  >
+                    <div
+                      style={{
+                        width: `${Number(percentage.toFixed(2))}%`,
+                        background: "#389e0d",
+                        height: "100%",
+                      }}
+                    />
+                  </div>
                 </div>
               );
             })}

--- a/ticketing-frontend/src/features/tickets/ui/dashboard/AgentAdminDashboardPage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/dashboard/AgentAdminDashboardPage.tsx
@@ -1,11 +1,8 @@
-import { Alert, Button, Card, Empty, Skeleton, Space, Table, Tag, Typography } from "antd";
-import type { TableProps } from "antd";
+import { Alert, Card, Empty, Progress, Skeleton, Space, Typography } from "antd";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ticketsApi } from "../../api/ticketsApi";
-import { ticketPriorityLabel } from "../../model/presentation";
-import type { TicketPriority, TicketStatus, TicketSummary } from "../../model/types";
-import { TicketStatusBadge } from "../shared/TicketStatusBadge";
+import type { DashboardAgentCount, DashboardStats, TicketStatus } from "../../model/types";
 
 type LoadState = "loading" | "ready" | "error";
 
@@ -17,13 +14,6 @@ type DashboardMetric = {
   status?: TicketStatus;
 };
 
-function formatDate(isoDate: string) {
-  return new Intl.DateTimeFormat("es-ES", {
-    dateStyle: "short",
-    timeStyle: "short",
-  }).format(new Date(isoDate));
-}
-
 function buildTicketsLink(metric: DashboardMetric) {
   const params = new URLSearchParams();
   params.set("view", metric.view);
@@ -31,15 +21,57 @@ function buildTicketsLink(metric: DashboardMetric) {
   return `/tickets?${params.toString()}`;
 }
 
+function AgentBarChart({
+  title,
+  data,
+  emptyMessage,
+}: {
+  title: string;
+  data: DashboardAgentCount[];
+  emptyMessage: string;
+}) {
+  const maxCount = data.length > 0 ? Math.max(...data.map((item) => item.count)) : 0;
+
+  return (
+    <Card>
+      <Space direction="vertical" size={12} style={{ width: "100%" }}>
+        <Typography.Title level={4} style={{ margin: 0 }}>
+          {title}
+        </Typography.Title>
+
+        {data.length === 0 ? (
+          <Empty description={emptyMessage} />
+        ) : (
+          <Space direction="vertical" size={10} style={{ width: "100%" }}>
+            {data.map((item) => {
+              const percentage = maxCount === 0 ? 0 : (item.count / maxCount) * 100;
+
+              return (
+                <div key={item.assigneeUserId}>
+                  <Space style={{ width: "100%", justifyContent: "space-between" }}>
+                    <Typography.Text>{item.assigneeDisplayName}</Typography.Text>
+                    <Typography.Text strong>{item.count}</Typography.Text>
+                  </Space>
+                  <Progress
+                    percent={Number(percentage.toFixed(2))}
+                    showInfo={false}
+                    strokeColor="#389e0d"
+                  />
+                </div>
+              );
+            })}
+          </Space>
+        )}
+      </Space>
+    </Card>
+  );
+}
+
 export function AgentAdminDashboardPage() {
   const navigate = useNavigate();
   const [loadState, setLoadState] = useState<LoadState>("loading");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [attentionTickets, setAttentionTickets] = useState<TicketSummary[]>([]);
-  const [unassignedCount, setUnassignedCount] = useState(0);
-  const [mineCount, setMineCount] = useState(0);
-  const [inProgressCount, setInProgressCount] = useState(0);
-  const [waitingResponseCount, setWaitingResponseCount] = useState(0);
+  const [stats, setStats] = useState<DashboardStats | null>(null);
 
   useEffect(() => {
     let isMounted = true;
@@ -49,24 +81,11 @@ export function AgentAdminDashboardPage() {
       setErrorMessage(null);
 
       try {
-        const [unassigned, mine, inProgress, waitingResponse] = await Promise.all([
-          ticketsApi.getQueueTickets({ scope: "UNASSIGNED", page: 0, size: 1 }),
-          ticketsApi.getQueueTickets({ scope: "MINE", page: 0, size: 1 }),
-          ticketsApi.getQueueTickets({ scope: "ALL", status: "IN_PROGRESS", page: 0, size: 1 }),
-          ticketsApi.getQueueTickets({ scope: "MINE", status: "OPEN", page: 0, size: 20 }),
-        ]);
+        const response = await ticketsApi.getDashboardStats();
 
         if (!isMounted) return;
 
-        const requiresAttention = waitingResponse.items.filter(
-          (ticket) => ticket.assignedToUserId !== null,
-        );
-
-        setUnassignedCount(unassigned.total);
-        setMineCount(mine.total);
-        setInProgressCount(inProgress.total);
-        setWaitingResponseCount(waitingResponse.total);
-        setAttentionTickets(requiresAttention.slice(0, 8));
+        setStats(response);
         setLoadState("ready");
       } catch (error) {
         if (!isMounted) return;
@@ -85,68 +104,38 @@ export function AgentAdminDashboardPage() {
     };
   }, []);
 
-  const metrics: DashboardMetric[] = [
-    { key: "unassigned", label: "Sin asignar", value: unassignedCount, view: "unassigned" },
-    { key: "mine", label: "Asignados a mí", value: mineCount, view: "mine" },
-    {
-      key: "inProgress",
-      label: "En progreso",
-      value: inProgressCount,
-      view: "all",
-      status: "IN_PROGRESS",
-    },
-    {
-      key: "waitingResponse",
-      label: "Esperando respuesta",
-      value: waitingResponseCount,
-      view: "mine",
-      status: "OPEN",
-    },
-  ];
+  const metrics: DashboardMetric[] = useMemo(() => {
+    if (!stats) return [];
 
-  const columns: TableProps<TicketSummary>["columns"] = useMemo(
-    () => [
-      { title: "ID", dataIndex: "id", key: "id", width: 180 },
-      { title: "Título", dataIndex: "title", key: "title" },
+    return [
       {
-        title: "Estado",
-        dataIndex: "status",
-        key: "status",
-        width: 140,
-        render: (statusValue: unknown) => (
-          <TicketStatusBadge status={statusValue as TicketStatus} />
-        ),
+        key: "unassigned",
+        label: "Tickets sin asignar",
+        value: stats.cards.unassigned,
+        view: "unassigned",
       },
       {
-        title: "Prioridad",
-        dataIndex: "priority",
-        key: "priority",
-        width: 120,
-        render: (priorityValue: unknown) => (
-          <Tag>{ticketPriorityLabel[priorityValue as TicketPriority]}</Tag>
-        ),
+        key: "mine",
+        label: "Tickets asignados a mí",
+        value: stats.cards.assignedToMe,
+        view: "mine",
       },
       {
-        title: "Actualizado",
-        dataIndex: "updatedAt",
-        key: "updatedAt",
-        width: 180,
-        render: (updatedAtValue: unknown) => formatDate(String(updatedAtValue)),
+        key: "inProgress",
+        label: "WIP (en progreso)",
+        value: stats.cards.inProgress,
+        view: "all",
+        status: "IN_PROGRESS",
       },
       {
-        title: "Acciones",
-        dataIndex: "id",
-        key: "actions",
-        width: 120,
-        render: (_id: unknown, row: TicketSummary) => (
-          <Button size="small" onClick={() => navigate(`/tickets/${row.id}`)}>
-            Ver
-          </Button>
-        ),
+        key: "onHold",
+        label: "Esperando respuesta",
+        value: stats.cards.onHold,
+        view: "all",
+        status: "ON_HOLD",
       },
-    ],
-    [navigate],
-  );
+    ];
+  }, [stats]);
 
   return (
     <Space direction="vertical" size={16} style={{ width: "100%" }}>
@@ -154,10 +143,10 @@ export function AgentAdminDashboardPage() {
         Dashboard de soporte
       </Typography.Title>
       <Typography.Text type="secondary">
-        Resumen operativo para agentes y administradores.
+        Resumen operativo y estadístico para agentes y administradores.
       </Typography.Text>
 
-      {loadState === "loading" && <Skeleton active paragraph={{ rows: 5 }} />}
+      {loadState === "loading" && <Skeleton active paragraph={{ rows: 8 }} />}
 
       {loadState === "error" && (
         <Alert
@@ -168,9 +157,15 @@ export function AgentAdminDashboardPage() {
         />
       )}
 
-      {loadState === "ready" && (
+      {loadState === "ready" && stats && (
         <>
-          <Space style={{ display: "grid", gridTemplateColumns: "repeat(4, minmax(0, 1fr))" }}>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
+              gap: 12,
+            }}
+          >
             {metrics.map((metric) => (
               <Card key={metric.key}>
                 <button
@@ -182,35 +177,36 @@ export function AgentAdminDashboardPage() {
                     cursor: "pointer",
                     textAlign: "left",
                     width: "100%",
+                    padding: 0,
                   }}
                 >
                   <Typography.Text type="secondary">{metric.label}</Typography.Text>
-                  <Typography.Title level={3} style={{ margin: "8px 0 0" }}>
+                  <Typography.Title level={2} style={{ margin: "8px 0 0" }}>
                     {metric.value}
                   </Typography.Title>
                 </button>
               </Card>
             ))}
-          </Space>
+          </div>
 
-          <Card>
-            <Space direction="vertical" size={12} style={{ width: "100%" }}>
-              <Typography.Title level={4} style={{ margin: 0 }}>
-                Requieren atención
-              </Typography.Title>
-
-              {attentionTickets.length === 0 ? (
-                <Empty description="No hay tickets pendientes de atención inmediata" />
-              ) : (
-                <Table<TicketSummary>
-                  rowKey="id"
-                  columns={columns}
-                  dataSource={attentionTickets}
-                  pagination={false}
-                />
-              )}
-            </Space>
-          </Card>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+              gap: 12,
+            }}
+          >
+            <AgentBarChart
+              title="Tickets cerrados por agente/admin"
+              data={stats.charts.resolvedByAgent}
+              emptyMessage="No hay tickets cerrados asignados"
+            />
+            <AgentBarChart
+              title="Tickets asignados por agente/admin"
+              data={stats.charts.assignedByAgent}
+              emptyMessage="No hay tickets asignados"
+            />
+          </div>
         </>
       )}
     </Space>


### PR DESCRIPTION
### Motivation
- Provide operational dashboard metrics for agents and admins to see unassigned, assigned-to-me, in-progress and on-hold counts and charts of tickets per agent.
- Surface aggregated counts from the backend to support new frontend cards and charts for monitoring team activity.

