### PR TITLE
Exclude frontend test support files from Sonar coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -25,6 +25,10 @@ sonar.java.binaries=ticketing-backend/target/classes
 # Frontend coverage (Vitest LCOV)
 sonar.javascript.lcov.reportPaths=ticketing-frontend/coverage/lcov.info
 
+# Coverage exclusions for non-production support code
+sonar.coverage.exclusions=\
+  ticketing-frontend/src/test/**
+
 # Exclude generated artifacts and build outputs
 sonar.exclusions=\
   **/node_modules/**,\


### PR DESCRIPTION
Add `sonar.coverage.exclusions=\
  ticketing-frontend/src/test/**` to `sonar-project.properties` to exclude frontend test helper files from coverage calculation.
