### PR TITLE
Ocultar panel de Acciones para USER y mostrar nombre de Categoría en detalle

### DIFF
--- a/ticketing-frontend/src/app/layout/AppShell.test.tsx
+++ b/ticketing-frontend/src/app/layout/AppShell.test.tsx
@@ -7,9 +7,15 @@ import { renderWithProviders } from "src/test/utils/renderWithProviders";
 
 const hasRoleMock = vi.fn<(role: "USER" | "AGENT" | "ADMIN") => boolean>();
 const logoutMock = vi.fn();
+const authStateMock = {
+  user: {
+    displayName: "Ada Lovelace",
+  },
+};
 
 vi.mock("../../features/auth/hooks/useAuth", () => ({
   useAuth: () => ({
+    state: authStateMock,
     hasRole: hasRoleMock,
     logout: logoutMock,
   }),
@@ -45,6 +51,7 @@ describe("AppShell", () => {
     renderWithRouter();
 
     expect(await screen.findByText("TFG Ticketing")).toBeInTheDocument();
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
     expect(screen.getByText("Ticketing Platform")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Dashboard page" })).toBeInTheDocument();
   });

--- a/ticketing-frontend/src/app/layout/AppShell.tsx
+++ b/ticketing-frontend/src/app/layout/AppShell.tsx
@@ -41,7 +41,7 @@ function getSelectedKey(pathname: string, items: AppMenuItem[]) {
 export function AppShell() {
   const location = useLocation();
   const navigate = useNavigate();
-  const { hasRole, logout } = useAuth();
+  const { state, hasRole, logout } = useAuth();
 
   const isAdmin = hasRole("ADMIN");
   const canSeeDashboard = hasRole("AGENT") || isAdmin;
@@ -59,7 +59,7 @@ export function AppShell() {
           <Typography.Title level={4} style={{ margin: 0 }}>
             TFG Ticketing
           </Typography.Title>
-          <Typography.Text type="secondary">Frontend MVP</Typography.Text>
+          <Typography.Text type="secondary">{state.user?.displayName ?? "Usuario"}</Typography.Text>
         </div>
         <Menu
           mode="inline"

--- a/ticketing-frontend/src/app/pages/ProfilePage.tsx
+++ b/ticketing-frontend/src/app/pages/ProfilePage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import type { CSSProperties } from "react";
-import { Alert, Button, Card, Space, Typography } from "antd";
-import { useNavigate } from "react-router-dom";
+import { Alert, Card, Space, Typography } from "antd";
 import { useAuth } from "../../features/auth/hooks/useAuth";
 import { authApi } from "../../features/auth/api/authApi";
 import type { ProfileResponse } from "../../features/auth/model/types";
@@ -15,8 +14,7 @@ const rowStyle: CSSProperties = {
 };
 
 export function ProfilePage() {
-  const navigate = useNavigate();
-  const { state, logout } = useAuth();
+  const { state } = useAuth();
   const [profile, setProfile] = useState<ProfileResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -32,11 +30,6 @@ export function ProfilePage() {
         setError(err.message || "No se pudo cargar el perfil");
       });
   }, [state.token]);
-
-  const onLogout = () => {
-    logout();
-    navigate("/login", { replace: true });
-  };
 
   const data =
     profile ??
@@ -56,9 +49,6 @@ export function ProfilePage() {
         <Typography.Title level={3} style={{ marginBottom: 0 }}>
           Perfil
         </Typography.Title>
-        <Typography.Text type="secondary">
-          Información de sesión actual basada en JWT.
-        </Typography.Text>
       </div>
 
       {error && <Alert type="error" showIcon message={error} />}
@@ -87,10 +77,6 @@ export function ProfilePage() {
           <Typography.Text type="secondary">No hay datos de perfil disponibles.</Typography.Text>
         )}
       </Card>
-
-      <Button type="default" onClick={onLogout} style={{ width: "fit-content" }}>
-        Logout
-      </Button>
     </Space>
   );
 }

--- a/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.test.tsx
@@ -64,6 +64,14 @@ describe("TicketDetailPage", () => {
     navigateMock.mockReset();
     paramsMock.mockReturnValue({ id: "ticket-1" });
     hasAnyRoleMock.mockReturnValue(true);
+    server.use(
+      http.get("/api/categories", () =>
+        jsonResponse([
+          { id: "cat-1", name: "Hardware" },
+          { id: "cat-2", name: "Software" },
+        ]),
+      ),
+    );
   });
 
   it("carga el ticket y muestra título, estado y timeline", async () => {
@@ -74,6 +82,7 @@ describe("TicketDetailPage", () => {
     expect(await screen.findByTestId("ticket-detail-title")).toHaveTextContent("Printer issue");
     expect(screen.getByTestId("ticket-detail-status")).toHaveTextContent("Abierto");
     expect(screen.getByText("Paper jam on tray 2")).toBeInTheDocument();
+    expect(screen.getByText("Categoría: Hardware")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Asignarme ticket" })).toBeInTheDocument();
   });
 
@@ -167,13 +176,14 @@ describe("TicketDetailPage", () => {
     });
   });
 
-  it("en rol USER muestra vista solo lectura y oculta acciones de gestión", async () => {
+  it("en rol USER oculta la caja de acciones de gestión", async () => {
     hasAnyRoleMock.mockReturnValue(false);
     server.use(http.get("/api/tickets/ticket-1", () => jsonResponse(buildTicket())));
 
     renderWithProviders(<TicketDetailPage />, { router: {} });
 
-    expect(await screen.findByText("Vista de solo lectura")).toBeInTheDocument();
+    expect(await screen.findByText("Conversación")).toBeInTheDocument();
+    expect(screen.queryByText("Acciones")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Asignarme ticket" })).not.toBeInTheDocument();
     expect(screen.queryByTestId("ticket-status-transition-IN_PROGRESS")).not.toBeInTheDocument();
   });

--- a/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useAuth } from "../../../auth/hooks/useAuth";
 import { ticketsApi } from "../../api/ticketsApi";
 import { ticketPriorityLabel, ticketStatusLabel } from "../../model/presentation";
-import type { TicketDetail, TicketStatus, TimelineEntry } from "../../model/types";
+import type { TicketCategory, TicketDetail, TicketStatus, TimelineEntry } from "../../model/types";
 import { TicketStatusBadge } from "../shared/TicketStatusBadge";
 
 type LoadState = "loading" | "ready" | "error";
@@ -28,6 +28,7 @@ export function TicketDetailPage() {
   const [busyAction, setBusyAction] = useState<"assign" | "status" | null>(null);
   const [commentText, setCommentText] = useState("");
   const [busyComment, setBusyComment] = useState(false);
+  const [categories, setCategories] = useState<TicketCategory[]>([]);
 
   const availableStatusTransitions = useMemo(
     () => ticket?.availableTransitions ?? ([] as TicketStatus[]),
@@ -62,6 +63,12 @@ export function TicketDetailPage() {
     }));
   }, [ticket]);
 
+  const categoryDisplayName = useMemo(() => {
+    if (!ticket) return "";
+    const category = categories.find((item) => item.id === ticket.categoryId);
+    return category?.name ?? ticket.categoryId;
+  }, [categories, ticket]);
+
   useEffect(() => {
     if (!id) {
       setLoadState("error");
@@ -76,9 +83,13 @@ export function TicketDetailPage() {
       setErrorMessage(null);
 
       try {
-        const response = await ticketsApi.getTicketById(id);
+        const [ticketResponse, categoriesResponse] = await Promise.all([
+          ticketsApi.getTicketById(id),
+          ticketsApi.getCategories().catch(() => []),
+        ]);
         if (!mounted) return;
-        setTicket(response);
+        setTicket(ticketResponse);
+        setCategories(categoriesResponse);
         setLoadState("ready");
       } catch (error) {
         if (!mounted) return;
@@ -171,7 +182,13 @@ export function TicketDetailPage() {
         />
       )}
 
-      <div style={{ display: "grid", gridTemplateColumns: "2fr 3fr 1.5fr", gap: 16 }}>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: canManage ? "2fr 3fr 1.5fr" : "2fr 4fr",
+          gap: 16,
+        }}
+      >
         <div>
           <Card>
             <Space direction="vertical" size={12} style={{ width: "100%" }}>
@@ -186,7 +203,7 @@ export function TicketDetailPage() {
                 Metadata
               </Typography.Title>
               <Typography.Text>ID: {ticket.id}</Typography.Text>
-              <Typography.Text>Categoría: {ticket.categoryId}</Typography.Text>
+              <Typography.Text>Categoría: {categoryDisplayName}</Typography.Text>
               <Typography.Text>Creado por: {ticket.createdByDisplayName}</Typography.Text>
               <Typography.Text>
                 Asignado a: {ticket.assignedToDisplayName ?? "Sin asignar"}
@@ -240,21 +257,12 @@ export function TicketDetailPage() {
           </Card>
         </div>
 
-        <div>
-          <Card>
-            <Typography.Title level={5} style={{ margin: "0 0 12px" }}>
-              Acciones
-            </Typography.Title>
-            {!canManage && (
-              <Alert
-                showIcon
-                type="info"
-                message="Vista de solo lectura"
-                description="Tu rol solo puede ver el detalle y la conversación del ticket."
-              />
-            )}
-
-            {canManage && (
+        {canManage && (
+          <div>
+            <Card>
+              <Typography.Title level={5} style={{ margin: "0 0 12px" }}>
+                Acciones
+              </Typography.Title>
               <Space direction="vertical" style={{ width: "100%" }} size={12}>
                 {!ticket.assignedToUserId && (
                   <Button loading={busyAction === "assign"} onClick={handleAssignToMe}>
@@ -281,9 +289,9 @@ export function TicketDetailPage() {
                   </Button>
                 ))}
               </Space>
-            )}
-          </Card>
-        </div>
+            </Card>
+          </div>
+        )}
       </div>
     </Space>
   );


### PR DESCRIPTION
- Evitar que usuarios con rol `USER` vean el panel de Acciones y aprovechar su espacio para que la Conversación tenga más ancho. 
- Mostrar en la metadata de ticket el `name` de la categoría en lugar del `id` para mejorar la legibilidad. 
- Mantener la resiliencia ante fallos de carga de categorías y respetar patrones existentes de carga y presentación.
