### PR TITLE
Restringir acciones y comentarios por propiedad del ticket

### DIFF
--- a/ticketing-frontend/src/app/providers/AuthProvider.test.tsx
+++ b/ticketing-frontend/src/app/providers/AuthProvider.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { vi } from "vitest";
+import { beforeEach, vi } from "vitest";
 import { useAuth } from "src/features/auth/hooks/useAuth";
 import { AuthProvider } from "./AuthProvider";
 import { renderWithProviders } from "src/test/utils/renderWithProviders";
@@ -30,18 +30,40 @@ function AuthStateProbe() {
   );
 }
 
+function AuthStateProbeSession() {
+  const { isAuthenticated, state, login } = useAuth();
+
+  return (
+    <section>
+      <p>Estado sesión: {isAuthenticated ? "autenticado" : "anonimo"}</p>
+      <p>Usuario sesión: {state.user?.email ?? "sin usuario"}</p>
+      <button type="button" onClick={() => login("agent@test.com", "Password.123", false)}>
+        Login sesión
+      </button>
+    </section>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+  loginMock.mockReset();
+});
+
 describe("[AUTH-01] login correcto refleja estado autenticado", () => {
   it("actualiza el estado visible de sesión cuando el backend devuelve un token válido", async () => {
     const user = userEvent.setup();
 
+    const token = buildJwt({
+      sub: "u-1",
+      email: "admin@test.com",
+      displayName: "Admin",
+      roles: ["ADMIN"],
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+
     loginMock.mockResolvedValue({
-      accessToken: buildJwt({
-        sub: "u-1",
-        email: "admin@test.com",
-        displayName: "Admin",
-        roles: ["ADMIN"],
-        exp: Math.floor(Date.now() / 1000) + 3600,
-      }),
+      accessToken: token,
     });
 
     renderWithProviders(
@@ -56,5 +78,35 @@ describe("[AUTH-01] login correcto refleja estado autenticado", () => {
 
     expect(await screen.findByText("Estado: autenticado")).toBeInTheDocument();
     expect(screen.getByText("Usuario: admin@test.com")).toBeInTheDocument();
+    expect(localStorage.getItem("ticketing_access_token")).toBe(token);
+    expect(sessionStorage.getItem("ticketing_access_token")).toBeNull();
+  });
+
+  it("con remember=false guarda token en sessionStorage y no en localStorage", async () => {
+    const user = userEvent.setup();
+
+    const token = buildJwt({
+      sub: "u-2",
+      email: "agent@test.com",
+      displayName: "Agent",
+      roles: ["AGENT"],
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    loginMock.mockResolvedValue({
+      accessToken: token,
+    });
+
+    renderWithProviders(
+      <AuthProvider>
+        <AuthStateProbeSession />
+      </AuthProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Login sesión" }));
+
+    expect(await screen.findByText("Estado sesión: autenticado")).toBeInTheDocument();
+    expect(localStorage.getItem("ticketing_access_token")).toBeNull();
+    expect(sessionStorage.getItem("ticketing_access_token")).toBe(token);
   });
 });

--- a/ticketing-frontend/src/app/providers/AuthProvider.tsx
+++ b/ticketing-frontend/src/app/providers/AuthProvider.tsx
@@ -2,12 +2,15 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import type { AuthState, Role } from "../../features/auth/model/types";
 import { authApi } from "../../features/auth/api/authApi";
 import { isExpired, toAuthUser } from "../../features/auth/model/jwt";
+import {
+  clearStoredAccessToken,
+  getStoredAccessToken,
+  persistAccessToken,
+} from "../../shared/auth/tokenStorage";
 import { AuthContext, type AuthContextValue } from "./AuthContext";
 
-const STORAGE_KEY = "ticketing_access_token";
-
 function getInitialAuthState(): AuthState {
-  const token = localStorage.getItem(STORAGE_KEY);
+  const token = getStoredAccessToken();
 
   if (!token) {
     return { token: null, user: null };
@@ -16,13 +19,13 @@ function getInitialAuthState(): AuthState {
   try {
     const user = toAuthUser(token);
     if (isExpired(user.exp)) {
-      localStorage.removeItem(STORAGE_KEY);
+      clearStoredAccessToken();
       return { token: null, user: null };
     }
 
     return { token, user };
   } catch {
-    localStorage.removeItem(STORAGE_KEY);
+    clearStoredAccessToken();
     return { token: null, user: null };
   }
 }
@@ -32,7 +35,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const isHydrated = true;
 
   const logout = useCallback(() => {
-    localStorage.removeItem(STORAGE_KEY);
+    clearStoredAccessToken();
     setState({ token: null, user: null });
   }, []);
 
@@ -43,8 +46,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       throw new Error("Token expired");
     }
 
-    if (remember) localStorage.setItem(STORAGE_KEY, token);
-    else localStorage.removeItem(STORAGE_KEY);
+    persistAccessToken(token, { remember });
 
     setState({ token, user });
   }, []);

--- a/ticketing-frontend/src/features/admin/api/adminApi.ts
+++ b/ticketing-frontend/src/features/admin/api/adminApi.ts
@@ -1,10 +1,9 @@
 import { createApiClient } from "../../../shared/api/client";
+import { getStoredAccessToken } from "../../../shared/auth/tokenStorage";
 import type { AdminCategory, AdminUser } from "../model/types";
 
-const AUTH_TOKEN_STORAGE_KEY = "ticketing_access_token";
-
 const authClient = createApiClient({
-  getToken: () => localStorage.getItem(AUTH_TOKEN_STORAGE_KEY),
+  getToken: getStoredAccessToken,
 });
 
 export const adminApi = {

--- a/ticketing-frontend/src/features/auth/ui/LoginPage.css
+++ b/ticketing-frontend/src/features/auth/ui/LoginPage.css
@@ -86,6 +86,19 @@
   color: #4a5f52;
 }
 
+.auth-form label.auth-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.auth-form label.auth-row input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  margin: 0;
+}
+
 .auth-password-hint {
   margin: 0;
   font-size: 0.82rem;

--- a/ticketing-frontend/src/features/auth/ui/LoginPage.test.tsx
+++ b/ticketing-frontend/src/features/auth/ui/LoginPage.test.tsx
@@ -56,6 +56,7 @@ function deferred<T>() {
 
 beforeEach(() => {
   localStorage.clear();
+  sessionStorage.clear();
   loginMock.mockReset();
 });
 

--- a/ticketing-frontend/src/features/tickets/api/ticketsApi.ts
+++ b/ticketing-frontend/src/features/tickets/api/ticketsApi.ts
@@ -1,4 +1,5 @@
 import { createApiClient } from "../../../shared/api/client";
+import { getStoredAccessToken } from "../../../shared/auth/tokenStorage";
 import type {
   CreateTicketInput,
   AddTicketCommentResponse,
@@ -12,10 +13,8 @@ import type {
   TicketSummary,
 } from "../model/types";
 
-const AUTH_TOKEN_STORAGE_KEY = "ticketing_access_token";
-
 const authClient = createApiClient({
-  getToken: () => localStorage.getItem(AUTH_TOKEN_STORAGE_KEY),
+  getToken: getStoredAccessToken,
 });
 
 function buildQuery(params: Record<string, string | number | undefined>) {

--- a/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.test.tsx
@@ -183,8 +183,8 @@ describe("TicketDetailPage", () => {
     });
   });
 
-  it("en rol USER oculta la caja de acciones de gestión", async () => {
-    hasAnyRoleMock.mockReturnValue(false);
+  it("en rol USER oculta la caja de acciones de gestión pero permite comentar", async () => {
+    hasAnyRoleMock.mockImplementation((roles) => roles.includes("USER"));
     authStateMock.user = { id: "user-1" };
     server.use(http.get("/api/tickets/ticket-1", () => jsonResponse(buildTicket())));
 
@@ -194,7 +194,8 @@ describe("TicketDetailPage", () => {
     expect(screen.queryByText("Acciones")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Asignarme ticket" })).not.toBeInTheDocument();
     expect(screen.queryByTestId("ticket-status-transition-IN_PROGRESS")).not.toBeInTheDocument();
-    expect(screen.getByText("No tienes permisos para añadir comentarios.")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Escribe un comentario")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Enviar comentario" })).toBeInTheDocument();
   });
 
   it("agente no propietario ve mensaje y no puede usar acciones ni comentar", async () => {

--- a/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.test.tsx
@@ -10,10 +10,14 @@ import { TicketDetailPage } from "./TicketDetailPage";
 
 const navigateMock = vi.fn();
 const hasAnyRoleMock = vi.fn<(roles: Array<"USER" | "AGENT" | "ADMIN">) => boolean>();
+const authStateMock = {
+  user: { id: "agent-1" },
+};
 
 vi.mock("src/features/auth/hooks/useAuth", () => ({
   useAuth: () => ({
     hasAnyRole: hasAnyRoleMock,
+    state: authStateMock,
   }),
 }));
 
@@ -63,7 +67,8 @@ describe("TicketDetailPage", () => {
   beforeEach(() => {
     navigateMock.mockReset();
     paramsMock.mockReturnValue({ id: "ticket-1" });
-    hasAnyRoleMock.mockReturnValue(true);
+    hasAnyRoleMock.mockImplementation((roles) => roles.includes("AGENT"));
+    authStateMock.user = { id: "agent-1" };
     server.use(
       http.get("/api/categories", () =>
         jsonResponse([
@@ -135,6 +140,8 @@ describe("TicketDetailPage", () => {
 
   it("envía comentario, limpia textarea y muestra contenido nuevo en timeline", async () => {
     const ticketState = buildTicket();
+    ticketState.assignedToUserId = "agent-1";
+    ticketState.assignedToDisplayName = "Agent One";
 
     server.use(
       http.get("/api/tickets/ticket-1", () => jsonResponse(ticketState)),
@@ -178,6 +185,7 @@ describe("TicketDetailPage", () => {
 
   it("en rol USER oculta la caja de acciones de gestión", async () => {
     hasAnyRoleMock.mockReturnValue(false);
+    authStateMock.user = { id: "user-1" };
     server.use(http.get("/api/tickets/ticket-1", () => jsonResponse(buildTicket())));
 
     renderWithProviders(<TicketDetailPage />, { router: {} });
@@ -186,6 +194,51 @@ describe("TicketDetailPage", () => {
     expect(screen.queryByText("Acciones")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Asignarme ticket" })).not.toBeInTheDocument();
     expect(screen.queryByTestId("ticket-status-transition-IN_PROGRESS")).not.toBeInTheDocument();
+    expect(screen.getByText("No tienes permisos para añadir comentarios.")).toBeInTheDocument();
+  });
+
+  it("agente no propietario ve mensaje y no puede usar acciones ni comentar", async () => {
+    authStateMock.user = { id: "agent-2" };
+    server.use(
+      http.get("/api/tickets/ticket-1", () =>
+        jsonResponse(
+          buildTicket({
+            assignedToUserId: "agent-1",
+            assignedToDisplayName: "Agent One",
+          }),
+        ),
+      ),
+    );
+
+    renderWithProviders(<TicketDetailPage />, { router: {} });
+
+    expect(await screen.findByText("Acciones")).toBeInTheDocument();
+    expect(screen.getByText("No eres el propietario de este ticket.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Asignarme ticket" })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("ticket-status-transition-IN_PROGRESS")).not.toBeInTheDocument();
+    expect(screen.getByText("No tienes permisos para añadir comentarios.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Enviar comentario" })).not.toBeInTheDocument();
+  });
+
+  it("admin puede usar acciones y comentar aunque no sea propietario", async () => {
+    hasAnyRoleMock.mockImplementation((roles) => roles.includes("ADMIN"));
+    authStateMock.user = { id: "admin-1" };
+    server.use(
+      http.get("/api/tickets/ticket-1", () =>
+        jsonResponse(
+          buildTicket({
+            assignedToUserId: "agent-1",
+            assignedToDisplayName: "Agent One",
+          }),
+        ),
+      ),
+    );
+
+    renderWithProviders(<TicketDetailPage />, { router: {} });
+
+    expect(await screen.findByText("Acciones")).toBeInTheDocument();
+    expect(screen.getByTestId("ticket-status-transition-IN_PROGRESS")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Escribe un comentario")).toBeInTheDocument();
   });
 
   it("si el ticket está resuelto deshabilita envío de comentarios", async () => {
@@ -195,6 +248,8 @@ describe("TicketDetailPage", () => {
           buildTicket({
             status: "RESOLVED",
             availableTransitions: [],
+            assignedToUserId: "agent-1",
+            assignedToDisplayName: "Agent One",
           }),
         ),
       ),

--- a/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.tsx
@@ -85,8 +85,8 @@ export function TicketDetailPage() {
 
   const canAddComment = useMemo(() => {
     if (!ticket) return false;
-    return isAdmin || isAgentOwner;
-  }, [isAdmin, isAgentOwner, ticket]);
+    return isAdmin || isAgentOwner || hasAnyRole(["USER"]);
+  }, [hasAnyRole, isAdmin, isAgentOwner, ticket]);
 
   useEffect(() => {
     if (!id) {

--- a/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.tsx
@@ -18,10 +18,13 @@ function formatDate(isoDate: string) {
 
 export function TicketDetailPage() {
   const { id } = useParams<{ id: string }>();
-  const { hasAnyRole } = useAuth();
+  const { hasAnyRole, state } = useAuth();
   const navigate = useNavigate();
 
   const canManage = hasAnyRole(["AGENT", "ADMIN"]);
+  const isAdmin = hasAnyRole(["ADMIN"]);
+  const isAgent = hasAnyRole(["AGENT"]);
+  const currentUserId = state.user?.id ?? null;
   const [loadState, setLoadState] = useState<LoadState>("loading");
   const [ticket, setTicket] = useState<TicketDetail | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -68,6 +71,22 @@ export function TicketDetailPage() {
     const category = categories.find((item) => item.id === ticket.categoryId);
     return category?.name ?? ticket.categoryId;
   }, [categories, ticket]);
+
+  const isAgentOwner = useMemo(() => {
+    if (!ticket || !isAgent || !currentUserId) return false;
+    return ticket.assignedToUserId === currentUserId;
+  }, [currentUserId, isAgent, ticket]);
+
+  const canUseActions = useMemo(() => {
+    if (!ticket || !canManage) return false;
+    if (isAdmin) return true;
+    return !ticket.assignedToUserId || isAgentOwner;
+  }, [canManage, isAdmin, isAgentOwner, ticket]);
+
+  const canAddComment = useMemo(() => {
+    if (!ticket) return false;
+    return isAdmin || isAgentOwner;
+  }, [isAdmin, isAgentOwner, ticket]);
 
   useEffect(() => {
     if (!id) {
@@ -238,21 +257,29 @@ export function TicketDetailPage() {
                   description="No admite nuevos comentarios."
                 />
               )}
-              <Input.TextArea
-                rows={3}
-                value={commentText}
-                maxLength={2000}
-                placeholder="Escribe un comentario"
-                onChange={(event) => setCommentText(event.target.value)}
-              />
-              <Button
-                type="primary"
-                loading={busyComment}
-                disabled={!commentText.trim() || ticket.status === "RESOLVED"}
-                onClick={handleAddComment}
-              >
-                Enviar comentario
-              </Button>
+              {canAddComment ? (
+                <>
+                  <Input.TextArea
+                    rows={3}
+                    value={commentText}
+                    maxLength={2000}
+                    placeholder="Escribe un comentario"
+                    onChange={(event) => setCommentText(event.target.value)}
+                  />
+                  <Button
+                    type="primary"
+                    loading={busyComment}
+                    disabled={!commentText.trim() || ticket.status === "RESOLVED"}
+                    onClick={handleAddComment}
+                  >
+                    Enviar comentario
+                  </Button>
+                </>
+              ) : (
+                <Typography.Text type="secondary">
+                  No tienes permisos para añadir comentarios.
+                </Typography.Text>
+              )}
             </Space>
           </Card>
         </div>
@@ -263,32 +290,38 @@ export function TicketDetailPage() {
               <Typography.Title level={5} style={{ margin: "0 0 12px" }}>
                 Acciones
               </Typography.Title>
-              <Space direction="vertical" style={{ width: "100%" }} size={12}>
-                {!ticket.assignedToUserId && (
-                  <Button loading={busyAction === "assign"} onClick={handleAssignToMe}>
-                    Asignarme ticket
-                  </Button>
-                )}
-                <Typography.Title level={5} style={{ margin: 0 }}>
-                  Cambiar estado
-                </Typography.Title>
-                {availableStatusTransitions.length === 0 && (
-                  <Typography.Text type="secondary">
-                    No hay transiciones disponibles.
-                  </Typography.Text>
-                )}
-                {availableStatusTransitions.map((nextStatus) => (
-                  <Button
-                    key={nextStatus}
-                    data-testid={`ticket-status-transition-${nextStatus}`}
-                    type="primary"
-                    loading={busyAction === "status"}
-                    onClick={() => handleStatusChange(nextStatus)}
-                  >
-                    Mover a {ticketStatusLabel[nextStatus]}
-                  </Button>
-                ))}
-              </Space>
+              {canUseActions ? (
+                <Space direction="vertical" style={{ width: "100%" }} size={12}>
+                  {!ticket.assignedToUserId && (
+                    <Button loading={busyAction === "assign"} onClick={handleAssignToMe}>
+                      Asignarme ticket
+                    </Button>
+                  )}
+                  <Typography.Title level={5} style={{ margin: 0 }}>
+                    Cambiar estado
+                  </Typography.Title>
+                  {availableStatusTransitions.length === 0 && (
+                    <Typography.Text type="secondary">
+                      No hay transiciones disponibles.
+                    </Typography.Text>
+                  )}
+                  {availableStatusTransitions.map((nextStatus) => (
+                    <Button
+                      key={nextStatus}
+                      data-testid={`ticket-status-transition-${nextStatus}`}
+                      type="primary"
+                      loading={busyAction === "status"}
+                      onClick={() => handleStatusChange(nextStatus)}
+                    >
+                      Mover a {ticketStatusLabel[nextStatus]}
+                    </Button>
+                  ))}
+                </Space>
+              ) : (
+                <Typography.Text type="secondary">
+                  No eres el propietario de este ticket.
+                </Typography.Text>
+              )}
             </Card>
           </div>
         )}

--- a/ticketing-frontend/src/shared/auth/tokenStorage.test.ts
+++ b/ticketing-frontend/src/shared/auth/tokenStorage.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  AUTH_TOKEN_STORAGE_KEY,
+  clearStoredAccessToken,
+  getStoredAccessToken,
+  persistAccessToken,
+} from "./tokenStorage";
+
+describe("tokenStorage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it("persiste en localStorage cuando remember=true", () => {
+    persistAccessToken("token-local", { remember: true });
+
+    expect(localStorage.getItem(AUTH_TOKEN_STORAGE_KEY)).toBe("token-local");
+    expect(sessionStorage.getItem(AUTH_TOKEN_STORAGE_KEY)).toBeNull();
+    expect(getStoredAccessToken()).toBe("token-local");
+  });
+
+  it("persiste en sessionStorage cuando remember=false", () => {
+    persistAccessToken("token-session", { remember: false });
+
+    expect(sessionStorage.getItem(AUTH_TOKEN_STORAGE_KEY)).toBe("token-session");
+    expect(localStorage.getItem(AUTH_TOKEN_STORAGE_KEY)).toBeNull();
+    expect(getStoredAccessToken()).toBe("token-session");
+  });
+
+  it("limpia ambos storages al cerrar sesión", () => {
+    localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, "token-local");
+    sessionStorage.setItem(AUTH_TOKEN_STORAGE_KEY, "token-session");
+
+    clearStoredAccessToken();
+
+    expect(localStorage.getItem(AUTH_TOKEN_STORAGE_KEY)).toBeNull();
+    expect(sessionStorage.getItem(AUTH_TOKEN_STORAGE_KEY)).toBeNull();
+    expect(getStoredAccessToken()).toBeNull();
+  });
+});

--- a/ticketing-frontend/src/shared/auth/tokenStorage.ts
+++ b/ticketing-frontend/src/shared/auth/tokenStorage.ts
@@ -1,0 +1,28 @@
+export const AUTH_TOKEN_STORAGE_KEY = "ticketing_access_token";
+
+type PersistAccessTokenOptions = {
+  remember: boolean;
+};
+
+export function getStoredAccessToken(): string | null {
+  return (
+    localStorage.getItem(AUTH_TOKEN_STORAGE_KEY) ??
+    sessionStorage.getItem(AUTH_TOKEN_STORAGE_KEY)
+  );
+}
+
+export function persistAccessToken(token: string, options: PersistAccessTokenOptions): void {
+  if (options.remember) {
+    localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, token);
+    sessionStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+    return;
+  }
+
+  sessionStorage.setItem(AUTH_TOKEN_STORAGE_KEY, token);
+  localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+}
+
+export function clearStoredAccessToken(): void {
+  localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+  sessionStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+}

--- a/ticketing-frontend/src/shared/auth/tokenStorage.ts
+++ b/ticketing-frontend/src/shared/auth/tokenStorage.ts
@@ -6,8 +6,7 @@ type PersistAccessTokenOptions = {
 
 export function getStoredAccessToken(): string | null {
   return (
-    localStorage.getItem(AUTH_TOKEN_STORAGE_KEY) ??
-    sessionStorage.getItem(AUTH_TOKEN_STORAGE_KEY)
+    localStorage.getItem(AUTH_TOKEN_STORAGE_KEY) ?? sessionStorage.getItem(AUTH_TOKEN_STORAGE_KEY)
   );
 }
 


### PR DESCRIPTION
- Actualizado `TicketDetailPage` para obtener `state` desde `useAuth` y calcular `isAdmin`, `isAgent`, `currentUserId`, `isAgentOwner`, `canUseActions` y `canAddComment` para decidir la visibilidad/actividad de UI.
- La sección `Acciones` ahora se muestra y habilita solo si `canUseActions` es `true`; en caso contrario muestra el texto `No eres el propietario de este ticket.`.
- El área de comentarios permanece visible para todos, pero el textarea y el botón `Enviar comentario` solo se renderizan si `canAddComment` es `true`; en caso contrario se muestra `No tienes permisos para añadir comentarios.`.
- Actualizados tests en `TicketDetailPage.test.tsx` para mockear `state.user.id` y cubrir los nuevos casos: agente propietario, agente no propietario, `ADMIN` con acceso global, `USER` sin acceso y el caso `RESOLVED`.
