### PR TITLE
Migrate frontend UI copy from Spanish to English

### DIFF
--- a/ticketing-frontend/e2e/tickets-agent.spec.ts
+++ b/ticketing-frontend/e2e/tickets-agent.spec.ts
@@ -10,9 +10,9 @@ async function createTicketAsUser(page: Page) {
   await page.getByTestId("user-create-ticket-cta").click();
   await expect(page).toHaveURL(/\/tickets\/new$/);
 
-  await page.getByLabel("Título").fill(title);
+  await page.getByLabel("Title").fill(title);
   await page
-    .getByLabel("Descripción")
+    .getByLabel("Description")
     .fill("Ticket creado para validar cambio de estado por agente.");
   await selectFirstTicketCategory(page);
   await page.getByTestId("create-ticket-submit").click();
@@ -29,17 +29,17 @@ test("TICKET-AGENT-01 agent/admin cambia estado correctamente", async ({ page })
   await loginAs(page, "agent");
   await page.goto("/tickets");
   await expect(page).toHaveURL(/\/tickets(?:\?.*)?$/);
-  await page.getByRole("button", { name: "Todos" }).click();
+  await page.getByRole("button", { name: "All" }).click();
 
-  await page.getByPlaceholder("Buscar por título o ID").fill(ticketTitle);
-  await page.getByRole("button", { name: "Buscar" }).click();
-  await page.getByRole("button", { name: "Ver" }).first().click();
+  await page.getByPlaceholder("Search by title or ID").fill(ticketTitle);
+  await page.getByRole("button", { name: "Search" }).click();
+  await page.getByRole("button", { name: "View" }).first().click();
 
   await expect(page.getByTestId("ticket-detail-title")).toContainText(ticketTitle);
-  await expect(page.getByTestId("ticket-detail-status")).toContainText("Abierto");
+  await expect(page.getByTestId("ticket-detail-status")).toContainText("Open");
 
   await page.getByTestId("ticket-status-transition-IN_PROGRESS").click();
-  await expect(page.getByTestId("ticket-detail-status")).toContainText("En progreso");
+  await expect(page.getByTestId("ticket-detail-status")).toContainText("In progress");
 });
 
 test("TICKET-AGENT-04 agent se asigna ticket y comenta en el detalle", async ({ page }) => {
@@ -49,20 +49,20 @@ test("TICKET-AGENT-04 agent se asigna ticket y comenta en el detalle", async ({ 
   await loginAs(page, "agent");
   await page.goto("/tickets");
   await expect(page).toHaveURL(/\/tickets(?:\?.*)?$/);
-  await page.getByRole("button", { name: "Todos" }).click();
+  await page.getByRole("button", { name: "All" }).click();
 
-  await page.getByPlaceholder("Buscar por título o ID").fill(ticketTitle);
-  await page.getByRole("button", { name: "Buscar" }).click();
-  await page.getByRole("button", { name: "Ver" }).first().click();
+  await page.getByPlaceholder("Search by title or ID").fill(ticketTitle);
+  await page.getByRole("button", { name: "Search" }).click();
+  await page.getByRole("button", { name: "View" }).first().click();
 
   await expect(page.getByTestId("ticket-detail-title")).toContainText(ticketTitle);
 
-  await page.getByRole("button", { name: "Asignarme ticket" }).click();
-  await expect(page.getByRole("button", { name: "Asignarme ticket" })).toHaveCount(0);
+  await page.getByRole("button", { name: "Assign ticket to me" }).click();
+  await expect(page.getByRole("button", { name: "Assign ticket to me" })).toHaveCount(0);
 
   const commentText = `Comentario E2E agente ${Date.now()}`;
-  await page.getByPlaceholder("Escribe un comentario").fill(commentText);
-  await page.getByRole("button", { name: "Enviar comentario" }).click();
+  await page.getByPlaceholder("Write a comment").fill(commentText);
+  await page.getByRole("button", { name: "Send comment" }).click();
 
   await expect(page.getByText(commentText)).toBeVisible();
 });

--- a/ticketing-frontend/e2e/tickets-user.spec.ts
+++ b/ticketing-frontend/e2e/tickets-user.spec.ts
@@ -9,8 +9,8 @@ test("TICKET-USER-01 usuario crea ticket y llega al detalle", async ({ page }) =
   await expect(page).toHaveURL(/\/tickets\/new$/);
 
   const uniqueSuffix = Date.now();
-  await page.getByLabel("Título").fill(`E2E ticket ${uniqueSuffix}`);
-  await page.getByLabel("Descripción").fill("Flujo E2E mínimo para validar creación de ticket.");
+  await page.getByLabel("Title").fill(`E2E ticket ${uniqueSuffix}`);
+  await page.getByLabel("Description").fill("Flujo E2E mínimo para validar creación de ticket.");
 
   await selectFirstTicketCategory(page);
   await page.getByTestId("create-ticket-submit").click();

--- a/ticketing-frontend/src/app/layout/AppShell.test.tsx
+++ b/ticketing-frontend/src/app/layout/AppShell.test.tsx
@@ -71,14 +71,14 @@ describe("AppShell", () => {
     renderWithRouter();
 
     await screen.findByRole("heading", { name: "Dashboard page" });
-    expect(screen.queryByText("Administración")).not.toBeInTheDocument();
+    expect(screen.queryByText("Administration")).not.toBeInTheDocument();
   });
 
   it("shows admin menu for ADMIN", async () => {
     hasRoleMock.mockReturnValue(true);
     renderWithRouter();
 
-    expect(await screen.findByText("Administración")).toBeInTheDocument();
+    expect(await screen.findByText("Administration")).toBeInTheDocument();
   });
 
   it("shows dashboard menu for AGENT but not admin menu", async () => {
@@ -86,7 +86,7 @@ describe("AppShell", () => {
     renderWithRouter();
 
     expect(await screen.findByText("Dashboard")).toBeInTheDocument();
-    expect(screen.queryByText("Administración")).not.toBeInTheDocument();
+    expect(screen.queryByText("Administration")).not.toBeInTheDocument();
   });
 
   it("logs out and redirects to login from header button", async () => {

--- a/ticketing-frontend/src/app/layout/AppShell.tsx
+++ b/ticketing-frontend/src/app/layout/AppShell.tsx
@@ -11,8 +11,8 @@ const { Header, Sider, Content } = Layout;
 
 const baseItems: AppMenuItem[] = [
   { key: "/tickets", icon: <HiTicket fontSize={18} />, label: "Tickets" },
-  { key: "/tickets/new", icon: <MdOutlineAdd fontSize={18} />, label: "Nuevo ticket" },
-  { key: "/profile", icon: <HiBars3 fontSize={18} />, label: "Perfil" },
+  { key: "/tickets/new", icon: <MdOutlineAdd fontSize={18} />, label: "New ticket" },
+  { key: "/profile", icon: <HiBars3 fontSize={18} />, label: "Profile" },
 ];
 
 function getMenuItems(canSeeDashboard: boolean, isAdmin: boolean): AppMenuItem[] {
@@ -23,7 +23,7 @@ function getMenuItems(canSeeDashboard: boolean, isAdmin: boolean): AppMenuItem[]
   }
 
   if (isAdmin) {
-    items.push({ key: "/admin", icon: <HiUsers fontSize={18} />, label: "Administración" });
+    items.push({ key: "/admin", icon: <HiUsers fontSize={18} />, label: "Administration" });
   }
 
   return items;
@@ -59,7 +59,7 @@ export function AppShell() {
           <Typography.Title level={4} style={{ margin: 0 }}>
             TFG Ticketing
           </Typography.Title>
-          <Typography.Text type="secondary">{state.user?.displayName ?? "Usuario"}</Typography.Text>
+          <Typography.Text type="secondary">{state.user?.displayName ?? "User"}</Typography.Text>
         </div>
         <Menu
           mode="inline"

--- a/ticketing-frontend/src/app/pages/NotFoundPage.tsx
+++ b/ticketing-frontend/src/app/pages/NotFoundPage.tsx
@@ -8,8 +8,8 @@ export function NotFoundPage() {
     <Result
       status="404"
       title="404"
-      subTitle="La página que buscas no existe."
-      extra={<Button onClick={() => navigate("/dashboard")}>Ir al dashboard</Button>}
+      subTitle="The page you are looking for does not exist."
+      extra={<Button onClick={() => navigate("/dashboard")}>Go to dashboard</Button>}
     />
   );
 }

--- a/ticketing-frontend/src/app/pages/PlaceholderPage.tsx
+++ b/ticketing-frontend/src/app/pages/PlaceholderPage.tsx
@@ -11,7 +11,7 @@ export function PlaceholderPage({ title }: PlaceholderPageProps) {
         {title}
       </Typography.Title>
       <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
-        Página placeholder para el MVP.
+        Placeholder page for the MVP.
       </Typography.Paragraph>
     </Card>
   );

--- a/ticketing-frontend/src/app/pages/ProfilePage.tsx
+++ b/ticketing-frontend/src/app/pages/ProfilePage.tsx
@@ -27,7 +27,7 @@ export function ProfilePage() {
         setProfile(data);
       })
       .catch((err: Error) => {
-        setError(err.message || "No se pudo cargar el perfil");
+        setError(err.message || "Could not load profile");
       });
   }, [state.token]);
 
@@ -47,7 +47,7 @@ export function ProfilePage() {
     <Space direction="vertical" size={16} style={{ width: "100%", maxWidth: 820 }}>
       <div>
         <Typography.Title level={3} style={{ marginBottom: 0 }}>
-          Perfil
+          Profile
         </Typography.Title>
       </div>
 
@@ -69,12 +69,12 @@ export function ProfilePage() {
               <span>{data.displayName}</span>
             </div>
             <div style={{ ...rowStyle, borderBottom: "none" }}>
-              <strong>Rol</strong>
+              <strong>Role</strong>
               <span>{data.role}</span>
             </div>
           </div>
         ) : (
-          <Typography.Text type="secondary">No hay datos de perfil disponibles.</Typography.Text>
+          <Typography.Text type="secondary">No profile data available.</Typography.Text>
         )}
       </Card>
     </Space>

--- a/ticketing-frontend/src/app/pages/TicketsPage.test.tsx
+++ b/ticketing-frontend/src/app/pages/TicketsPage.test.tsx
@@ -12,11 +12,11 @@ vi.mock("../../features/auth/hooks/useAuth", () => ({
 }));
 
 vi.mock("src/features/tickets/ui/ticketsPage/UserTicketsHomePage", () => ({
-  UserTicketsHomePage: () => <h1>Mis tickets</h1>,
+  UserTicketsHomePage: () => <h1>My tickets</h1>,
 }));
 
 vi.mock("src/features/tickets/ui/ticketsPage/AgentAdminTicketsPage", () => ({
-  AgentAdminTicketsPage: () => <h1>Gestión de tickets</h1>,
+  AgentAdminTicketsPage: () => <h1>Ticket management</h1>,
 }));
 
 describe("TicketsPage", () => {
@@ -29,7 +29,7 @@ describe("TicketsPage", () => {
 
     renderWithProviders(<TicketsPage />, { router: {} });
 
-    expect(screen.getByRole("heading", { name: "Mis tickets" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "My tickets" })).toBeInTheDocument();
   });
 
   it("renderiza vista de gestión cuando tiene rol AGENT/ADMIN", () => {
@@ -37,6 +37,6 @@ describe("TicketsPage", () => {
 
     renderWithProviders(<TicketsPage />, { router: {} });
 
-    expect(screen.getByRole("heading", { name: "Gestión de tickets" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Ticket management" })).toBeInTheDocument();
   });
 });

--- a/ticketing-frontend/src/app/providers/AuthProvider.test.tsx
+++ b/ticketing-frontend/src/app/providers/AuthProvider.test.tsx
@@ -21,8 +21,8 @@ function AuthStateProbe() {
 
   return (
     <section>
-      <p>Estado: {isAuthenticated ? "autenticado" : "anonimo"}</p>
-      <p>Usuario: {state.user?.email ?? "sin usuario"}</p>
+      <p>Estado: {isAuthenticated ? "authenticated" : "anonymous"}</p>
+      <p>Usuario: {state.user?.email ?? "no user"}</p>
       <button type="button" onClick={() => login("admin@test.com", "Password.123", true)}>
         Login
       </button>
@@ -35,10 +35,10 @@ function AuthStateProbeSession() {
 
   return (
     <section>
-      <p>Estado sesión: {isAuthenticated ? "autenticado" : "anonimo"}</p>
-      <p>Usuario sesión: {state.user?.email ?? "sin usuario"}</p>
+      <p>Estado sesión: {isAuthenticated ? "authenticated" : "anonymous"}</p>
+      <p>Usuario sesión: {state.user?.email ?? "no user"}</p>
       <button type="button" onClick={() => login("agent@test.com", "Password.123", false)}>
-        Login sesión
+        Session login
       </button>
     </section>
   );
@@ -50,7 +50,7 @@ beforeEach(() => {
   loginMock.mockReset();
 });
 
-describe("[AUTH-01] login correcto refleja estado autenticado", () => {
+describe("[AUTH-01] login correcto refleja estado authenticated", () => {
   it("actualiza el estado visible de sesión cuando el backend devuelve un token válido", async () => {
     const user = userEvent.setup();
 
@@ -72,11 +72,11 @@ describe("[AUTH-01] login correcto refleja estado autenticado", () => {
       </AuthProvider>,
     );
 
-    expect(screen.getByText("Estado: anonimo")).toBeInTheDocument();
+    expect(screen.getByText("Estado: anonymous")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Login" }));
 
-    expect(await screen.findByText("Estado: autenticado")).toBeInTheDocument();
+    expect(await screen.findByText("Estado: authenticated")).toBeInTheDocument();
     expect(screen.getByText("Usuario: admin@test.com")).toBeInTheDocument();
     expect(localStorage.getItem("ticketing_access_token")).toBe(token);
     expect(sessionStorage.getItem("ticketing_access_token")).toBeNull();
@@ -103,9 +103,9 @@ describe("[AUTH-01] login correcto refleja estado autenticado", () => {
       </AuthProvider>,
     );
 
-    await user.click(screen.getByRole("button", { name: "Login sesión" }));
+    await user.click(screen.getByRole("button", { name: "Session login" }));
 
-    expect(await screen.findByText("Estado sesión: autenticado")).toBeInTheDocument();
+    expect(await screen.findByText("Estado sesión: authenticated")).toBeInTheDocument();
     expect(localStorage.getItem("ticketing_access_token")).toBeNull();
     expect(sessionStorage.getItem("ticketing_access_token")).toBe(token);
   });

--- a/ticketing-frontend/src/features/admin/ui/AdminPage.test.tsx
+++ b/ticketing-frontend/src/features/admin/ui/AdminPage.test.tsx
@@ -138,4 +138,18 @@ describe("AdminPage", () => {
       expect(messageErrorSpy).toHaveBeenCalledWith("Could not load users");
     });
   });
+
+  it("muestra error si se intenta guardar categoría con nombre vacío", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AdminPage />);
+
+    await user.click(await screen.findByRole("button", { name: "Edit" }));
+    const nameInput = await screen.findByPlaceholderText("Name");
+    await user.clear(nameInput);
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(messageErrorSpy).toHaveBeenCalledWith("Name is required");
+    expect(updateCategoryMock).not.toHaveBeenCalled();
+  });
 });

--- a/ticketing-frontend/src/features/admin/ui/AdminPage.test.tsx
+++ b/ticketing-frontend/src/features/admin/ui/AdminPage.test.tsx
@@ -54,9 +54,9 @@ describe("AdminPage", () => {
   it("renderiza tabs y datos cargados en categorías", async () => {
     renderWithProviders(<AdminPage />);
 
-    expect(screen.getByRole("heading", { name: "Administración" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Administration" })).toBeInTheDocument();
     expect(await screen.findByText("Software")).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Usuarios" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Users" })).toBeInTheDocument();
   });
 
   it("crea una categoría nueva y limpia el input", async () => {
@@ -65,16 +65,16 @@ describe("AdminPage", () => {
     const user = userEvent.setup();
     renderWithProviders(<AdminPage />);
 
-    const input = await screen.findByPlaceholderText("Nueva categoría");
+    const input = await screen.findByPlaceholderText("New category");
     await user.type(input, "Hardware");
-    await user.click(screen.getByRole("button", { name: "Crear" }));
+    await user.click(screen.getByRole("button", { name: "Create" }));
 
     await waitFor(() => {
       expect(createCategoryMock).toHaveBeenCalledWith("Hardware");
       expect(screen.getByText("Hardware")).toBeInTheDocument();
-      expect(screen.getByPlaceholderText("Nueva categoría")).toHaveValue("");
+      expect(screen.getByPlaceholderText("New category")).toHaveValue("");
     });
-    expect(messageSuccessSpy).toHaveBeenCalledWith("Categoría creada");
+    expect(messageSuccessSpy).toHaveBeenCalledWith("Category created");
   });
 
   it("edita categoría existente (nombre + activa/inactiva)", async () => {
@@ -83,16 +83,16 @@ describe("AdminPage", () => {
     const user = userEvent.setup();
     renderWithProviders(<AdminPage />);
 
-    await user.click(await screen.findByRole("button", { name: "Editar" }));
+    await user.click(await screen.findByRole("button", { name: "Edit" }));
 
-    const nameInput = await screen.findByPlaceholderText("Nombre");
+    const nameInput = await screen.findByPlaceholderText("Name");
     await user.clear(nameInput);
     await user.type(nameInput, "Software Legacy");
 
     const modalSwitch = screen.getAllByRole("switch")[0];
     await user.click(modalSwitch);
 
-    await user.click(screen.getByRole("button", { name: "Guardar" }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
       expect(updateCategoryMock).toHaveBeenCalledWith("cat-1", {
@@ -100,9 +100,9 @@ describe("AdminPage", () => {
         isActive: false,
       });
       expect(screen.getByText("Software Legacy")).toBeInTheDocument();
-      expect(screen.getByText("Inactiva")).toBeInTheDocument();
+      expect(screen.getByText("Inactive")).toBeInTheDocument();
     });
-    expect(messageSuccessSpy).toHaveBeenCalledWith("Categoría actualizada");
+    expect(messageSuccessSpy).toHaveBeenCalledWith("Category updated");
   });
 
   it("deactiva usuario desde tab de usuarios", async () => {
@@ -117,14 +117,14 @@ describe("AdminPage", () => {
     const user = userEvent.setup();
     renderWithProviders(<AdminPage />);
 
-    await user.click(screen.getByRole("tab", { name: "Usuarios" }));
+    await user.click(screen.getByRole("tab", { name: "Users" }));
     const userSwitch = await screen.findByRole("switch");
     await user.click(userSwitch);
 
     await waitFor(() => {
       expect(updateUserActiveMock).toHaveBeenCalledWith("u1", false);
     });
-    expect(messageSuccessSpy).toHaveBeenCalledWith("Estado de usuario actualizado");
+    expect(messageSuccessSpy).toHaveBeenCalledWith("User status updated");
   });
 
   it("muestra error cuando falla la carga inicial", async () => {
@@ -134,8 +134,8 @@ describe("AdminPage", () => {
     renderWithProviders(<AdminPage />);
 
     await waitFor(() => {
-      expect(messageErrorSpy).toHaveBeenCalledWith("No se pudieron cargar las categorías");
-      expect(messageErrorSpy).toHaveBeenCalledWith("No se pudieron cargar los usuarios");
+      expect(messageErrorSpy).toHaveBeenCalledWith("Could not load categories");
+      expect(messageErrorSpy).toHaveBeenCalledWith("Could not load users");
     });
   });
 });

--- a/ticketing-frontend/src/features/admin/ui/AdminPage.tsx
+++ b/ticketing-frontend/src/features/admin/ui/AdminPage.tsx
@@ -27,7 +27,7 @@ export function AdminPage() {
       const data = await adminApi.getCategories();
       setCategories(data);
     } catch {
-      message.error("No se pudieron cargar las categorías");
+      message.error("Could not load categories");
     } finally {
       setLoadingCategories(false);
     }
@@ -39,7 +39,7 @@ export function AdminPage() {
       const data = await adminApi.getUsers();
       setUsers(data);
     } catch {
-      message.error("No se pudieron cargar los usuarios");
+      message.error("Could not load users");
     } finally {
       setLoadingUsers(false);
     }
@@ -51,15 +51,15 @@ export function AdminPage() {
 
   const categoryColumns = useMemo<SimpleColumn<AdminCategory>[]>(
     () => [
-      { title: "Nombre", dataIndex: "name", key: "name" },
+      { title: "Name", dataIndex: "name", key: "name" },
       {
-        title: "Estado",
+        title: "Status",
         key: "isActive",
         render: (_: unknown, record: AdminCategory) =>
-          record.isActive ? <Tag color="success">Activa</Tag> : <Tag>Inactiva</Tag>,
+          record.isActive ? <Tag color="success">Active</Tag> : <Tag>Inactive</Tag>,
       },
       {
-        title: "Acciones",
+        title: "Actions",
         key: "actions",
         render: (_: unknown, record: AdminCategory) => (
           <Button
@@ -69,7 +69,7 @@ export function AdminPage() {
               setEditingActive(record.isActive);
             }}
           >
-            Editar
+            Edit
           </Button>
         ),
       },
@@ -79,16 +79,16 @@ export function AdminPage() {
 
   const userColumns = useMemo<SimpleColumn<AdminUser>[]>(
     () => [
-      { title: "Nombre", dataIndex: "displayName", key: "displayName" },
+      { title: "Name", dataIndex: "displayName", key: "displayName" },
       { title: "Email", dataIndex: "email", key: "email" },
       {
-        title: "Rol",
+        title: "Role",
         dataIndex: "role",
         key: "role",
         render: (role: unknown) => <Tag>{String(role)}</Tag>,
       },
       {
-        title: "Activo",
+        title: "Active",
         key: "isActive",
         render: (_: unknown, record: AdminUser) => (
           <Switch
@@ -97,9 +97,9 @@ export function AdminPage() {
               try {
                 const updated = await adminApi.updateUserActive(record.id, checked);
                 setUsers((prev) => prev.map((user) => (user.id === updated.id ? updated : user)));
-                message.success("Estado de usuario actualizado");
+                message.success("User status updated");
               } catch {
-                message.error("No se pudo actualizar el estado del usuario");
+                message.error("Could not update user status");
               }
             }}
           />
@@ -112,24 +112,24 @@ export function AdminPage() {
   return (
     <Space direction="vertical" size={16} style={{ width: "100%" }}>
       <Typography.Title level={3} style={{ margin: 0 }}>
-        <span data-testid="admin-title">Administración</span>
+        <span data-testid="admin-title">Administration</span>
       </Typography.Title>
       <Typography.Text type="secondary">
-        Gestiona categorías y usuarios de la plataforma. Solo los administradores tienen acceso.
+        Manage platform categories and users. Only administrators can access this area.
       </Typography.Text>
 
       <Tabs
         items={[
           {
             key: "categories",
-            label: "Categorías",
+            label: "Categories",
             children: (
               <Space direction="vertical" size={16} style={{ width: "100%" }}>
                 <Space>
                   <Input
                     value={newCategoryName}
                     onChange={(event) => setNewCategoryName(event.target.value)}
-                    placeholder="Nueva categoría"
+                    placeholder="New category"
                   />
                   <Button
                     type="primary"
@@ -137,7 +137,7 @@ export function AdminPage() {
                     onClick={async () => {
                       const name = newCategoryName.trim();
                       if (!name) {
-                        message.error("Nombre obligatorio");
+                        message.error("Name is required");
                         return;
                       }
 
@@ -148,15 +148,15 @@ export function AdminPage() {
                           [...prev, created].sort((a, b) => a.name.localeCompare(b.name)),
                         );
                         setNewCategoryName("");
-                        message.success("Categoría creada");
+                        message.success("Category created");
                       } catch {
-                        message.error("No se pudo crear la categoría (puede que ya exista)");
+                        message.error("Could not create category (it may already exist)");
                       } finally {
                         setCreatingCategory(false);
                       }
                     }}
                   >
-                    Crear
+                    Create
                   </Button>
                 </Space>
 
@@ -172,7 +172,7 @@ export function AdminPage() {
           },
           {
             key: "users",
-            label: "Usuarios",
+            label: "Users",
             children: (
               <Table
                 rowKey="id"
@@ -187,7 +187,7 @@ export function AdminPage() {
       />
 
       <Modal
-        title="Editar categoría"
+        title="Edit category"
         open={Boolean(editingCategory)}
         onCancel={() => setEditingCategory(null)}
         onOk={async () => {
@@ -197,7 +197,7 @@ export function AdminPage() {
 
           const name = editingName.trim();
           if (!name) {
-            message.error("Nombre obligatorio");
+            message.error("Name is required");
             return;
           }
 
@@ -210,21 +210,21 @@ export function AdminPage() {
               prev.map((category) => (category.id === updated.id ? updated : category)),
             );
             setEditingCategory(null);
-            message.success("Categoría actualizada");
+            message.success("Category updated");
           } catch {
-            message.error("No se pudo actualizar la categoría");
+            message.error("Could not update category");
           }
         }}
-        okText="Guardar"
+        okText="Save"
       >
         <Space direction="vertical" style={{ width: "100%" }}>
           <Input
             value={editingName}
             onChange={(event) => setEditingName(event.target.value)}
-            placeholder="Nombre"
+            placeholder="Name"
           />
           <Space>
-            <Typography.Text>Activa</Typography.Text>
+            <Typography.Text>Active</Typography.Text>
             <Switch checked={editingActive} onChange={setEditingActive} />
           </Space>
         </Space>

--- a/ticketing-frontend/src/features/auth/ui/LoginPage.test.tsx
+++ b/ticketing-frontend/src/features/auth/ui/LoginPage.test.tsx
@@ -35,11 +35,11 @@ function renderLogin(initialState?: { from?: string }) {
   );
 }
 
-function getSubmitButton(name: RegExp | string = /^Iniciar sesión$/i) {
+function getSubmitButton(name: RegExp | string = /^Sign in$/i) {
   const buttons = screen.getAllByRole("button", { name });
   const submit = buttons.find((button) => button.getAttribute("type") === "submit");
 
-  if (!submit) throw new Error("No se encontró el botón submit del formulario de login");
+  if (!submit) throw new Error("Could not find the login submit button");
   return submit;
 }
 
@@ -77,7 +77,7 @@ describe("[AUTH-01] Login correcto", () => {
     renderLogin({ from: "/tickets" });
 
     await user.type(screen.getByLabelText("Email"), "user@test.com");
-    await user.type(screen.getByLabelText("Contraseña"), "Password.123");
+    await user.type(screen.getByLabelText("Password"), "Password.123");
     await user.click(getSubmitButton());
 
     expect(loginMock).toHaveBeenCalledWith({ email: "user@test.com", password: "Password.123" });
@@ -93,10 +93,10 @@ describe("[AUTH-01] Login correcto", () => {
     renderLogin();
 
     await user.type(screen.getByLabelText("Email"), "user@test.com");
-    await user.type(screen.getByLabelText("Contraseña"), "Password.123");
+    await user.type(screen.getByLabelText("Password"), "Password.123");
     await user.click(getSubmitButton());
 
-    const submit = await screen.findByRole("button", { name: "Procesando..." });
+    const submit = await screen.findByRole("button", { name: "Processing..." });
     expect(submit).toBeDisabled();
 
     request.resolve({
@@ -128,15 +128,15 @@ describe("[AUTH-02] Login inválido", () => {
   it("muestra feedback de error y mantiene al usuario en login", async () => {
     const user = userEvent.setup();
 
-    loginMock.mockRejectedValueOnce(new ApiError("Credenciales inválidas", 401));
+    loginMock.mockRejectedValueOnce(new ApiError("Invalid credentials", 401));
 
     renderLogin({ from: "/tickets" });
 
     await user.type(screen.getByLabelText("Email"), "user@test.com");
-    await user.type(screen.getByLabelText("Contraseña"), "wrong-pass");
+    await user.type(screen.getByLabelText("Password"), "wrong-pass");
     await user.click(getSubmitButton());
 
-    expect(await screen.findByText("401 — Credenciales inválidas")).toBeInTheDocument();
+    expect(await screen.findByText("401 — Invalid credentials")).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Tickets" })).not.toBeInTheDocument();
     expect(getSubmitButton()).toBeEnabled();
   });

--- a/ticketing-frontend/src/features/auth/ui/LoginPage.tsx
+++ b/ticketing-frontend/src/features/auth/ui/LoginPage.tsx
@@ -22,7 +22,7 @@ export function LoginPage() {
   const [error, setError] = useState<string | null>(null);
 
   const submitText = useMemo(
-    () => (loading ? "Procesando..." : mode === "login" ? "Iniciar sesión" : "Crear cuenta"),
+    () => (loading ? "Processing..." : mode === "login" ? "Sign in" : "Create account"),
     [loading, mode],
   );
 
@@ -42,7 +42,7 @@ export function LoginPage() {
       nav(from, { replace: true });
     } catch (err) {
       if (err instanceof ApiError) setError(`${err.status} — ${err.message}`);
-      else setError("No se pudo completar la autenticación");
+      else setError("Could not complete authentication");
     } finally {
       setLoading(false);
     }
@@ -53,10 +53,10 @@ export function LoginPage() {
       <section className="auth-card">
         <div className="auth-brand">
           <h1>Ticketing Platform</h1>
-          <p>Accede o crea tu cuenta para gestionar incidencias de forma eficiente.</p>
+          <p>Sign in or create your account to manage support tickets efficiently.</p>
         </div>
 
-        <div className="auth-tabs" role="tablist" aria-label="Autenticación">
+        <div className="auth-tabs" role="tablist" aria-label="Authentication">
           <button
             type="button"
             className={`auth-tab ${mode === "login" ? "active" : ""}`}
@@ -65,7 +65,7 @@ export function LoginPage() {
               setError(null);
             }}
           >
-            Iniciar sesión
+            Sign in
           </button>
           <button
             type="button"
@@ -75,7 +75,7 @@ export function LoginPage() {
               setError(null);
             }}
           >
-            Registrarse
+            Sign up
           </button>
         </div>
 
@@ -94,7 +94,7 @@ export function LoginPage() {
 
           {mode === "register" && (
             <label>
-              Nombre a mostrar
+              Display name
               <input
                 value={displayName}
                 onChange={(e) => setDisplayName(e.target.value)}
@@ -105,7 +105,7 @@ export function LoginPage() {
           )}
 
           <label>
-            Contraseña
+            Password
             <input
               data-testid="auth-password"
               value={password}
@@ -119,7 +119,7 @@ export function LoginPage() {
           {mode === "register" && (
             <>
               <label>
-                Confirmar contraseña
+                Confirm password
                 <input
                   value={confirmPassword}
                   onChange={(e) => setConfirmPassword(e.target.value)}
@@ -129,8 +129,8 @@ export function LoginPage() {
                 />
               </label>
               <p className="auth-password-hint">
-                La contraseña debe tener mínimo 8 caracteres e incluir mayúsculas, minúsculas,
-                número y símbolo.
+                Password must be at least 8 characters and include uppercase, lowercase, a number,
+                and a symbol.
               </p>
             </>
           )}
@@ -141,7 +141,7 @@ export function LoginPage() {
               checked={remember}
               onChange={(e) => setRemember(e.target.checked)}
             />
-            Recordar sesión
+            Remember session
           </label>
 
           {error && (

--- a/ticketing-frontend/src/features/tickets/model/presentation.ts
+++ b/ticketing-frontend/src/features/tickets/model/presentation.ts
@@ -1,10 +1,10 @@
 import type { TicketPriority, TicketStatus } from "./types";
 
 export const ticketStatusLabel: Record<TicketStatus, string> = {
-  OPEN: "Abierto",
-  IN_PROGRESS: "En progreso",
-  ON_HOLD: "En espera",
-  RESOLVED: "Resuelto",
+  OPEN: "Open",
+  IN_PROGRESS: "In progress",
+  ON_HOLD: "On hold",
+  RESOLVED: "Resolved",
 };
 
 export const ticketStatusColor: Record<TicketStatus, string> = {
@@ -15,7 +15,7 @@ export const ticketStatusColor: Record<TicketStatus, string> = {
 };
 
 export const ticketPriorityLabel: Record<TicketPriority, string> = {
-  LOW: "Baja",
-  MEDIUM: "Media",
-  HIGH: "Alta",
+  LOW: "Low",
+  MEDIUM: "Medium",
+  HIGH: "High",
 };

--- a/ticketing-frontend/src/features/tickets/ui/create/CreateTicketPage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/create/CreateTicketPage.test.tsx
@@ -27,7 +27,7 @@ describe("CreateTicketPage", () => {
 
     renderWithProviders(<CreateTicketPage />, { router: {} });
 
-    const submitButton = await screen.findByRole("button", { name: "Crear ticket" });
+    const submitButton = await screen.findByRole("button", { name: "Create ticket" });
     expect(submitButton).toBeDisabled();
   });
 
@@ -41,7 +41,7 @@ describe("CreateTicketPage", () => {
 
     renderWithProviders(<CreateTicketPage />, { router: {} });
 
-    const submitButton = screen.getByRole("button", { name: "Crear ticket" });
+    const submitButton = screen.getByRole("button", { name: "Create ticket" });
     expect(submitButton).toBeDisabled();
   });
 
@@ -59,22 +59,22 @@ describe("CreateTicketPage", () => {
 
     renderWithProviders(<CreateTicketPage />, { router: {} });
 
-    fireEvent.change(await screen.findByLabelText("Título"), {
+    fireEvent.change(await screen.findByLabelText("Title"), {
       target: { value: "  Impresora bloqueada  " },
     });
-    fireEvent.change(screen.getByLabelText("Descripción"), {
+    fireEvent.change(screen.getByLabelText("Description"), {
       target: { value: "  Error E23 al imprimir PDF  " },
     });
 
-    const categoryCombobox = screen.getByRole("combobox", { name: "Categoría" });
+    const categoryCombobox = screen.getByRole("combobox", { name: "Category" });
     fireEvent.mouseDown(categoryCombobox);
     fireEvent.click(await screen.findByText("General"));
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Crear ticket" })).toBeEnabled();
+      expect(screen.getByRole("button", { name: "Create ticket" })).toBeEnabled();
     });
 
-    await user.click(screen.getByRole("button", { name: "Crear ticket" }));
+    await user.click(screen.getByRole("button", { name: "Create ticket" }));
 
     await waitFor(() => {
       expect(payload).toEqual({
@@ -101,16 +101,16 @@ describe("CreateTicketPage", () => {
 
     renderWithProviders(<CreateTicketPage />, { router: {} });
 
-    fireEvent.change(await screen.findByLabelText("Título"), {
+    fireEvent.change(await screen.findByLabelText("Title"), {
       target: { value: "Ticket en cola" },
     });
-    fireEvent.change(screen.getByLabelText("Descripción"), {
-      target: { value: "Descripción completa" },
+    fireEvent.change(screen.getByLabelText("Description"), {
+      target: { value: "Description completa" },
     });
-    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Categoría" }));
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Category" }));
     fireEvent.click(await screen.findByText("General"));
 
-    const submitButton = screen.getByRole("button", { name: "Crear ticket" });
+    const submitButton = screen.getByRole("button", { name: "Create ticket" });
     const form = submitButton.closest("form");
     expect(form).not.toBeNull();
     fireEvent.submit(form!);
@@ -131,13 +131,13 @@ describe("CreateTicketPage", () => {
 
     renderWithProviders(<CreateTicketPage />, { router: {} });
 
-    await user.type(await screen.findByLabelText("Título"), "No imprime");
-    await user.type(screen.getByLabelText("Descripción"), "Error de cola de impresión");
+    await user.type(await screen.findByLabelText("Title"), "No imprime");
+    await user.type(screen.getByLabelText("Description"), "Error de cola de impresión");
 
-    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Categoría" }));
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Category" }));
     fireEvent.click(await screen.findByText("General"));
-    await user.click(screen.getByRole("button", { name: "Crear ticket" }));
+    await user.click(screen.getByRole("button", { name: "Create ticket" }));
 
-    expect(await screen.findByText("Error al crear ticket")).toBeInTheDocument();
+    expect(await screen.findByText("Error creating ticket")).toBeInTheDocument();
   });
 });

--- a/ticketing-frontend/src/features/tickets/ui/create/CreateTicketPage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/create/CreateTicketPage.tsx
@@ -5,9 +5,9 @@ import { ticketsApi } from "../../api/ticketsApi";
 import type { TicketCategory, TicketPriority } from "../../model/types";
 
 const priorityOptions: Array<{ value: TicketPriority; label: string }> = [
-  { value: "LOW", label: "Baja" },
-  { value: "MEDIUM", label: "Media" },
-  { value: "HIGH", label: "Alta" },
+  { value: "LOW", label: "Low" },
+  { value: "MEDIUM", label: "Medium" },
+  { value: "HIGH", label: "High" },
 ];
 
 export function CreateTicketPage() {
@@ -39,9 +39,7 @@ export function CreateTicketPage() {
         setCategories(loadedCategories);
       } catch (error) {
         if (!isMounted) return;
-        setErrorMessage(
-          error instanceof Error ? error.message : "No se pudieron cargar las categorías.",
-        );
+        setErrorMessage(error instanceof Error ? error.message : "Could not load categories.");
       } finally {
         if (isMounted) {
           setIsLoadingCategories(false);
@@ -73,7 +71,7 @@ export function CreateTicketPage() {
       });
       navigate(`/tickets/${response.ticketId}`);
     } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : "No se pudo crear el ticket.");
+      setErrorMessage(error instanceof Error ? error.message : "Could not create the ticket.");
     } finally {
       setIsSubmitting(false);
     }
@@ -83,44 +81,44 @@ export function CreateTicketPage() {
     <Card>
       <Space direction="vertical" size={20} style={{ width: "100%" }}>
         <Typography.Title level={3} style={{ margin: 0 }}>
-          Crear ticket
+          Create ticket
         </Typography.Title>
 
         {errorMessage && (
-          <Alert showIcon type="error" message="Error al crear ticket" description={errorMessage} />
+          <Alert showIcon type="error" message="Error creating ticket" description={errorMessage} />
         )}
 
         <Form layout="vertical" onFinish={handleSubmit}>
           <Space direction="vertical" size={16} style={{ width: "100%" }}>
-            <Form.Item label="Título" style={{ marginBottom: 0 }}>
+            <Form.Item label="Title" style={{ marginBottom: 0 }}>
               <Input
-                aria-label="Título"
+                aria-label="Title"
                 value={title}
                 onChange={(event) => setTitle(event.target.value)}
-                placeholder="Describe brevemente tu incidencia"
+                placeholder="Briefly describe your issue"
                 maxLength={200}
               />
             </Form.Item>
 
-            <Form.Item label="Descripción" style={{ marginBottom: 0 }}>
+            <Form.Item label="Description" style={{ marginBottom: 0 }}>
               <Input.TextArea
-                aria-label="Descripción"
+                aria-label="Description"
                 value={description}
                 onChange={(event) => setDescription(event.target.value)}
-                placeholder="Explica qué ocurre, cuándo empezó y qué has probado"
+                placeholder="Explain what is happening, when it started, and what you have tried"
                 maxLength={1000}
                 rows={6}
               />
             </Form.Item>
 
-            <Form.Item label="Categoría" style={{ marginBottom: 0 }}>
+            <Form.Item label="Category" style={{ marginBottom: 0 }}>
               <Select
                 data-testid="create-ticket-category"
-                aria-label="Categoría"
+                aria-label="Category"
                 value={categoryId || undefined}
                 onChange={(value) => setCategoryId(value)}
                 disabled={isLoadingCategories}
-                placeholder="Selecciona una categoría"
+                placeholder="Select a category"
                 options={categories.map((category) => ({
                   label: category.name,
                   value: category.id,
@@ -128,9 +126,9 @@ export function CreateTicketPage() {
               />
             </Form.Item>
 
-            <Form.Item label="Prioridad" style={{ marginBottom: 0 }}>
+            <Form.Item label="Priority" style={{ marginBottom: 0 }}>
               <Select
-                aria-label="Prioridad"
+                aria-label="Priority"
                 value={priority}
                 onChange={(value) => setPriority(value as TicketPriority)}
                 options={priorityOptions}
@@ -145,7 +143,7 @@ export function CreateTicketPage() {
               disabled={isSubmitDisabled || isLoadingCategories}
               style={{ backgroundColor: "#389e0d" }}
             >
-              Crear ticket
+              Create ticket
             </Button>
           </Space>
         </Form>

--- a/ticketing-frontend/src/features/tickets/ui/dashboard/AgentAdminDashboardPage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/dashboard/AgentAdminDashboardPage.test.tsx
@@ -44,8 +44,8 @@ describe("AgentAdminDashboardPage", () => {
 
     renderPage();
 
-    expect(await screen.findByText("Tickets sin asignar")).toBeInTheDocument();
-    expect(screen.getByText("Tickets cerrados por agente/admin")).toBeInTheDocument();
+    expect(await screen.findByText("Unassigned tickets")).toBeInTheDocument();
+    expect(screen.getByText("Tickets resolved by agent/admin")).toBeInTheDocument();
     expect(screen.getAllByText("Agent Uno")).toHaveLength(2);
     expect(screen.getAllByText("Admin Uno")).toHaveLength(2);
   });
@@ -56,9 +56,9 @@ describe("AgentAdminDashboardPage", () => {
     const { router } = renderPage();
     const user = userEvent.setup();
 
-    await screen.findByText("WIP (en progreso)");
+    await screen.findByText("WIP (in progress)");
 
-    await user.click(screen.getByRole("button", { name: /WIP \(en progreso\)/i }));
+    await user.click(screen.getByRole("button", { name: /WIP \(in progress\)/i }));
 
     expect(router.state.location.pathname).toBe("/tickets");
     expect(router.state.location.search).toContain("view=all");

--- a/ticketing-frontend/src/features/tickets/ui/dashboard/AgentAdminDashboardPage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/dashboard/AgentAdminDashboardPage.tsx
@@ -105,7 +105,7 @@ export function AgentAdminDashboardPage() {
 
         setLoadState("error");
         setErrorMessage(
-          error instanceof Error ? error.message : "No se pudo cargar el dashboard de tickets.",
+          error instanceof Error ? error.message : "Could not load ticket dashboard.",
         );
       }
     };
@@ -123,26 +123,26 @@ export function AgentAdminDashboardPage() {
     return [
       {
         key: "unassigned",
-        label: "Tickets sin asignar",
+        label: "Unassigned tickets",
         value: stats.cards.unassigned,
         view: "unassigned",
       },
       {
         key: "mine",
-        label: "Tickets asignados a mí",
+        label: "Tickets assigned to me",
         value: stats.cards.assignedToMe,
         view: "mine",
       },
       {
         key: "inProgress",
-        label: "WIP (en progreso)",
+        label: "WIP (in progress)",
         value: stats.cards.inProgress,
         view: "all",
         status: "IN_PROGRESS",
       },
       {
         key: "onHold",
-        label: "Esperando respuesta",
+        label: "Waiting for response",
         value: stats.cards.onHold,
         view: "all",
         status: "ON_HOLD",
@@ -153,10 +153,10 @@ export function AgentAdminDashboardPage() {
   return (
     <Space direction="vertical" size={16} style={{ width: "100%" }}>
       <Typography.Title level={3} style={{ margin: 0 }}>
-        Dashboard de soporte
+        Support dashboard
       </Typography.Title>
       <Typography.Text type="secondary">
-        Resumen operativo y estadístico para agentes y administradores.
+        Operational and statistical summary for agents and administrators.
       </Typography.Text>
 
       {loadState === "loading" && <Skeleton active paragraph={{ rows: 8 }} />}
@@ -165,7 +165,7 @@ export function AgentAdminDashboardPage() {
         <Alert
           type="error"
           showIcon
-          message="No se ha podido cargar el dashboard"
+          message="Could not load the dashboard"
           description={errorMessage}
         />
       )}
@@ -210,14 +210,14 @@ export function AgentAdminDashboardPage() {
             }}
           >
             <AgentBarChart
-              title="Tickets cerrados por agente/admin"
+              title="Tickets resolved by agent/admin"
               data={stats.charts.resolvedByAgent}
-              emptyMessage="No hay tickets cerrados asignados"
+              emptyMessage="No resolved assigned tickets"
             />
             <AgentBarChart
-              title="Tickets asignados por agente/admin"
+              title="Tickets assigned by agent/admin"
               data={stats.charts.assignedByAgent}
-              emptyMessage="No hay tickets asignados"
+              emptyMessage="No assigned tickets"
             />
           </div>
         </>

--- a/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.test.tsx
@@ -85,10 +85,10 @@ describe("TicketDetailPage", () => {
     renderWithProviders(<TicketDetailPage />, { router: {} });
 
     expect(await screen.findByTestId("ticket-detail-title")).toHaveTextContent("Printer issue");
-    expect(screen.getByTestId("ticket-detail-status")).toHaveTextContent("Abierto");
+    expect(screen.getByTestId("ticket-detail-status")).toHaveTextContent("Open");
     expect(screen.getByText("Paper jam on tray 2")).toBeInTheDocument();
-    expect(screen.getByText("Categoría: Hardware")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Asignarme ticket" })).toBeInTheDocument();
+    expect(screen.getByText("Category: Hardware")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Assign ticket to me" })).toBeInTheDocument();
   });
 
   it("permite asignarse ticket y recarga detalle", async () => {
@@ -107,10 +107,10 @@ describe("TicketDetailPage", () => {
     const user = userEvent.setup();
     renderWithProviders(<TicketDetailPage />, { router: {} });
 
-    await user.click(await screen.findByRole("button", { name: "Asignarme ticket" }));
+    await user.click(await screen.findByRole("button", { name: "Assign ticket to me" }));
 
     await waitFor(() => {
-      expect(screen.getByText(/Asignado a: Agent One/i)).toBeInTheDocument();
+      expect(screen.getByText(/Assigned to: Agent One/i)).toBeInTheDocument();
     });
   });
 
@@ -134,7 +134,7 @@ describe("TicketDetailPage", () => {
     await user.click(await screen.findByTestId("ticket-status-transition-IN_PROGRESS"));
 
     await waitFor(() => {
-      expect(screen.getByTestId("ticket-detail-status")).toHaveTextContent("En progreso");
+      expect(screen.getByTestId("ticket-detail-status")).toHaveTextContent("In progress");
     });
   });
 
@@ -173,9 +173,9 @@ describe("TicketDetailPage", () => {
     const user = userEvent.setup();
     renderWithProviders(<TicketDetailPage />, { router: {} });
 
-    const textarea = await screen.findByPlaceholderText("Escribe un comentario");
+    const textarea = await screen.findByPlaceholderText("Write a comment");
     await user.type(textarea, "  Revisado, aplico solución.  ");
-    await user.click(screen.getByRole("button", { name: "Enviar comentario" }));
+    await user.click(screen.getByRole("button", { name: "Send comment" }));
 
     await waitFor(() => {
       expect(screen.getByDisplayValue("")).toBeInTheDocument();
@@ -190,12 +190,12 @@ describe("TicketDetailPage", () => {
 
     renderWithProviders(<TicketDetailPage />, { router: {} });
 
-    expect(await screen.findByText("Conversación")).toBeInTheDocument();
-    expect(screen.queryByText("Acciones")).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Asignarme ticket" })).not.toBeInTheDocument();
+    expect(await screen.findByText("Conversation")).toBeInTheDocument();
+    expect(screen.queryByText("Actions")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Assign ticket to me" })).not.toBeInTheDocument();
     expect(screen.queryByTestId("ticket-status-transition-IN_PROGRESS")).not.toBeInTheDocument();
-    expect(screen.getByPlaceholderText("Escribe un comentario")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Enviar comentario" })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Write a comment")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send comment" })).toBeInTheDocument();
   });
 
   it("agente no propietario ve mensaje y no puede usar acciones ni comentar", async () => {
@@ -213,12 +213,12 @@ describe("TicketDetailPage", () => {
 
     renderWithProviders(<TicketDetailPage />, { router: {} });
 
-    expect(await screen.findByText("Acciones")).toBeInTheDocument();
-    expect(screen.getByText("No eres el propietario de este ticket.")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Asignarme ticket" })).not.toBeInTheDocument();
+    expect(await screen.findByText("Actions")).toBeInTheDocument();
+    expect(screen.getByText("You are not the owner of this ticket.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Assign ticket to me" })).not.toBeInTheDocument();
     expect(screen.queryByTestId("ticket-status-transition-IN_PROGRESS")).not.toBeInTheDocument();
-    expect(screen.getByText("No tienes permisos para añadir comentarios.")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Enviar comentario" })).not.toBeInTheDocument();
+    expect(screen.getByText("You do not have permission to add comments.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Send comment" })).not.toBeInTheDocument();
   });
 
   it("admin puede usar acciones y comentar aunque no sea propietario", async () => {
@@ -237,9 +237,9 @@ describe("TicketDetailPage", () => {
 
     renderWithProviders(<TicketDetailPage />, { router: {} });
 
-    expect(await screen.findByText("Acciones")).toBeInTheDocument();
+    expect(await screen.findByText("Actions")).toBeInTheDocument();
     expect(screen.getByTestId("ticket-status-transition-IN_PROGRESS")).toBeInTheDocument();
-    expect(screen.getByPlaceholderText("Escribe un comentario")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Write a comment")).toBeInTheDocument();
   });
 
   it("si el ticket está resuelto deshabilita envío de comentarios", async () => {
@@ -258,8 +258,8 @@ describe("TicketDetailPage", () => {
 
     renderWithProviders(<TicketDetailPage />, { router: {} });
 
-    expect(await screen.findByText("Ticket resuelto")).toBeInTheDocument();
-    const submitCommentButton = screen.getByRole("button", { name: "Enviar comentario" });
+    expect(await screen.findByText("Ticket resolved")).toBeInTheDocument();
+    const submitCommentButton = screen.getByRole("button", { name: "Send comment" });
     expect(submitCommentButton).toBeDisabled();
   });
 
@@ -269,10 +269,10 @@ describe("TicketDetailPage", () => {
 
     renderWithProviders(<TicketDetailPage />, { router: {} });
 
-    expect(await screen.findByText("Error cargando el ticket")).toBeInTheDocument();
-    expect(screen.getByText("Id de ticket inválido")).toBeInTheDocument();
+    expect(await screen.findByText("Error loading ticket")).toBeInTheDocument();
+    expect(screen.getByText("Invalid ticket id")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Volver a tickets" }));
+    await user.click(screen.getByRole("button", { name: "Back to tickets" }));
     expect(navigateMock).toHaveBeenCalledWith("/tickets");
   });
 });

--- a/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.test.tsx
@@ -275,4 +275,66 @@ describe("TicketDetailPage", () => {
     await user.click(screen.getByRole("button", { name: "Back to tickets" }));
     expect(navigateMock).toHaveBeenCalledWith("/tickets");
   });
+
+  it("renderiza eventos de timeline para creación, cambio de estado y asignación", async () => {
+    server.use(
+      http.get("/api/tickets/ticket-1", () =>
+        jsonResponse(
+          buildTicket({
+            timeline: [
+              {
+                id: "ev-1",
+                kind: "EVENT",
+                createdAt: "2026-03-15T10:00:00.000Z",
+                actorUserId: "user-1",
+                actorDisplayName: "User One",
+                content: null,
+                eventType: "TICKET_CREATED",
+                payload: {},
+              },
+              {
+                id: "ev-2",
+                kind: "EVENT",
+                createdAt: "2026-03-15T10:01:00.000Z",
+                actorUserId: "agent-1",
+                actorDisplayName: "Agent One",
+                content: null,
+                eventType: "STATUS_CHANGED",
+                payload: { from: "OPEN", to: "IN_PROGRESS" },
+              },
+              {
+                id: "ev-3",
+                kind: "EVENT",
+                createdAt: "2026-03-15T10:02:00.000Z",
+                actorUserId: "agent-1",
+                actorDisplayName: "Agent One",
+                content: null,
+                eventType: "ASSIGNED_TO_ME",
+                payload: {},
+              },
+            ],
+          }),
+        ),
+      ),
+    );
+
+    renderWithProviders(<TicketDetailPage />, { router: {} });
+
+    expect(await screen.findByText("Ticket creado")).toBeInTheDocument();
+    expect(screen.getByText("Cambio de estado: OPEN → IN_PROGRESS")).toBeInTheDocument();
+    expect(screen.getByText("Assigned to Agent One")).toBeInTheDocument();
+  });
+
+  it("muestra mensaje genérico cuando la carga falla con error no tipado", async () => {
+    server.use(
+      http.get("/api/tickets/ticket-1", () => {
+        throw "boom";
+      }),
+    );
+
+    renderWithProviders(<TicketDetailPage />, { router: {} });
+
+    expect(await screen.findByText("Error loading ticket")).toBeInTheDocument();
+    expect(screen.getByText("Could not load the ticket.")).toBeInTheDocument();
+  });
 });

--- a/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/detail/TicketDetailPage.tsx
@@ -10,7 +10,7 @@ import { TicketStatusBadge } from "../shared/TicketStatusBadge";
 type LoadState = "loading" | "ready" | "error";
 
 function formatDate(isoDate: string) {
-  return new Intl.DateTimeFormat("es-ES", {
+  return new Intl.DateTimeFormat("en-US", {
     dateStyle: "medium",
     timeStyle: "short",
   }).format(new Date(isoDate));
@@ -57,7 +57,7 @@ export function TicketDetailPage() {
               {entry.eventType === "STATUS_CHANGED" &&
                 `Cambio de estado: ${entry.payload.from} → ${entry.payload.to}`}
               {entry.eventType === "ASSIGNED_TO_ME" &&
-                `Asignado a ${entry.actorDisplayName ?? "agente"}`}
+                `Assigned to ${entry.actorDisplayName ?? "agent"}`}
               {entry.eventType === "TICKET_CREATED" && "Ticket creado"}
             </Typography.Text>
           )}
@@ -91,7 +91,7 @@ export function TicketDetailPage() {
   useEffect(() => {
     if (!id) {
       setLoadState("error");
-      setErrorMessage("Id de ticket inválido");
+      setErrorMessage("Invalid ticket id");
       return;
     }
 
@@ -113,7 +113,7 @@ export function TicketDetailPage() {
       } catch (error) {
         if (!mounted) return;
         setLoadState("error");
-        setErrorMessage(error instanceof Error ? error.message : "No se pudo cargar el ticket.");
+        setErrorMessage(error instanceof Error ? error.message : "Could not load the ticket.");
       }
     };
 
@@ -137,7 +137,7 @@ export function TicketDetailPage() {
       await ticketsApi.assignToMe(id);
       await reload();
     } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : "No se pudo asignar el ticket.");
+      setErrorMessage(error instanceof Error ? error.message : "Could not assign the ticket.");
     } finally {
       setBusyAction(null);
     }
@@ -151,7 +151,7 @@ export function TicketDetailPage() {
       await ticketsApi.changeStatus(id, status);
       await reload();
     } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : "No se pudo cambiar el estado.");
+      setErrorMessage(error instanceof Error ? error.message : "Could not change status.");
     } finally {
       setBusyAction(null);
     }
@@ -166,7 +166,7 @@ export function TicketDetailPage() {
       setCommentText("");
       await reload();
     } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : "No se pudo añadir el comentario.");
+      setErrorMessage(error instanceof Error ? error.message : "Could not add comment.");
     } finally {
       setBusyComment(false);
     }
@@ -179,13 +179,8 @@ export function TicketDetailPage() {
   if (loadState === "error" || !ticket) {
     return (
       <Space direction="vertical" style={{ width: "100%" }} size={16}>
-        <Alert
-          type="error"
-          showIcon
-          message="Error cargando el ticket"
-          description={errorMessage}
-        />
-        <Button onClick={() => navigate("/tickets")}>Volver a tickets</Button>
+        <Alert type="error" showIcon message="Error loading ticket" description={errorMessage} />
+        <Button onClick={() => navigate("/tickets")}>Back to tickets</Button>
       </Space>
     );
   }
@@ -196,7 +191,7 @@ export function TicketDetailPage() {
         <Alert
           type="error"
           showIcon
-          message="No se pudo completar la acción"
+          message="Could not complete action"
           description={errorMessage}
         />
       )}
@@ -222,13 +217,13 @@ export function TicketDetailPage() {
                 Metadata
               </Typography.Title>
               <Typography.Text>ID: {ticket.id}</Typography.Text>
-              <Typography.Text>Categoría: {categoryDisplayName}</Typography.Text>
-              <Typography.Text>Creado por: {ticket.createdByDisplayName}</Typography.Text>
+              <Typography.Text>Category: {categoryDisplayName}</Typography.Text>
+              <Typography.Text>Created by: {ticket.createdByDisplayName}</Typography.Text>
               <Typography.Text>
-                Asignado a: {ticket.assignedToDisplayName ?? "Sin asignar"}
+                Assigned to: {ticket.assignedToDisplayName ?? "Unassigned"}
               </Typography.Text>
-              <Typography.Text>Creado: {formatDate(ticket.createdAt)}</Typography.Text>
-              <Typography.Text>Actualizado: {formatDate(ticket.updatedAt)}</Typography.Text>
+              <Typography.Text>Created: {formatDate(ticket.createdAt)}</Typography.Text>
+              <Typography.Text>Updated: {formatDate(ticket.updatedAt)}</Typography.Text>
             </Space>
           </Card>
         </div>
@@ -237,10 +232,10 @@ export function TicketDetailPage() {
           <Card>
             <Space direction="vertical" size={12} style={{ width: "100%" }}>
               <Typography.Title level={5} style={{ margin: 0 }}>
-                Conversación
+                Conversation
               </Typography.Title>
               {timelineItems.length === 0 ? (
-                <Empty description="Sin actividad todavía" />
+                <Empty description="No activity yet" />
               ) : (
                 <div style={{ maxHeight: 420, overflowY: "auto", paddingRight: 8 }}>
                   <Space direction="vertical" size={12} style={{ width: "100%" }}>
@@ -253,8 +248,8 @@ export function TicketDetailPage() {
               {ticket.status === "RESOLVED" && (
                 <Alert
                   type="info"
-                  message="Ticket resuelto"
-                  description="No admite nuevos comentarios."
+                  message="Ticket resolved"
+                  description="No new comments allowed."
                 />
               )}
               {canAddComment ? (
@@ -263,7 +258,7 @@ export function TicketDetailPage() {
                     rows={3}
                     value={commentText}
                     maxLength={2000}
-                    placeholder="Escribe un comentario"
+                    placeholder="Write a comment"
                     onChange={(event) => setCommentText(event.target.value)}
                   />
                   <Button
@@ -272,12 +267,12 @@ export function TicketDetailPage() {
                     disabled={!commentText.trim() || ticket.status === "RESOLVED"}
                     onClick={handleAddComment}
                   >
-                    Enviar comentario
+                    Send comment
                   </Button>
                 </>
               ) : (
                 <Typography.Text type="secondary">
-                  No tienes permisos para añadir comentarios.
+                  You do not have permission to add comments.
                 </Typography.Text>
               )}
             </Space>
@@ -288,22 +283,20 @@ export function TicketDetailPage() {
           <div>
             <Card>
               <Typography.Title level={5} style={{ margin: "0 0 12px" }}>
-                Acciones
+                Actions
               </Typography.Title>
               {canUseActions ? (
                 <Space direction="vertical" style={{ width: "100%" }} size={12}>
                   {!ticket.assignedToUserId && (
                     <Button loading={busyAction === "assign"} onClick={handleAssignToMe}>
-                      Asignarme ticket
+                      Assign ticket to me
                     </Button>
                   )}
                   <Typography.Title level={5} style={{ margin: 0 }}>
-                    Cambiar estado
+                    Change status
                   </Typography.Title>
                   {availableStatusTransitions.length === 0 && (
-                    <Typography.Text type="secondary">
-                      No hay transiciones disponibles.
-                    </Typography.Text>
+                    <Typography.Text type="secondary">No transitions available.</Typography.Text>
                   )}
                   {availableStatusTransitions.map((nextStatus) => (
                     <Button
@@ -313,13 +306,13 @@ export function TicketDetailPage() {
                       loading={busyAction === "status"}
                       onClick={() => handleStatusChange(nextStatus)}
                     >
-                      Mover a {ticketStatusLabel[nextStatus]}
+                      Move to {ticketStatusLabel[nextStatus]}
                     </Button>
                   ))}
                 </Space>
               ) : (
                 <Typography.Text type="secondary">
-                  No eres el propietario de este ticket.
+                  You are not the owner of this ticket.
                 </Typography.Text>
               )}
             </Card>

--- a/ticketing-frontend/src/features/tickets/ui/shared/TicketStatusBadge.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/shared/TicketStatusBadge.test.tsx
@@ -3,17 +3,17 @@ import { renderWithProviders } from "src/test/utils/renderWithProviders";
 import { TicketStatusBadge } from "./TicketStatusBadge";
 
 describe("TicketStatusBadge", () => {
-  it("renderiza el texto de estado en español para estados críticos", () => {
+  it("renders status text in English for critical states", () => {
     const { rerender } = renderWithProviders(<TicketStatusBadge status="OPEN" />);
-    expect(screen.getByText("Abierto")).toBeInTheDocument();
+    expect(screen.getByText("Open")).toBeInTheDocument();
 
     rerender(<TicketStatusBadge status="IN_PROGRESS" />);
-    expect(screen.getByText("En progreso")).toBeInTheDocument();
+    expect(screen.getByText("In progress")).toBeInTheDocument();
 
     rerender(<TicketStatusBadge status="ON_HOLD" />);
-    expect(screen.getByText("En espera")).toBeInTheDocument();
+    expect(screen.getByText("On hold")).toBeInTheDocument();
 
     rerender(<TicketStatusBadge status="RESOLVED" />);
-    expect(screen.getByText("Resuelto")).toBeInTheDocument();
+    expect(screen.getByText("Resolved")).toBeInTheDocument();
   });
 });

--- a/ticketing-frontend/src/features/tickets/ui/ticketsPage/AgentAdminTicketsPage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/ticketsPage/AgentAdminTicketsPage.test.tsx
@@ -1,4 +1,5 @@
 import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "src/test/utils/renderWithProviders";
 import { jsonResponse } from "src/test/msw/handlers";
 import { http } from "src/test/msw/http";
@@ -102,5 +103,60 @@ describe("AgentAdminTicketsPage", () => {
 
     // En esta pantalla actualmente solo existe acción "View".
     expect(screen.getByRole("button", { name: "View" })).toBeInTheDocument();
+  });
+
+  it("fallback a vista unassigned y estado all cuando query params son inválidos", async () => {
+    let capturedSearch = "";
+
+    server.use(
+      http.get("/api/tickets", (request) => {
+        capturedSearch = request.url.search;
+        return jsonResponse({ items: [], page: 0, size: 20, total: 0 });
+      }),
+    );
+
+    renderWithProviders(<AgentAdminTicketsPage />, {
+      router: { initialEntries: ["/tickets?view=legacy&status=UNKNOWN"] },
+    });
+
+    await waitFor(() => {
+      expect(capturedSearch).toContain("scope=UNASSIGNED");
+      expect(capturedSearch).not.toContain("status=");
+    });
+
+    expect(screen.getByRole("heading", { name: "Unassigned queue" })).toBeInTheDocument();
+  });
+
+  it("permite aplicar búsqueda y limpiar filtros", async () => {
+    let capturedSearch = "";
+    const user = userEvent.setup();
+
+    server.use(
+      http.get("/api/tickets", (request) => {
+        capturedSearch = request.url.search;
+        return jsonResponse({ items: [], page: 0, size: 20, total: 0 });
+      }),
+    );
+
+    renderWithProviders(<AgentAdminTicketsPage />, {
+      router: { initialEntries: ["/tickets?view=mine&status=IN_PROGRESS&q=printer"] },
+    });
+
+    await screen.findByRole("heading", { name: "Tickets assigned to me" });
+
+    await user.clear(screen.getByPlaceholderText("Search by title or ID"));
+    await user.type(screen.getByPlaceholderText("Search by title or ID"), "network");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(capturedSearch).toContain("q=network");
+    });
+
+    await user.click(screen.getByRole("button", { name: "Clear filters" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Unassigned queue" })).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("Search by title or ID")).toHaveValue("");
+    });
   });
 });

--- a/ticketing-frontend/src/features/tickets/ui/ticketsPage/AgentAdminTicketsPage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/ticketsPage/AgentAdminTicketsPage.test.tsx
@@ -55,7 +55,7 @@ describe("AgentAdminTicketsPage", () => {
       expect(capturedSearch).toContain("q=printer");
     });
 
-    expect(screen.getByRole("heading", { name: "Tickets asignados a mí" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Tickets assigned to me" })).toBeInTheDocument();
   });
 
   it("muestra loading y empty state", async () => {
@@ -72,7 +72,7 @@ describe("AgentAdminTicketsPage", () => {
 
     expect(container.querySelector(".ant-skeleton")).toBeInTheDocument();
     expect(
-      await screen.findByText("No hay tickets para mostrar con los filtros actuales"),
+      await screen.findByText("No tickets to display with the current filters"),
     ).toBeInTheDocument();
   });
 
@@ -81,9 +81,7 @@ describe("AgentAdminTicketsPage", () => {
 
     renderWithProviders(<AgentAdminTicketsPage />, { router: { initialEntries: ["/tickets"] } });
 
-    expect(
-      await screen.findByText("No se ha podido cargar la cola de tickets"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("Could not load the ticket queue")).toBeInTheDocument();
   });
 
   it("[TICKET-AGENT-01] muestra acciones de UI para gestión de estado si existen", async () => {
@@ -102,7 +100,7 @@ describe("AgentAdminTicketsPage", () => {
 
     await screen.findByRole("cell", { name: "TCK-200" });
 
-    // En esta pantalla actualmente solo existe acción "Ver".
-    expect(screen.getByRole("button", { name: "Ver" })).toBeInTheDocument();
+    // En esta pantalla actualmente solo existe acción "View".
+    expect(screen.getByRole("button", { name: "View" })).toBeInTheDocument();
   });
 });

--- a/ticketing-frontend/src/features/tickets/ui/ticketsPage/AgentAdminTicketsPage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/ticketsPage/AgentAdminTicketsPage.tsx
@@ -29,11 +29,11 @@ type LoadState = "loading" | "ready" | "error";
 type QueueFilter = "all" | TicketStatus;
 
 const statusFilterOptions: Array<{ label: string; value: QueueFilter }> = [
-  { label: "Todos los estados", value: "all" },
-  { label: "Abierto", value: "OPEN" },
-  { label: "En progreso", value: "IN_PROGRESS" },
-  { label: "En espera", value: "ON_HOLD" },
-  { label: "Resuelto", value: "RESOLVED" },
+  { label: "All statuses", value: "all" },
+  { label: "Open", value: "OPEN" },
+  { label: "In progress", value: "IN_PROGRESS" },
+  { label: "On hold", value: "ON_HOLD" },
+  { label: "Resolved", value: "RESOLVED" },
 ];
 
 function toQueueView(value: string | null): QueueView {
@@ -53,7 +53,7 @@ function toStatusFilter(value: string | null): QueueFilter {
 }
 
 function formatDate(isoDate: string) {
-  return new Intl.DateTimeFormat("es-ES", {
+  return new Intl.DateTimeFormat("en-US", {
     dateStyle: "short",
     timeStyle: "short",
   }).format(new Date(isoDate));
@@ -114,7 +114,7 @@ export function AgentAdminTicketsPage() {
 
         setLoadState("error");
         setErrorMessage(
-          error instanceof Error ? error.message : "No se pudo cargar la cola de tickets.",
+          error instanceof Error ? error.message : "Could not load the ticket queue.",
         );
       }
     };
@@ -129,9 +129,9 @@ export function AgentAdminTicketsPage() {
   const columns: TableProps<TicketSummary>["columns"] = useMemo(
     () => [
       { title: "ID", dataIndex: "id", key: "id", width: 180 },
-      { title: "Título", dataIndex: "title", key: "title" },
+      { title: "Title", dataIndex: "title", key: "title" },
       {
-        title: "Estado",
+        title: "Status",
         dataIndex: "status",
         key: "status",
         width: 140,
@@ -140,7 +140,7 @@ export function AgentAdminTicketsPage() {
         ),
       },
       {
-        title: "Prioridad",
+        title: "Priority",
         dataIndex: "priority",
         key: "priority",
         width: 120,
@@ -149,27 +149,27 @@ export function AgentAdminTicketsPage() {
         ),
       },
       {
-        title: "Asignado",
+        title: "Assigned",
         dataIndex: "assignedToUserId",
         key: "assignedToUserId",
         width: 180,
-        render: (assigneeValue: unknown) => (assigneeValue ? String(assigneeValue) : "Sin asignar"),
+        render: (assigneeValue: unknown) => (assigneeValue ? String(assigneeValue) : "Unassigned"),
       },
       {
-        title: "Actualizado",
+        title: "Updated",
         dataIndex: "updatedAt",
         key: "updatedAt",
         width: 180,
         render: (updatedAtValue: unknown) => formatDate(String(updatedAtValue)),
       },
       {
-        title: "Acciones",
+        title: "Actions",
         dataIndex: "id",
         key: "actions",
         width: 120,
         render: (_id: unknown, row: TicketSummary) => (
           <Button size="small" onClick={() => navigate(`/tickets/${row.id}`)}>
-            Ver
+            View
           </Button>
         ),
       },
@@ -179,10 +179,10 @@ export function AgentAdminTicketsPage() {
 
   const viewLabel =
     view === "unassigned"
-      ? "Cola sin asignar"
+      ? "Unassigned queue"
       : view === "mine"
-        ? "Tickets asignados a mí"
-        : "Todos los tickets";
+        ? "Tickets assigned to me"
+        : "All tickets";
 
   const unassignedCount = tickets.filter((ticket) => ticket.assignedToUserId === null).length;
   const inProgressCount = tickets.filter((ticket) => ticket.status === "IN_PROGRESS").length;
@@ -201,30 +201,30 @@ export function AgentAdminTicketsPage() {
   return (
     <Space direction="vertical" size={16} style={{ width: "100%" }}>
       <Typography.Title level={3} style={{ margin: 0 }}>
-        <span data-testid="agent-tickets-title">Gestión de tickets</span>
+        <span data-testid="agent-tickets-title">Ticket management</span>
       </Typography.Title>
 
       <Space style={{ display: "grid", gridTemplateColumns: "repeat(4, minmax(0, 1fr))" }}>
         <Card>
-          <Typography.Text type="secondary">Sin asignar (vista)</Typography.Text>
+          <Typography.Text type="secondary">Unassigned (view)</Typography.Text>
           <Typography.Title level={3} style={{ margin: "8px 0 0" }}>
             {unassignedCount}
           </Typography.Title>
         </Card>
         <Card>
-          <Typography.Text type="secondary">Total (vista)</Typography.Text>
+          <Typography.Text type="secondary">Total (view)</Typography.Text>
           <Typography.Title level={3} style={{ margin: "8px 0 0" }}>
             {total}
           </Typography.Title>
         </Card>
         <Card>
-          <Typography.Text type="secondary">En progreso (vista)</Typography.Text>
+          <Typography.Text type="secondary">In progress (view)</Typography.Text>
           <Typography.Title level={3} style={{ margin: "8px 0 0" }}>
             {inProgressCount}
           </Typography.Title>
         </Card>
         <Card>
-          <Typography.Text type="secondary">Scope actual</Typography.Text>
+          <Typography.Text type="secondary">Current scope</Typography.Text>
           <Typography.Title level={3} style={{ margin: "8px 0 0" }}>
             {queueScopeFromView(view)}
           </Typography.Title>
@@ -236,20 +236,20 @@ export function AgentAdminTicketsPage() {
           type={view === "unassigned" ? "primary" : "default"}
           onClick={() => setView("unassigned")}
         >
-          Sin asignar
+          Unassigned
         </Button>
         <Button type={view === "mine" ? "primary" : "default"} onClick={() => setView("mine")}>
-          Asignados a mí
+          Assigned to me
         </Button>
         <Button type={view === "all" ? "primary" : "default"} onClick={() => setView("all")}>
-          Todos
+          All
         </Button>
       </Space>
 
       <Card>
         <Space>
           <Select
-            aria-label="Estado"
+            aria-label="Status"
             value={statusFilter}
             onChange={(value) => setStatusFilter(value as QueueFilter)}
             options={statusFilterOptions}
@@ -258,10 +258,10 @@ export function AgentAdminTicketsPage() {
           <Input
             value={inputQuery}
             onChange={(event) => setInputQuery(event.target.value)}
-            placeholder="Buscar por título o ID"
+            placeholder="Search by title or ID"
           />
-          <Button onClick={onApplySearch}>Buscar</Button>
-          <Button onClick={onClearFilters}>Limpiar filtros</Button>
+          <Button onClick={onApplySearch}>Search</Button>
+          <Button onClick={onClearFilters}>Clear filters</Button>
         </Space>
       </Card>
 
@@ -277,13 +277,13 @@ export function AgentAdminTicketsPage() {
             <Alert
               type="error"
               showIcon
-              message="No se ha podido cargar la cola de tickets"
+              message="Could not load the ticket queue"
               description={errorMessage}
             />
           )}
 
           {loadState === "ready" && tickets.length === 0 && (
-            <Empty description="No hay tickets para mostrar con los filtros actuales" />
+            <Empty description="No tickets to display with the current filters" />
           )}
 
           {loadState === "ready" && tickets.length > 0 && (

--- a/ticketing-frontend/src/features/tickets/ui/ticketsPage/UserTicketsHomePage.test.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/ticketsPage/UserTicketsHomePage.test.tsx
@@ -17,7 +17,7 @@ const baseTicket = {
 } as const;
 
 describe("UserTicketsHomePage", () => {
-  it("[TICKET-USER-03] muestra solo los tickets del usuario autenticado", async () => {
+  it("[TICKET-USER-03] muestra solo los tickets del usuario authenticated", async () => {
     server.use(
       http.get("/api/tickets/me", () =>
         jsonResponse({
@@ -33,7 +33,7 @@ describe("UserTicketsHomePage", () => {
 
     expect(await screen.findByRole("cell", { name: "TCK-001" })).toBeInTheDocument();
     expect(screen.getByRole("cell", { name: "No funciona la VPN" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Ver" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "View" })).toBeInTheDocument();
   });
 
   it("muestra loading state mientras la petición está en curso", async () => {
@@ -47,7 +47,7 @@ describe("UserTicketsHomePage", () => {
     const { container } = renderWithProviders(<UserTicketsHomePage />, { router: {} });
 
     expect(container.querySelector(".ant-skeleton")).toBeInTheDocument();
-    expect(await screen.findByText("Aún no tienes tickets creados")).toBeInTheDocument();
+    expect(await screen.findByText("You do not have any tickets yet")).toBeInTheDocument();
   });
 
   it("muestra empty state cuando el usuario no tiene tickets", async () => {
@@ -57,7 +57,7 @@ describe("UserTicketsHomePage", () => {
 
     renderWithProviders(<UserTicketsHomePage />, { router: {} });
 
-    expect(await screen.findByText("Aún no tienes tickets creados")).toBeInTheDocument();
+    expect(await screen.findByText("You do not have any tickets yet")).toBeInTheDocument();
   });
 
   it("muestra error state cuando falla la carga", async () => {
@@ -67,7 +67,7 @@ describe("UserTicketsHomePage", () => {
 
     renderWithProviders(<UserTicketsHomePage />, { router: {} });
 
-    expect(await screen.findByText("No hemos podido cargar tus tickets")).toBeInTheDocument();
+    expect(await screen.findByText("Could not load your tickets")).toBeInTheDocument();
   });
 
   it("[TICKET-USER-05] no muestra acciones de cambio de estado", async () => {

--- a/ticketing-frontend/src/features/tickets/ui/ticketsPage/UserTicketsHomePage.tsx
+++ b/ticketing-frontend/src/features/tickets/ui/ticketsPage/UserTicketsHomePage.tsx
@@ -10,7 +10,7 @@ import { TicketStatusBadge } from "../shared/TicketStatusBadge";
 type LoadState = "loading" | "ready" | "error";
 
 function formatDate(isoDate: string) {
-  return new Intl.DateTimeFormat("es-ES", {
+  return new Intl.DateTimeFormat("en-US", {
     dateStyle: "medium",
     timeStyle: "short",
   }).format(new Date(isoDate));
@@ -40,9 +40,7 @@ export function UserTicketsHomePage() {
         if (!isMounted) return;
 
         setLoadState("error");
-        setErrorMessage(
-          error instanceof Error ? error.message : "No se pudieron cargar tus tickets.",
-        );
+        setErrorMessage(error instanceof Error ? error.message : "Could not load your tickets.");
       }
     };
 
@@ -63,12 +61,12 @@ export function UserTicketsHomePage() {
         ellipsis: true,
       },
       {
-        title: "Título",
+        title: "Title",
         dataIndex: "title",
         key: "title",
       },
       {
-        title: "Estado",
+        title: "Status",
         dataIndex: "status",
         key: "status",
         width: 140,
@@ -78,7 +76,7 @@ export function UserTicketsHomePage() {
         },
       },
       {
-        title: "Prioridad",
+        title: "Priority",
         dataIndex: "priority",
         key: "priority",
         width: 120,
@@ -87,20 +85,20 @@ export function UserTicketsHomePage() {
         ),
       },
       {
-        title: "Fecha creación",
+        title: "Created date",
         dataIndex: "createdAt",
         key: "createdAt",
         width: 220,
         render: (createdAtValue: unknown) => formatDate(String(createdAtValue)),
       },
       {
-        title: "Acciones",
+        title: "Actions",
         dataIndex: "id",
         key: "actions",
         width: 120,
         render: (_id: unknown, row: TicketSummary) => (
           <Button size="small" onClick={() => navigate(`/tickets/${row.id}`)}>
-            Ver
+            View
           </Button>
         ),
       },
@@ -112,7 +110,7 @@ export function UserTicketsHomePage() {
     <Space direction="vertical" size={20} style={{ width: "100%" }}>
       <Space style={{ width: "100%", justifyContent: "space-between" }}>
         <Typography.Title level={3} style={{ margin: 0 }}>
-          <span data-testid="user-tickets-title">Mis tickets</span>
+          <span data-testid="user-tickets-title">My tickets</span>
         </Typography.Title>
         <Button
           data-testid="user-create-ticket-cta"
@@ -120,7 +118,7 @@ export function UserTicketsHomePage() {
           size="large"
           onClick={() => navigate("/tickets/new")}
         >
-          Crear ticket
+          Create ticket
         </Button>
       </Space>
 
@@ -130,13 +128,13 @@ export function UserTicketsHomePage() {
         <Alert
           type="error"
           showIcon
-          message="No hemos podido cargar tus tickets"
+          message="Could not load your tickets"
           description={errorMessage}
         />
       )}
 
       {loadState === "ready" && tickets.length === 0 && (
-        <Empty description="Aún no tienes tickets creados" />
+        <Empty description="You do not have any tickets yet" />
       )}
 
       {loadState === "ready" && tickets.length > 0 && (


### PR DESCRIPTION
- Replaced visible Spanish copy with English equivalents across auth, tickets, dashboard, admin, profile, navigation and generic pages by editing string literals (examples: `src/features/auth/ui/LoginPage.tsx`, `src/features/tickets/ui/detail/TicketDetailPage.tsx`, `src/features/admin/ui/AdminPage.tsx`, `src/app/layout/AppShell.tsx`).
- Unified presentation labels for ticket domain terminology in `src/features/tickets/model/presentation.ts` (`Open`, `In progress`, `On hold`, `Resolved`; `Low`, `Medium`, `High`).
- Updated tests (unit/component + page tests) and Playwright e2e files to reflect new English copy and more stable queries where appropriate (files under `src/**/tests` and `e2e/**`).
- Kept all business logic, APIs and internal types unchanged and avoided introducing any i18n frameworks, providers, or translation systems.
