### PR TITLE
feat(frontend): add custom favicon and update index.html

### DIFF
--- a/ticketing-frontend/index.html
+++ b/ticketing-frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ticketing-frontend</title>
   </head>

--- a/ticketing-frontend/public/favicon.svg
+++ b/ticketing-frontend/public/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Ticketing favicon">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#2fd466"/>
+      <stop offset="1" stop-color="#0f9f3a"/>
+    </linearGradient>
+  </defs>
+  <rect x="2" y="20" width="22" height="6" rx="3" fill="url(#g)"/>
+  <rect x="2" y="30" width="28" height="6" rx="3" fill="url(#g)"/>
+  <rect x="2" y="40" width="22" height="6" rx="3" fill="url(#g)"/>
+  <path fill="#087a2f" d="M26 10h23c1.7 0 3 1.3 3 3v9.5a5.5 5.5 0 0 1 0 11V43c0 1.7-1.3 3-3 3H26a3 3 0 0 1-3-3V13c0-1.7 1.3-3 3-3z"/>
+  <circle cx="40" cy="28" r="2.5" fill="#d6ffe1"/>
+</svg>


### PR DESCRIPTION
### Motivation
- Replace the default Vite icon with a custom favicon derived from the provided ticket/speed mark to match the app branding. 
- Ensure the frontend loads the new favicon asset instead of the placeholder `/vite.svg`.

### Description
- Added a new SVG asset at `ticketing-frontend/public/favicon.svg` containing the green ticket/speed mark artwork. 
- Updated `ticketing-frontend/index.html` to reference the new favicon by changing the link href to `/favicon.svg`.

### Testing
- No automated tests were required for this static asset and HTML link update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f86e160bc08328848a8c95b12b625b)