### PR TITLE
Introduce application-level pagination (PageQuery/PagedResult) and replace Spring Pageable/Page with internal types

### DIFF
--- a/docs/testing/testing-strategy.md
+++ b/docs/testing/testing-strategy.md
@@ -55,6 +55,8 @@ Unit tests are expected to be the fastest and most numerous.
 Primary role:
 
 - protect domain/application logic (use-case rules, transitions, validations),
+- keep use-case tests as the main unit-level regression net,
+- complement use-case tests with pure domain tests only where internal domain rules exist (ticket transitions, comments, assignment, terminal states),
 - provide fast feedback for regressions in business decisions,
 - isolate logic defects with high diagnosis precision.
 
@@ -66,6 +68,7 @@ Primary role:
 
 - enforce layer boundaries (`domain`, `application`, `api`, `infrastructure`),
 - prevent accidental coupling to technical frameworks in core layers,
+- keep application-level ports framework-agnostic (for example, pagination is expressed with `PageQuery`/`PagedResult`, not Spring Data `Page`/`Pageable`),
 - and detect architectural erosion early in CI with fast feedback.
 
 Why this decision was made:
@@ -177,7 +180,8 @@ When adding or modifying behavior:
 2. Select the lowest-cost layer that can provide credible evidence.
 3. Add higher-layer tests only when lower layers cannot prove the risk.
 4. Keep assertions behavior-centric and deterministic.
-5. Update traceability status honestly.
+5. Keep framework-specific types at API/infrastructure boundaries; application-layer test doubles should depend on application-owned contracts.
+6. Update traceability status honestly.
 
 ---
 

--- a/docs/testing/testing-types-deep-dive.md
+++ b/docs/testing/testing-types-deep-dive.md
@@ -47,6 +47,9 @@ Backend unit tests validate application and domain behavior **without booting th
 
 - Use-case invariants and branch logic (e.g., create ticket, status transitions, assignment rules).
 - Authentication and registration decision logic.
+- Admin/category use-case decisions (category creation/update/listing, user activation toggles, active category listing).
+- Ticket detail composition and access-rule preservation at use-case level.
+- Pure domain behavior only where the domain object owns meaningful rules (ticket defaults, comments, assignment, terminal resolved state, available transitions).
 - Domain transitions and permission checks handled inside use cases.
 
 Representative files:
@@ -55,7 +58,14 @@ Representative files:
 - `ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/auth/RegisterUseCaseTest.java`
 - `ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/ChangeTicketStatusUseCaseTest.java`
 - `ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/AssignTicketToMeUseCaseTest.java`
+- `ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/GetTicketDetailUseCaseTest.java`
 - `ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/TicketAvailableTransitionsTest.java`
+- `ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/TicketDomainBehaviorTest.java`
+- `ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/admin/CreateCategoryUseCaseTest.java`
+- `ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/admin/UpdateCategoryUseCaseTest.java`
+- `ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/admin/ListAdminUsersUseCaseTest.java`
+- `ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/admin/UpdateUserActiveUseCaseTest.java`
+- `ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/categories/ListActiveCategoriesUseCaseTest.java`
 
 ### Worked example (repository-based)
 
@@ -75,11 +85,24 @@ Representative files:
 - The test asserts that registration with a duplicate email triggers a business rejection path.
 - This directly protects the domain/application rule independent of transport/database wiring.
 
+### Application-level test doubles and pagination boundary
+
+Backend unit tests may use in-memory repositories as test doubles for application ports. Those doubles should implement the same application-owned contracts as production adapters.
+
+For ticket list use cases, pagination is intentionally represented in the application layer with:
+
+- `PageQuery` for page/size/sort/direction input,
+- `PagedResult<T>` for content and totals,
+- `PageDirection` for sort direction.
+
+This avoids leaking Spring Data `Page`/`Pageable` into use-case signatures or application ports. Spring-specific translation belongs in API/infrastructure adapters (`TicketController`, `JpaTicketRepository`), while in-memory repositories can simulate filtering/sorting/paging deterministically for unit tests.
+
 ### What they do not validate
 
 - Spring MVC serialization/deserialization.
 - Security filter-chain behavior (`401` vs `403`, JWT parsing in runtime filters).
 - Real JPA/PostgreSQL behavior.
+- Exact Spring Data pagination/query execution; repository adapter behavior remains integration-test territory.
 
 ### Real value
 
@@ -91,6 +114,7 @@ Representative files:
 
 - Re-testing framework internals (e.g., asserting Spring annotations from unit tests).
 - Over-mocking until tests no longer represent business behavior.
+- Reintroducing framework-specific types (for example Spring Data `Pageable`) into application ports just to simplify tests.
 - Treating unit tests as sufficient evidence for API-level correctness.
 
 ### When to write
@@ -100,7 +124,8 @@ Write backend unit tests when adding/changing:
 - domain rules,
 - use-case decision trees,
 - error conditions,
-- role/permission decisions in application services.
+- role/permission decisions in application services,
+- application-owned boundary contracts used by multiple adapters (for example pagination DTOs), while keeping adapter-specific execution in integration tests.
 
 ## 4. Backend integration tests (reference architecture)
 
@@ -131,7 +156,8 @@ A typical backend integration test in this project validates, end-to-end inside 
 3. Security configuration and role restrictions.
 4. Application service invocation.
 5. Persistence adapters and database writes/reads in PostgreSQL.
-6. HTTP response mapping and status code contract.
+6. Translation between application-owned boundary contracts and framework/runtime details (for example `PageQuery` -> Spring Data `PageRequest`).
+7. HTTP response mapping and status code contract.
 
 Representative files:
 
@@ -198,6 +224,7 @@ Write backend integration tests for:
 - new endpoints,
 - security-sensitive changes,
 - changes in persistence mapping/query behavior,
+- adapter translation between application contracts and framework types,
 - business flows where HTTP contract is part of the requirement.
 
 ## 5. Frontend UI/component tests (Vitest + RTL + MSW)

--- a/docs/testing/traceability-matrix.md
+++ b/docs/testing/traceability-matrix.md
@@ -25,16 +25,16 @@ Sources used for this snapshot:
 | AUTH-05 | ✅ Unit + integration covered. | ❌ No duplicate-email UI test. | ❌ No duplicate-email E2E test. | PARTIAL | Duplicate email rejection currently evidenced only in backend tests. |
 | TICKET-USER-01 | ✅ Unit + integration covered. | ✅ `CreateTicketPage.test.tsx` (`[TICKET-USER-01]`). | ✅ `e2e/tickets-user.spec.ts` (`TICKET-USER-01`). | COVERED | Multi-layer coverage from form submission to browser-level navigation/result. |
 | TICKET-USER-02 | ✅ Integration covered. | ❌ No scenario-specific UI test (API/security-focused scenario). | ❌ No E2E scenario. | PARTIAL | Unauthorized ticket creation path is backend-only today. |
-| TICKET-USER-03 | ✅ Integration covered. | ⚠️ `UserTicketsHomePage.test.tsx` tagged `[TICKET-USER-03]` with fixture-level assertion. | ❌ No E2E scenario. | PARTIAL | Useful UI evidence exists, but full cross-user leakage proof remains backend-centric. |
-| TICKET-USER-04 | ✅ Integration covered. | ❌ No ownership-specific ticket detail UI test. | ❌ No E2E scenario. | PARTIAL | Missing UI/E2E evidence for owner-only detail access journey. |
+| TICKET-USER-03 | ✅ Unit + integration covered. | ⚠️ `UserTicketsHomePage.test.tsx` tagged `[TICKET-USER-03]` with fixture-level assertion. | ❌ No E2E scenario. | PARTIAL | Unit and integration backend evidence protect owner scoping; useful UI evidence exists, but full browser-level cross-user leakage proof remains absent. |
+| TICKET-USER-04 | ✅ Unit + integration covered. | ❌ No ownership-specific ticket detail UI test. | ❌ No E2E scenario. | PARTIAL | Backend unit and integration evidence protect owner-only detail access; UI/E2E evidence for the journey is still missing. |
 | TICKET-USER-05 | ✅ Unit + integration covered. | ✅ `UserTicketsHomePage.test.tsx` (`[TICKET-USER-05]`). | ❌ No E2E scenario. | PARTIAL | UI role restriction exists; no browser-level forbidden status-change journey yet. |
 | TICKET-AGENT-01 | ✅ Unit + integration covered. | ⚠️ `AgentAdminTicketsPage.test.tsx` tagged `[TICKET-AGENT-01]` (UI action visibility). | ✅ `e2e/tickets-agent.spec.ts` (`TICKET-AGENT-01`). | COVERED | Backend + E2E demonstrate transition behavior; UI unit evidence is supportive but shallow. |
 | TICKET-AGENT-02 | ✅ Unit + integration covered. | ❌ No UI invalid-transition handling test. | ❌ No E2E invalid-transition scenario. | PARTIAL | Invalid transition behavior is validated only in backend tests. |
-| TICKET-AGENT-03 | ✅ Integration covered. | ✅ `AgentAdminTicketsPage.test.tsx` (`[TICKET-AGENT-03]`) filter/query mapping. | ❌ No E2E scenario. | PARTIAL | Queue/filtering has UI evidence but no browser-level journey yet. |
+| TICKET-AGENT-03 | ✅ Unit + integration covered. | ✅ `AgentAdminTicketsPage.test.tsx` (`[TICKET-AGENT-03]`) filter/query mapping. | ❌ No E2E scenario. | PARTIAL | Queue/filtering has backend unit/integration plus UI evidence, but no browser-level journey yet. |
 | TICKET-AGENT-04 | ✅ Unit + integration covered. | ❌ No UI “assign to me” scenario test. | ✅ `e2e/tickets-agent.spec.ts` (`TICKET-AGENT-04`). | PARTIAL | Backend + E2E evidence exists; frontend UI unit scenario is still missing. |
-| ADMIN-01 | ✅ Integration covered. | ❌ No scenario-specific UI test ID currently detected. | ❌ No E2E scenario. | PARTIAL | Admin user list is backend-covered; explicit scenario-tagged UI/E2E evidence absent. |
-| ADMIN-02 | ✅ Integration covered. | ❌ No scenario-specific UI test ID currently detected. | ❌ No E2E scenario. | PARTIAL | Admin categories listing is backend-covered; explicit UI/E2E scenario mapping missing. |
-| ADMIN-03 | ✅ Integration covered. | ❌ No UI deactivation scenario test. | ❌ No E2E deactivation scenario. | PARTIAL | User deactivation currently validated only via backend automation. |
+| ADMIN-01 | ✅ Unit support + integration covered. | ❌ No scenario-specific UI test ID currently detected. | ❌ No E2E scenario. | PARTIAL | Admin user listing now has use-case unit support plus backend integration coverage; explicit scenario-tagged UI/E2E evidence remains absent. |
+| ADMIN-02 | ✅ Unit support + integration covered. | ❌ No scenario-specific UI test ID currently detected. | ❌ No E2E scenario. | PARTIAL | Admin category listing now has use-case unit support plus backend integration coverage; explicit UI/E2E scenario mapping remains missing. |
+| ADMIN-03 | ✅ Unit support + integration covered. | ❌ No UI deactivation scenario test. | ❌ No E2E deactivation scenario. | PARTIAL | User deactivation now has use-case unit support plus backend integration coverage; UI/E2E deactivation journeys remain missing. |
 | ADMIN-04 | ✅ Integration covered. | ✅ `RequireRole.test.tsx` tagged `[ADMIN-04]`. | ✅ `e2e/admin.spec.ts` (`ADMIN-04`). | COVERED | Forbidden non-admin access is covered in backend, UI guard, and browser flow. |
 
 ## Status legend
@@ -51,6 +51,17 @@ Based on `artifacts/traceability/traceability-report.md`:
 - **MULTI_LAYER (covered): 5** -> AUTH-01, AUTH-02, TICKET-USER-01, TICKET-AGENT-01, ADMIN-04.
 - **PARTIAL: 13**
 - **NOT_REFERENCED: 0**
+
+### Backend unit expansion note
+
+The backend unit suite now includes additional use-case and domain-level support that is broader than the scenario-reference counters alone:
+
+- Admin/category use-case tests for category creation/update/listing, active category listing, user listing, and user activation toggling.
+- Ticket detail use-case tests for detail composition and access-rule preservation.
+- Pure domain tests for ticket defaults, comments, assignment, and terminal resolved-state behavior.
+- Application-owned pagination contracts (`PageQuery`, `PagedResult`, `PageDirection`) used by list use cases and test doubles instead of Spring Data `Page`/`Pageable`.
+
+These additions improve backend diagnosis and architectural confidence while leaving API/security/persistence evidence in the backend integration layer. They do not by themselves convert scenarios to `COVERED` unless the missing UI/E2E evidence noted in the matrix is also present.
 
 ## CI/CD evaluation of the previous recommendation
 

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/shared/pagination/PageResponse.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/shared/pagination/PageResponse.java
@@ -1,6 +1,6 @@
 package com.aperdigon.ticketing_backend.api.shared.pagination;
 
-import org.springframework.data.domain.Page;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PagedResult;
 
 import java.util.List;
 
@@ -10,12 +10,12 @@ public record PageResponse<T>(
         int size,
         long total
 ) {
-    public static <T> PageResponse<T> from(Page<T> page) {
+    public static <T> PageResponse<T> from(PagedResult<T> page) {
         return new PageResponse<>(
-                page.getContent(),
-                page.getNumber(),
-                page.getSize(),
-                page.getTotalElements()
+                page.content(),
+                page.page(),
+                page.size(),
+                page.totalElements()
         );
     }
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/TicketController.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/tickets/TicketController.java
@@ -10,6 +10,8 @@ import com.aperdigon.ticketing_backend.api.tickets.create.CreateTicketResponse;
 import com.aperdigon.ticketing_backend.api.tickets.dashboard.DashboardStatsResponse;
 import com.aperdigon.ticketing_backend.api.tickets.detail.TicketDetailResponse;
 import com.aperdigon.ticketing_backend.api.tickets.list.TicketSummaryResponse;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PageDirection;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PageQuery;
 import com.aperdigon.ticketing_backend.application.tickets.change_status.ChangeTicketStatusCommand;
 import com.aperdigon.ticketing_backend.application.tickets.change_status.ChangeTicketStatusUseCase;
 import com.aperdigon.ticketing_backend.application.tickets.add_comment.AddTicketCommentCommand;
@@ -30,8 +32,6 @@ import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -103,9 +103,9 @@ public class TicketController {
             @RequestParam(defaultValue = "20") int size
     ) {
         var actor = currentUserProvider.getCurrentUser();
-        var pageable = PageRequest.of(page, Math.min(Math.max(size, 1), 100), Sort.by(Sort.Direction.DESC, "updatedAt"));
+        var pageQuery = PageQuery.of(page, Math.min(Math.max(size, 1), 100), "updatedAt", PageDirection.DESC);
 
-        var result = listMyTicketsUseCase.execute(new ListMyTicketsQuery(actor, status, q, pageable));
+        var result = listMyTicketsUseCase.execute(new ListMyTicketsQuery(actor, status, q, pageQuery));
         return PageResponse.from(result.map(TicketSummaryResponse::from));
     }
 
@@ -119,9 +119,9 @@ public class TicketController {
             @RequestParam(defaultValue = "20") int size
     ) {
         var actor = currentUserProvider.getCurrentUser();
-        var pageable = PageRequest.of(page, Math.min(Math.max(size, 1), 100), Sort.by(Sort.Direction.DESC, "updatedAt"));
+        var pageQuery = PageQuery.of(page, Math.min(Math.max(size, 1), 100), "updatedAt", PageDirection.DESC);
 
-        var result = listTicketsUseCase.execute(new ListTicketsQuery(actor, scope, status, q, pageable));
+        var result = listTicketsUseCase.execute(new ListTicketsQuery(actor, scope, status, q, pageQuery));
         return PageResponse.from(result.map(TicketSummaryResponse::from));
     }
 

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/ports/TicketRepository.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/ports/TicketRepository.java
@@ -1,14 +1,14 @@
 package com.aperdigon.ticketing_backend.application.ports;
 
-import com.aperdigon.ticketing_backend.application.tickets.list.TicketQueueScope;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PageQuery;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PagedResult;
 import com.aperdigon.ticketing_backend.application.tickets.dashboard.AgentTicketCount;
+import com.aperdigon.ticketing_backend.application.tickets.list.TicketQueueScope;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
 import com.aperdigon.ticketing_backend.domain.user.UserId;
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,9 +18,9 @@ public interface TicketRepository {
     Ticket save(Ticket ticket);
     Optional<Ticket> findById(TicketId id);
 
-    Page<Ticket> findMyTickets(UserId createdBy, TicketStatus status, String q, Pageable pageable);
+    PagedResult<Ticket> findMyTickets(UserId createdBy, TicketStatus status, String q, PageQuery pageQuery);
 
-    Page<Ticket> findAgentTickets(UserId actorId, TicketQueueScope scope, TicketStatus status, String q, Pageable pageable);
+    PagedResult<Ticket> findAgentTickets(UserId actorId, TicketQueueScope scope, TicketStatus status, String q, PageQuery pageQuery);
 
     long countUnassigned();
 

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/shared/pagination/PageDirection.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/shared/pagination/PageDirection.java
@@ -1,0 +1,6 @@
+package com.aperdigon.ticketing_backend.application.shared.pagination;
+
+public enum PageDirection {
+    ASC,
+    DESC
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/shared/pagination/PageQuery.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/shared/pagination/PageQuery.java
@@ -1,0 +1,25 @@
+package com.aperdigon.ticketing_backend.application.shared.pagination;
+
+import com.aperdigon.ticketing_backend.domain.shared.validation.Guard;
+
+public record PageQuery(
+        int page,
+        int size,
+        String sortBy,
+        PageDirection direction
+) {
+    public PageQuery {
+        if (page < 0) {
+            throw new IllegalArgumentException("page must be greater than or equal to 0");
+        }
+        if (size < 1) {
+            throw new IllegalArgumentException("size must be greater than 0");
+        }
+        sortBy = Guard.notBlank(sortBy, "sortBy");
+        direction = Guard.notNull(direction, "direction");
+    }
+
+    public static PageQuery of(int page, int size, String sortBy, PageDirection direction) {
+        return new PageQuery(page, size, sortBy, direction);
+    }
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/shared/pagination/PagedResult.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/shared/pagination/PagedResult.java
@@ -1,0 +1,31 @@
+package com.aperdigon.ticketing_backend.application.shared.pagination;
+
+import com.aperdigon.ticketing_backend.domain.shared.validation.Guard;
+
+import java.util.List;
+import java.util.function.Function;
+
+public record PagedResult<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements
+) {
+    public PagedResult {
+        content = List.copyOf(Guard.notNull(content, "content"));
+        if (page < 0) {
+            throw new IllegalArgumentException("page must be greater than or equal to 0");
+        }
+        if (size < 1) {
+            throw new IllegalArgumentException("size must be greater than 0");
+        }
+        if (totalElements < 0) {
+            throw new IllegalArgumentException("totalElements must be greater than or equal to 0");
+        }
+    }
+
+    public <R> PagedResult<R> map(Function<T, R> mapper) {
+        Guard.notNull(mapper, "mapper");
+        return new PagedResult<>(content.stream().map(mapper).toList(), page, size, totalElements);
+    }
+}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/list/ListMyTicketsQuery.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/list/ListMyTicketsQuery.java
@@ -1,12 +1,12 @@
 package com.aperdigon.ticketing_backend.application.tickets.list;
 
 import com.aperdigon.ticketing_backend.application.shared.CurrentUser;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PageQuery;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
-import org.springframework.data.domain.Pageable;
 
 public record ListMyTicketsQuery(
         CurrentUser actor,
         TicketStatus status,
         String q,
-        Pageable pageable
+        PageQuery pageQuery
 ) {}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/list/ListMyTicketsUseCase.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/list/ListMyTicketsUseCase.java
@@ -2,8 +2,8 @@ package com.aperdigon.ticketing_backend.application.tickets.list;
 
 import com.aperdigon.ticketing_backend.application.ports.TicketRepository;
 import com.aperdigon.ticketing_backend.domain.shared.validation.Guard;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PagedResult;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
-import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -15,13 +15,13 @@ public final class ListMyTicketsUseCase {
         this.ticketRepository = Guard.notNull(ticketRepository, "ticketRepository");
     }
 
-    public Page<Ticket> execute(ListMyTicketsQuery query) {
+    public PagedResult<Ticket> execute(ListMyTicketsQuery query) {
         Guard.notNull(query, "query");
         return ticketRepository.findMyTickets(
                 query.actor().id(),
                 query.status(),
                 query.q(),
-                query.pageable()
+                query.pageQuery()
         );
     }
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/list/ListTicketsQuery.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/list/ListTicketsQuery.java
@@ -1,13 +1,13 @@
 package com.aperdigon.ticketing_backend.application.tickets.list;
 
 import com.aperdigon.ticketing_backend.application.shared.CurrentUser;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PageQuery;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
-import org.springframework.data.domain.Pageable;
 
 public record ListTicketsQuery(
         CurrentUser actor,
         TicketQueueScope scope,
         TicketStatus status,
         String q,
-        Pageable pageable
+        PageQuery pageQuery
 ) {}

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/list/ListTicketsUseCase.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/list/ListTicketsUseCase.java
@@ -3,8 +3,8 @@ package com.aperdigon.ticketing_backend.application.tickets.list;
 import com.aperdigon.ticketing_backend.application.ports.TicketRepository;
 import com.aperdigon.ticketing_backend.application.shared.exception.ForbiddenException;
 import com.aperdigon.ticketing_backend.domain.shared.validation.Guard;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PagedResult;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
-import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -16,7 +16,7 @@ public final class ListTicketsUseCase {
         this.ticketRepository = Guard.notNull(ticketRepository, "ticketRepository");
     }
 
-    public Page<Ticket> execute(ListTicketsQuery query) {
+    public PagedResult<Ticket> execute(ListTicketsQuery query) {
         Guard.notNull(query, "query");
 
         if (!query.actor().isAgentOrAdmin()) {
@@ -28,7 +28,7 @@ public final class ListTicketsUseCase {
                 query.scope(),
                 query.status(),
                 query.q(),
-                query.pageable()
+                query.pageQuery()
         );
     }
 }

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/adapter/JpaTicketRepository.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/infrastructure/persistence/adapter/JpaTicketRepository.java
@@ -1,6 +1,9 @@
 package com.aperdigon.ticketing_backend.infrastructure.persistence.adapter;
 
 import com.aperdigon.ticketing_backend.application.ports.TicketRepository;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PageDirection;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PageQuery;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PagedResult;
 import com.aperdigon.ticketing_backend.application.tickets.dashboard.AgentTicketCount;
 import com.aperdigon.ticketing_backend.application.tickets.list.TicketQueueScope;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
@@ -15,8 +18,8 @@ import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.TicketSpringDataRepository;
 import com.aperdigon.ticketing_backend.infrastructure.persistence.jpa.repository.UserSpringDataRepository;
 import jakarta.persistence.criteria.Predicate;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -100,7 +103,7 @@ public class JpaTicketRepository implements TicketRepository {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<Ticket> findMyTickets(UserId createdBy, TicketStatus status, String q, Pageable pageable) {
+    public PagedResult<Ticket> findMyTickets(UserId createdBy, TicketStatus status, String q, PageQuery pageQuery) {
         Specification<TicketJpaEntity> spec = (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
             predicates.add(cb.equal(root.get("createdBy").get("id"), createdBy.value()));
@@ -117,12 +120,18 @@ public class JpaTicketRepository implements TicketRepository {
             return cb.and(predicates.toArray(new Predicate[0]));
         };
 
-        return ticketSpringRepo.findAll(spec, pageable).map(TicketMapper::toDomain);
+        var page = ticketSpringRepo.findAll(spec, toPageRequest(pageQuery));
+        return new PagedResult<>(
+                page.getContent().stream().map(TicketMapper::toDomain).toList(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements()
+        );
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Page<Ticket> findAgentTickets(UserId actorId, TicketQueueScope scope, TicketStatus status, String q, Pageable pageable) {
+    public PagedResult<Ticket> findAgentTickets(UserId actorId, TicketQueueScope scope, TicketStatus status, String q, PageQuery pageQuery) {
         Specification<TicketJpaEntity> spec = (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
 
@@ -147,7 +156,18 @@ public class JpaTicketRepository implements TicketRepository {
             return cb.and(predicates.toArray(new Predicate[0]));
         };
 
-        return ticketSpringRepo.findAll(spec, pageable).map(TicketMapper::toDomain);
+        var page = ticketSpringRepo.findAll(spec, toPageRequest(pageQuery));
+        return new PagedResult<>(
+                page.getContent().stream().map(TicketMapper::toDomain).toList(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements()
+        );
+    }
+
+    private static PageRequest toPageRequest(PageQuery pageQuery) {
+        var direction = pageQuery.direction() == PageDirection.ASC ? Sort.Direction.ASC : Sort.Direction.DESC;
+        return PageRequest.of(pageQuery.page(), pageQuery.size(), Sort.by(direction, pageQuery.sortBy()));
     }
 
     @Override

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/architecture/ArchitectureTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/architecture/ArchitectureTest.java
@@ -121,10 +121,10 @@ class ArchitectureTest {
         }
 
         @Test
-        @DisplayName("application must not depend on Spring Data JPA")
-        void applicationMustNotDependOnSpringDataJpa() {
+        @DisplayName("application must not depend on Spring Data")
+        void applicationMustNotDependOnSpringData() {
             noClasses().that().resideInAPackage("..application..")
-                    .should().dependOnClassesThat().resideInAPackage("org.springframework.data.jpa..")
+                    .should().dependOnClassesThat().resideInAPackage("org.springframework.data..")
                     .check(IMPORTED_CLASSES);
         }
 

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/InMemoryTicketRepository.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/test_support/InMemoryTicketRepository.java
@@ -1,6 +1,9 @@
 package com.aperdigon.ticketing_backend.test_support;
 
 import com.aperdigon.ticketing_backend.application.ports.TicketRepository;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PageDirection;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PageQuery;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PagedResult;
 import com.aperdigon.ticketing_backend.application.tickets.dashboard.AgentTicketCount;
 import com.aperdigon.ticketing_backend.application.tickets.list.TicketQueueScope;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
@@ -8,10 +11,6 @@ import com.aperdigon.ticketing_backend.domain.ticket.TicketId;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
 import com.aperdigon.ticketing_backend.domain.user.UserId;
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
-
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -36,25 +35,25 @@ public final class InMemoryTicketRepository implements TicketRepository {
     }
 
     @Override
-    public Page<Ticket> findMyTickets(UserId createdBy, TicketStatus status, String q, Pageable pageable) {
+    public PagedResult<Ticket> findMyTickets(UserId createdBy, TicketStatus status, String q, PageQuery pageQuery) {
         List<Ticket> filtered = sortedTickets()
                 .filter(ticket -> ticket.createdBy().equals(createdBy))
                 .filter(ticket -> status == null || ticket.status() == status)
                 .filter(ticket -> matchesQuery(ticket, q))
                 .toList();
 
-        return toPage(filtered, pageable);
+        return toPage(filtered, pageQuery);
     }
 
     @Override
-    public Page<Ticket> findAgentTickets(UserId actorId, TicketQueueScope scope, TicketStatus status, String q, Pageable pageable) {
+    public PagedResult<Ticket> findAgentTickets(UserId actorId, TicketQueueScope scope, TicketStatus status, String q, PageQuery pageQuery) {
         List<Ticket> filtered = sortedTickets()
                 .filter(ticket -> matchesScope(ticket, actorId, scope))
                 .filter(ticket -> status == null || ticket.status() == status)
                 .filter(ticket -> matchesQuery(ticket, q))
                 .toList();
 
-        return toPage(filtered, pageable);
+        return toPage(filtered, pageQuery);
     }
 
     @Override
@@ -132,17 +131,33 @@ public final class InMemoryTicketRepository implements TicketRepository {
                 || ticket.description().toLowerCase().contains(normalizedQuery);
     }
 
-    private Page<Ticket> toPage(List<Ticket> filtered, Pageable pageable) {
-        if (pageable == null || pageable.isUnpaged()) {
-            return new PageImpl<>(filtered, Pageable.unpaged(), filtered.size());
+    private PagedResult<Ticket> toPage(List<Ticket> filtered, PageQuery pageQuery) {
+        PageQuery effectivePageQuery = pageQuery == null
+                ? PageQuery.of(0, Math.max(filtered.size(), 1), "createdAt", PageDirection.ASC)
+                : pageQuery;
+
+        List<Ticket> sorted = sort(filtered, effectivePageQuery);
+        int start = effectivePageQuery.page() * effectivePageQuery.size();
+        if (start >= sorted.size()) {
+            return new PagedResult<>(List.of(), effectivePageQuery.page(), effectivePageQuery.size(), sorted.size());
         }
 
-        int start = (int) pageable.getOffset();
-        if (start >= filtered.size()) {
-            return new PageImpl<>(List.of(), pageable, filtered.size());
-        }
+        int end = Math.min(start + effectivePageQuery.size(), sorted.size());
+        return new PagedResult<>(sorted.subList(start, end), effectivePageQuery.page(), effectivePageQuery.size(), sorted.size());
+    }
 
-        int end = Math.min(start + pageable.getPageSize(), filtered.size());
-        return new PageImpl<>(filtered.subList(start, end), pageable, filtered.size());
+    private List<Ticket> sort(List<Ticket> tickets, PageQuery pageQuery) {
+        Comparator<Ticket> comparator = switch (pageQuery.sortBy()) {
+            case "updatedAt" -> Comparator.comparing(Ticket::updatedAt);
+            case "createdAt" -> Comparator.comparing(Ticket::createdAt);
+            case "title" -> Comparator.comparing(Ticket::title, String.CASE_INSENSITIVE_ORDER);
+            default -> Comparator.comparing(Ticket::createdAt);
+        };
+
+        comparator = comparator.thenComparing(ticket -> ticket.id().value());
+        if (pageQuery.direction() == PageDirection.DESC) {
+            comparator = comparator.reversed();
+        }
+        return tickets.stream().sorted(comparator).toList();
     }
 }

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/admin/CreateCategoryUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/admin/CreateCategoryUseCaseTest.java
@@ -1,0 +1,36 @@
+package com.aperdigon.ticketing_backend.unit.admin;
+
+import com.aperdigon.ticketing_backend.application.admin.categories.create.CreateCategoryCommand;
+import com.aperdigon.ticketing_backend.application.admin.categories.create.CreateCategoryUseCase;
+import com.aperdigon.ticketing_backend.domain.shared.exception.InvalidArgumentException;
+import com.aperdigon.ticketing_backend.test_support.DomainTestDataFactory;
+import com.aperdigon.ticketing_backend.test_support.InMemoryCategoryRepository;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class CreateCategoryUseCaseTest {
+
+    @Test
+    void creates_active_category_with_trimmed_name() {
+        var repository = new InMemoryCategoryRepository();
+        var useCase = new CreateCategoryUseCase(repository);
+
+        var category = useCase.execute(new CreateCategoryCommand("  Hardware  "));
+
+        assertEquals("Hardware", category.name());
+        assertTrue(category.isActive());
+        assertEquals(category, repository.findById(category.id()).orElseThrow());
+    }
+
+    @Test
+    void rejects_duplicate_category_name_case_insensitively() {
+        var repository = new InMemoryCategoryRepository();
+        repository.put(DomainTestDataFactory.activeCategory("Hardware"));
+        var useCase = new CreateCategoryUseCase(repository);
+
+        assertThrows(InvalidArgumentException.class, () -> useCase.execute(new CreateCategoryCommand(" hardware ")));
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/admin/ListAdminCategoriesUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/admin/ListAdminCategoriesUseCaseTest.java
@@ -1,0 +1,31 @@
+package com.aperdigon.ticketing_backend.unit.admin;
+
+import com.aperdigon.ticketing_backend.application.admin.categories.list.ListAdminCategoriesUseCase;
+import com.aperdigon.ticketing_backend.domain.category.Category;
+import com.aperdigon.ticketing_backend.domain.category.CategoryId;
+import com.aperdigon.ticketing_backend.test_support.DomainTestDataFactory;
+import com.aperdigon.ticketing_backend.test_support.InMemoryCategoryRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class ListAdminCategoriesUseCaseTest {
+
+    @Test
+    void lists_active_and_inactive_categories_sorted_by_name() {
+        var repository = new InMemoryCategoryRepository();
+        var zeta = DomainTestDataFactory.activeCategory("Zeta");
+        var alphaInactive = new Category(CategoryId.of(UUID.randomUUID()), "Alpha", false);
+        repository.put(zeta);
+        repository.put(alphaInactive);
+        var useCase = new ListAdminCategoriesUseCase(repository);
+
+        var result = useCase.execute();
+
+        assertEquals(2, result.size());
+        assertEquals(alphaInactive.id(), result.get(0).id());
+        assertEquals(zeta.id(), result.get(1).id());
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/admin/ListAdminUsersUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/admin/ListAdminUsersUseCaseTest.java
@@ -1,0 +1,28 @@
+package com.aperdigon.ticketing_backend.unit.admin;
+
+import com.aperdigon.ticketing_backend.application.admin.users.list.ListAdminUsersUseCase;
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import com.aperdigon.ticketing_backend.test_support.DomainTestDataFactory;
+import com.aperdigon.ticketing_backend.test_support.InMemoryUserRepository;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class ListAdminUsersUseCaseTest {
+
+    @Test
+    void lists_users_sorted_by_display_name_including_inactive_users() {
+        var repository = new InMemoryUserRepository();
+        var zed = DomainTestDataFactory.activeUser("zed@test.com", "Zed", UserRole.AGENT);
+        var amy = DomainTestDataFactory.inactiveUser("amy@test.com", "Amy", UserRole.USER);
+        repository.put(zed);
+        repository.put(amy);
+        var useCase = new ListAdminUsersUseCase(repository);
+
+        var result = useCase.execute();
+
+        assertEquals(2, result.size());
+        assertEquals(amy.id(), result.get(0).id());
+        assertEquals(zed.id(), result.get(1).id());
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/admin/UpdateCategoryUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/admin/UpdateCategoryUseCaseTest.java
@@ -1,0 +1,44 @@
+package com.aperdigon.ticketing_backend.unit.admin;
+
+import com.aperdigon.ticketing_backend.application.admin.categories.update.UpdateCategoryCommand;
+import com.aperdigon.ticketing_backend.application.admin.categories.update.UpdateCategoryUseCase;
+import com.aperdigon.ticketing_backend.application.shared.exception.NotFoundException;
+import com.aperdigon.ticketing_backend.domain.category.CategoryId;
+import com.aperdigon.ticketing_backend.test_support.DomainTestDataFactory;
+import com.aperdigon.ticketing_backend.test_support.InMemoryCategoryRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class UpdateCategoryUseCaseTest {
+
+    @Test
+    void updates_category_name_and_active_flag() {
+        var repository = new InMemoryCategoryRepository();
+        var existing = DomainTestDataFactory.activeCategory("Hardware");
+        repository.put(existing);
+        var useCase = new UpdateCategoryUseCase(repository);
+
+        var updated = useCase.execute(new UpdateCategoryCommand(existing.id(), "  Devices  ", false));
+
+        assertEquals(existing.id(), updated.id());
+        assertEquals("Devices", updated.name());
+        assertFalse(updated.isActive());
+        assertEquals(updated, repository.findById(existing.id()).orElseThrow());
+    }
+
+    @Test
+    void rejects_missing_category() {
+        var useCase = new UpdateCategoryUseCase(new InMemoryCategoryRepository());
+
+        assertThrows(NotFoundException.class, () -> useCase.execute(new UpdateCategoryCommand(
+                CategoryId.of(UUID.randomUUID()),
+                "Hardware",
+                true
+        )));
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/admin/UpdateUserActiveUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/admin/UpdateUserActiveUseCaseTest.java
@@ -1,0 +1,45 @@
+package com.aperdigon.ticketing_backend.unit.admin;
+
+import com.aperdigon.ticketing_backend.application.admin.users.update_active.UpdateUserActiveCommand;
+import com.aperdigon.ticketing_backend.application.admin.users.update_active.UpdateUserActiveUseCase;
+import com.aperdigon.ticketing_backend.application.shared.exception.NotFoundException;
+import com.aperdigon.ticketing_backend.domain.user.UserId;
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import com.aperdigon.ticketing_backend.test_support.DomainTestDataFactory;
+import com.aperdigon.ticketing_backend.test_support.InMemoryUserRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class UpdateUserActiveUseCaseTest {
+
+    @Test
+    void updates_active_flag_without_changing_identity_or_role() {
+        var repository = new InMemoryUserRepository();
+        var user = DomainTestDataFactory.activeUser("agent@test.com", "Agent", UserRole.AGENT);
+        repository.put(user);
+        var useCase = new UpdateUserActiveUseCase(repository);
+
+        var updated = useCase.execute(new UpdateUserActiveCommand(user.id(), false));
+
+        assertEquals(user.id(), updated.id());
+        assertEquals(user.email(), updated.email());
+        assertEquals(user.displayName(), updated.displayName());
+        assertEquals(user.role(), updated.role());
+        assertFalse(updated.isActive());
+    }
+
+    @Test
+    void rejects_missing_user() {
+        var useCase = new UpdateUserActiveUseCase(new InMemoryUserRepository());
+
+        assertThrows(NotFoundException.class, () -> useCase.execute(new UpdateUserActiveCommand(
+                UserId.of(UUID.randomUUID()),
+                false
+        )));
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/categories/ListActiveCategoriesUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/categories/ListActiveCategoriesUseCaseTest.java
@@ -1,0 +1,32 @@
+package com.aperdigon.ticketing_backend.unit.categories;
+
+import com.aperdigon.ticketing_backend.application.categories.list.ListActiveCategoriesUseCase;
+import com.aperdigon.ticketing_backend.domain.category.Category;
+import com.aperdigon.ticketing_backend.domain.category.CategoryId;
+import com.aperdigon.ticketing_backend.test_support.DomainTestDataFactory;
+import com.aperdigon.ticketing_backend.test_support.InMemoryCategoryRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class ListActiveCategoriesUseCaseTest {
+
+    @Test
+    void lists_only_active_categories_sorted_by_name() {
+        var repository = new InMemoryCategoryRepository();
+        var zeta = DomainTestDataFactory.activeCategory("Zeta");
+        var alpha = DomainTestDataFactory.activeCategory("Alpha");
+        repository.put(zeta);
+        repository.put(new Category(CategoryId.of(UUID.randomUUID()), "Inactive", false));
+        repository.put(alpha);
+        var useCase = new ListActiveCategoriesUseCase(repository);
+
+        var result = useCase.execute();
+
+        assertEquals(2, result.size());
+        assertEquals(alpha.id(), result.get(0).id());
+        assertEquals(zeta.id(), result.get(1).id());
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/GetDashboardStatsUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/GetDashboardStatsUseCaseTest.java
@@ -3,6 +3,8 @@ package com.aperdigon.ticketing_backend.unit.ticket;
 import com.aperdigon.ticketing_backend.application.ports.TicketRepository;
 import com.aperdigon.ticketing_backend.application.shared.CurrentUser;
 import com.aperdigon.ticketing_backend.application.shared.exception.ForbiddenException;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PageQuery;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PagedResult;
 import com.aperdigon.ticketing_backend.application.tickets.dashboard.AgentTicketCount;
 import com.aperdigon.ticketing_backend.application.tickets.dashboard.GetDashboardStatsUseCase;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
@@ -11,8 +13,6 @@ import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
 import com.aperdigon.ticketing_backend.domain.user.UserId;
 import com.aperdigon.ticketing_backend.domain.user.UserRole;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -108,12 +108,12 @@ public final class GetDashboardStatsUseCaseTest {
         }
 
         @Override
-        public Page<Ticket> findMyTickets(UserId createdBy, TicketStatus status, String q, Pageable pageable) {
+        public PagedResult<Ticket> findMyTickets(UserId createdBy, TicketStatus status, String q, PageQuery pageQuery) {
             throw new UnsupportedOperationException("Not needed in this test");
         }
 
         @Override
-        public Page<Ticket> findAgentTickets(UserId actorId, com.aperdigon.ticketing_backend.application.tickets.list.TicketQueueScope scope, TicketStatus status, String q, Pageable pageable) {
+        public PagedResult<Ticket> findAgentTickets(UserId actorId, com.aperdigon.ticketing_backend.application.tickets.list.TicketQueueScope scope, TicketStatus status, String q, PageQuery pageQuery) {
             throw new UnsupportedOperationException("Not needed in this test");
         }
 

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/GetTicketDetailUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/GetTicketDetailUseCaseTest.java
@@ -1,0 +1,78 @@
+package com.aperdigon.ticketing_backend.unit.ticket;
+
+import com.aperdigon.ticketing_backend.application.shared.CurrentUser;
+import com.aperdigon.ticketing_backend.application.shared.exception.ForbiddenException;
+import com.aperdigon.ticketing_backend.application.tickets.detail.GetTicketDetailUseCase;
+import com.aperdigon.ticketing_backend.application.tickets.get.GetTicketUseCase;
+import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEvent;
+import com.aperdigon.ticketing_backend.domain.ticket_event.TicketEventType;
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import com.aperdigon.ticketing_backend.test_support.DomainTestDataFactory;
+import com.aperdigon.ticketing_backend.test_support.InMemoryTicketEventRepository;
+import com.aperdigon.ticketing_backend.test_support.InMemoryTicketRepository;
+import com.aperdigon.ticketing_backend.test_support.InMemoryUserRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class GetTicketDetailUseCaseTest {
+
+    @Test
+    void returns_ticket_events_and_display_names_for_related_users() {
+        Clock clock = Clock.fixed(Instant.parse("2026-04-01T09:00:00Z"), ZoneOffset.UTC);
+        var ticketRepository = new InMemoryTicketRepository();
+        var eventRepository = new InMemoryTicketEventRepository();
+        var userRepository = new InMemoryUserRepository();
+
+        var creator = DomainTestDataFactory.activeUser("creator@test.com", "Creator", UserRole.USER);
+        var agent = DomainTestDataFactory.activeUser("agent@test.com", "Agent", UserRole.AGENT);
+        var category = DomainTestDataFactory.activeCategory("General");
+        var ticket = DomainTestDataFactory.openTicket("Printer", "Printer is offline", category, creator, clock);
+        ticket.assignTo(agent.id(), clock);
+        ticket.addComment("I am checking it", agent.id(), clock);
+        ticketRepository.save(ticket);
+        userRepository.put(creator);
+        userRepository.put(agent);
+        var event = new TicketEvent(
+                UUID.randomUUID(),
+                ticket.id(),
+                TicketEventType.ASSIGNED_TO_ME,
+                agent.id(),
+                Map.of(),
+                Instant.parse("2026-04-01T09:00:00Z")
+        );
+        eventRepository.save(event);
+        var useCase = new GetTicketDetailUseCase(new GetTicketUseCase(ticketRepository), eventRepository, userRepository);
+
+        var result = useCase.execute(ticket.id(), new CurrentUser(creator.id(), creator.role()));
+
+        assertEquals(ticket.id(), result.ticket().id());
+        assertEquals(1, result.events().size());
+        assertEquals(event, result.events().get(0));
+        assertEquals("Creator", result.resolveUserDisplayName(creator.id().value()));
+        assertEquals("Agent", result.resolveUserDisplayName(agent.id().value()));
+    }
+
+    @Test
+    void preserves_get_ticket_access_rules_for_non_owner_users() {
+        Clock clock = Clock.fixed(Instant.parse("2026-04-01T09:00:00Z"), ZoneOffset.UTC);
+        var ticketRepository = new InMemoryTicketRepository();
+        var eventRepository = new InMemoryTicketEventRepository();
+        var userRepository = new InMemoryUserRepository();
+        var creator = DomainTestDataFactory.activeUser("creator@test.com", "Creator", UserRole.USER);
+        var otherUser = DomainTestDataFactory.activeUser("other@test.com", "Other", UserRole.USER);
+        var category = DomainTestDataFactory.activeCategory("General");
+        var ticket = DomainTestDataFactory.openTicket("Printer", "Printer is offline", category, creator, clock);
+        ticketRepository.save(ticket);
+        var useCase = new GetTicketDetailUseCase(new GetTicketUseCase(ticketRepository), eventRepository, userRepository);
+
+        assertThrows(ForbiddenException.class, () -> useCase.execute(ticket.id(), new CurrentUser(otherUser.id(), otherUser.role())));
+    }
+}

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/ListMyTicketsUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/ListMyTicketsUseCaseTest.java
@@ -1,6 +1,8 @@
 package com.aperdigon.ticketing_backend.unit.ticket;
 
 import com.aperdigon.ticketing_backend.application.shared.CurrentUser;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PageDirection;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PageQuery;
 import com.aperdigon.ticketing_backend.application.tickets.list.ListMyTicketsQuery;
 import com.aperdigon.ticketing_backend.application.tickets.list.ListMyTicketsUseCase;
 import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/ListMyTicketsUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/ListMyTicketsUseCaseTest.java
@@ -10,7 +10,6 @@ import com.aperdigon.ticketing_backend.specification.TestLevel;
 import com.aperdigon.ticketing_backend.test_support.DomainTestDataFactory;
 import com.aperdigon.ticketing_backend.test_support.InMemoryTicketRepository;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.domain.PageRequest;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -44,10 +43,10 @@ final class ListMyTicketsUseCaseTest {
                 new CurrentUser(actor.id(), actor.role()),
                 TicketStatus.OPEN,
                 "printer",
-                PageRequest.of(0, 10)
+                PageQuery.of(0, 10, "createdAt", PageDirection.ASC)
         ));
 
-        assertEquals(1, result.getTotalElements());
-        assertEquals(matchingTicket.id(), result.getContent().get(0).id());
+        assertEquals(1, result.totalElements());
+        assertEquals(matchingTicket.id(), result.content().get(0).id());
     }
 }

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/ListTicketsUseCaseTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/ListTicketsUseCaseTest.java
@@ -2,6 +2,8 @@ package com.aperdigon.ticketing_backend.unit.ticket;
 
 import com.aperdigon.ticketing_backend.application.shared.CurrentUser;
 import com.aperdigon.ticketing_backend.application.shared.exception.ForbiddenException;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PageDirection;
+import com.aperdigon.ticketing_backend.application.shared.pagination.PageQuery;
 import com.aperdigon.ticketing_backend.application.tickets.list.ListTicketsQuery;
 import com.aperdigon.ticketing_backend.application.tickets.list.ListTicketsUseCase;
 import com.aperdigon.ticketing_backend.application.tickets.list.TicketQueueScope;
@@ -12,7 +14,6 @@ import com.aperdigon.ticketing_backend.specification.TestLevel;
 import com.aperdigon.ticketing_backend.test_support.DomainTestDataFactory;
 import com.aperdigon.ticketing_backend.test_support.InMemoryTicketRepository;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.domain.PageRequest;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -54,11 +55,11 @@ final class ListTicketsUseCaseTest {
                 TicketQueueScope.MINE,
                 TicketStatus.IN_PROGRESS,
                 "printer",
-                PageRequest.of(0, 10)
+                PageQuery.of(0, 10, "createdAt", PageDirection.ASC)
         ));
 
-        assertEquals(1, result.getTotalElements());
-        assertEquals(myAssignedTicket.id(), result.getContent().get(0).id());
+        assertEquals(1, result.totalElements());
+        assertEquals(myAssignedTicket.id(), result.content().get(0).id());
     }
 
     @Test
@@ -70,7 +71,7 @@ final class ListTicketsUseCaseTest {
                 TicketQueueScope.ALL,
                 null,
                 null,
-                PageRequest.of(0, 10)
+                PageQuery.of(0, 10, "createdAt", PageDirection.ASC)
         )));
     }
 }

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/TicketDomainBehaviorTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/ticket/TicketDomainBehaviorTest.java
@@ -1,0 +1,96 @@
+package com.aperdigon.ticketing_backend.unit.ticket;
+
+import com.aperdigon.ticketing_backend.domain.shared.exception.InvalidArgumentException;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketPriority;
+import com.aperdigon.ticketing_backend.domain.ticket.TicketStatus;
+import com.aperdigon.ticketing_backend.domain.ticket.exceptions.TicketAlreadyResolved;
+import com.aperdigon.ticketing_backend.domain.user.UserRole;
+import com.aperdigon.ticketing_backend.test_support.DomainTestDataFactory;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class TicketDomainBehaviorTest {
+
+    private final Clock clock = Clock.fixed(Instant.parse("2026-04-01T09:00:00Z"), ZoneOffset.UTC);
+
+    @Test
+    void open_new_ticket_sets_initial_state_and_defaults() {
+        var category = DomainTestDataFactory.activeCategory("General");
+        var creator = DomainTestDataFactory.activeUser("user@test.com", "User", UserRole.USER);
+
+        var ticket = DomainTestDataFactory.openTicket("Printer", "Printer is offline", category, creator, clock);
+
+        assertNotNull(ticket.id());
+        assertEquals("Printer", ticket.title());
+        assertEquals("Printer is offline", ticket.description());
+        assertEquals(category.id(), ticket.categoryId());
+        assertEquals(creator.id(), ticket.createdBy());
+        assertEquals(TicketStatus.OPEN, ticket.status());
+        assertEquals(TicketPriority.MEDIUM, ticket.priority());
+        assertEquals(Instant.parse("2026-04-01T09:00:00Z"), ticket.createdAt());
+        assertEquals(ticket.createdAt(), ticket.updatedAt());
+        assertEquals(0, ticket.comments().size());
+    }
+
+    @Test
+    void add_comment_records_author_timestamp_and_updates_ticket() {
+        var category = DomainTestDataFactory.activeCategory("General");
+        var creator = DomainTestDataFactory.activeUser("user@test.com", "User", UserRole.USER);
+        var ticket = DomainTestDataFactory.openTicket("Printer", "Printer is offline", category, creator, clock);
+
+        var comment = ticket.addComment("I can reproduce it", creator.id(), clock);
+
+        assertNotNull(comment.id());
+        assertEquals("I can reproduce it", comment.content());
+        assertEquals(creator.id(), comment.authorId());
+        assertEquals(Instant.parse("2026-04-01T09:00:00Z"), comment.createdAt());
+        assertEquals(1, ticket.comments().size());
+        assertEquals(comment, ticket.comments().get(0));
+        assertEquals(Instant.parse("2026-04-01T09:00:00Z"), ticket.updatedAt());
+    }
+
+    @Test
+    void add_comment_rejects_blank_content_and_null_author() {
+        var category = DomainTestDataFactory.activeCategory("General");
+        var creator = DomainTestDataFactory.activeUser("user@test.com", "User", UserRole.USER);
+        var ticket = DomainTestDataFactory.openTicket("Printer", "Printer is offline", category, creator, clock);
+
+        assertThrows(InvalidArgumentException.class, () -> ticket.addComment("  ", creator.id(), clock));
+        assertThrows(InvalidArgumentException.class, () -> ticket.addComment("valid", null, clock));
+        assertTrue(ticket.comments().isEmpty());
+    }
+
+    @Test
+    void assign_to_agent_id_updates_assignee_and_updated_at() {
+        var category = DomainTestDataFactory.activeCategory("General");
+        var creator = DomainTestDataFactory.activeUser("user@test.com", "User", UserRole.USER);
+        var agent = DomainTestDataFactory.activeUser("agent@test.com", "Agent", UserRole.AGENT);
+        var ticket = DomainTestDataFactory.openTicket("Printer", "Printer is offline", category, creator, clock);
+        var assignmentClock = Clock.fixed(Instant.parse("2026-04-01T10:00:00Z"), ZoneOffset.UTC);
+
+        ticket.assignTo(agent.id(), assignmentClock);
+
+        assertEquals(agent.id(), ticket.assignedTo());
+        assertEquals(Instant.parse("2026-04-01T10:00:00Z"), ticket.updatedAt());
+    }
+
+    @Test
+    void resolved_ticket_is_terminal() {
+        var category = DomainTestDataFactory.activeCategory("General");
+        var creator = DomainTestDataFactory.activeUser("user@test.com", "User", UserRole.USER);
+        var ticket = DomainTestDataFactory.openTicket("Printer", "Printer is offline", category, creator, clock);
+        ticket.changeStatus(TicketStatus.IN_PROGRESS, clock);
+        ticket.changeStatus(TicketStatus.RESOLVED, clock);
+
+        assertThrows(TicketAlreadyResolved.class, () -> ticket.changeStatus(TicketStatus.IN_PROGRESS, clock));
+        assertEquals(TicketStatus.RESOLVED, ticket.status());
+    }
+}


### PR DESCRIPTION

### Description

- Added `PageQuery`, `PagedResult`, and `PageDirection` records/enums under `application.shared.pagination` and validation logic in their constructors. 
- Replaced usages of Spring `Page`/`Pageable` in the application API and ports with `PagedResult<T>` and `PageQuery` respectively, including `TicketRepository` interface and use case signatures. 
- Updated `PageResponse` to build responses from `PagedResult` and changed controllers to construct `PageQuery` (moved sorting/direction out of Spring types). 
- Implemented conversion in the JPA adapter (`JpaTicketRepository`) to translate `PageQuery` to Spring `PageRequest` and adapted repository methods to return `PagedResult` by mapping `TicketJpaEntity` results to domain objects. 
- Updated the in-memory test repository to support sorting and paging via `PageQuery` and added a deterministic `sort` helper for supported sort keys. 
- Modified the architecture test to assert no dependency on `org.springframework.data..` instead of only JPA subpackage, and added multiple unit tests for admin flows, ticket listing/detail behavior and domain behaviors.
