### PR TITLE
Demo: revisar permisos de cambio de estado de tickets

### DIFF
--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/change_status/ChangeTicketStatusUseCase.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/application/tickets/change_status/ChangeTicketStatusUseCase.java
@@ -2,7 +2,6 @@ package com.aperdigon.ticketing_backend.application.tickets.change_status;
 
 import com.aperdigon.ticketing_backend.application.ports.TicketRepository;
 import com.aperdigon.ticketing_backend.application.ports.TicketEventRepository;
-import com.aperdigon.ticketing_backend.application.shared.exception.ForbiddenException;
 import com.aperdigon.ticketing_backend.application.shared.exception.NotFoundException;
 import com.aperdigon.ticketing_backend.domain.shared.validation.Guard;
 import com.aperdigon.ticketing_backend.domain.ticket.Ticket;
@@ -30,10 +29,6 @@ public final class ChangeTicketStatusUseCase {
 
     public ChangeTicketStatusResult execute(ChangeTicketStatusCommand command) {
         Guard.notNull(command, "command");
-
-        if (!command.actor().isAgentOrAdmin()) {
-            throw new ForbiddenException("Only AGENT/ADMIN can change ticket status");
-        }
 
         Ticket ticket = ticketRepository.findById(command.ticketId())
                 .orElseThrow(() -> new NotFoundException("Ticket not found: " + command.ticketId().value()));


### PR DESCRIPTION
Refs #120

## Resumen

Esta PR simula una contribucion en la que se revisa el flujo de cambio de estado de tickets.

## Intencion de la demo

El cambio introduce una regresion: el caso de uso deja de bloquear usuarios sin rol operativo antes de buscar el ticket.

## Valor DevOps que muestra

La CI debe bloquear la PR porque una prueba existente detecta que un usuario normal podria avanzar hacia una operacion no permitida.

## Check esperado

- Falla `backend-unit-and-architecture-fitness`.
- Test clave: `ChangeTicketStatusUseCaseTest.user_cannot_change_status`.