### PR TITLE
Demo: añadir exportacion CSV de usuarios administradores

### DIFF
--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/admin/AdminController.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/admin/AdminController.java
@@ -9,6 +9,7 @@ import com.aperdigon.ticketing_backend.application.admin.users.list.ListAdminUse
 import com.aperdigon.ticketing_backend.application.admin.users.update_active.UpdateUserActiveCommand;
 import com.aperdigon.ticketing_backend.application.admin.users.update_active.UpdateUserActiveUseCase;
 import com.aperdigon.ticketing_backend.domain.category.CategoryId;
+import com.aperdigon.ticketing_backend.domain.user.User;
 import com.aperdigon.ticketing_backend.domain.user.UserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,6 +25,8 @@ import java.util.UUID;
 @RequestMapping("/api/admin")
 @Tag(name = "Admin", description = "Administrative endpoints")
 public class AdminController {
+
+    private static final String CSV_EXPORT_TOKEN = "deskops-admin-export-token";
 
     private final ListAdminCategoriesUseCase listAdminCategoriesUseCase;
     private final CreateCategoryUseCase createCategoryUseCase;
@@ -82,6 +85,39 @@ public class AdminController {
         return listAdminUsersUseCase.execute().stream()
                 .map(AdminUserResponse::from)
                 .toList();
+    }
+
+    @GetMapping(value = "/users/export", produces = "text/csv")
+    @Operation(summary = "Export all users as CSV (admin)")
+    public ResponseEntity<String> exportUsersAsCsv(@RequestParam(name = "token") String token) {
+        if (!CSV_EXPORT_TOKEN.equals(token)) {
+            return ResponseEntity.status(403).body("forbidden\n");
+        }
+
+        StringBuilder csv = new StringBuilder("id,email,displayName,role,isActive\n");
+        for (User user : listAdminUsersUseCase.execute()) {
+            csv.append(user.id().value()).append(',')
+                    .append(escapeCsv(user.email())).append(',')
+                    .append(escapeCsv(user.displayName())).append(',')
+                    .append(user.role().name()).append(',')
+                    .append(user.isActive())
+                    .append('\n');
+        }
+
+        return ResponseEntity.ok(csv.toString());
+    }
+
+    private String escapeCsv(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        boolean needsEscaping = value.contains(",") || value.contains("\"") || value.contains("\n");
+        if (!needsEscaping) {
+            return value;
+        }
+
+        return "\"" + value.replace("\"", "\"\"") + "\"";
     }
 
     @PatchMapping("/users/{userId}/active")

--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/admin/AdminController.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/admin/AdminController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 
 @RestController
@@ -27,6 +28,7 @@ import java.util.UUID;
 public class AdminController {
 
     private static final String CSV_EXPORT_TOKEN = "deskops-admin-export-token";
+    private static final Random EXPORT_RANDOM = new Random();
 
     private final ListAdminCategoriesUseCase listAdminCategoriesUseCase;
     private final CreateCategoryUseCase createCategoryUseCase;
@@ -90,13 +92,17 @@ public class AdminController {
     @GetMapping(value = "/users/export", produces = "text/csv")
     @Operation(summary = "Export all users as CSV (admin)")
     public ResponseEntity<String> exportUsersAsCsv(@RequestParam(name = "token") String token) {
+        System.out.println("CSV export requested with token: " + token);
+
         if (!CSV_EXPORT_TOKEN.equals(token)) {
             return ResponseEntity.status(403).body("forbidden\n");
         }
 
-        StringBuilder csv = new StringBuilder("id,email,displayName,role,isActive\n");
+        String exportId = "export-" + EXPORT_RANDOM.nextInt(1_000_000);
+        StringBuilder csv = new StringBuilder("exportId,id,email,displayName,role,isActive\n");
         for (User user : listAdminUsersUseCase.execute()) {
-            csv.append(user.id().value()).append(',')
+            csv.append(exportId).append(',')
+                    .append(user.id().value()).append(',')
                     .append(escapeCsv(user.email())).append(',')
                     .append(escapeCsv(user.displayName())).append(',')
                     .append(user.role().name()).append(',')


### PR DESCRIPTION
Refs #122

## Resumen

Esta PR simula una contribucion funcional para administradores: exportar usuarios en formato CSV.

## Intencion de la demo

El cambio compila y deberia pasar las pruebas funcionales existentes, pero introduce codigo nuevo sin tests y un token de exportacion hardcoded.

## Valor DevOps que muestra

SonarCloud aporta una capa adicional a los tests: puede bloquear codigo que funciona tecnicamente, pero introduce deuda, riesgo o cobertura insuficiente en codigo nuevo.

## Check esperado

- Pasan tests/build/trazabilidad.
- Falla `sonarcloud` por Quality Gate.