### PR TITLE
Demo: exponer metadatos en el endpoint de health

### DIFF
--- a/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/controller/health/HealthController.java
+++ b/ticketing-backend/src/main/java/com/aperdigon/ticketing_backend/api/controller/health/HealthController.java
@@ -11,7 +11,9 @@ public final class HealthController {
 
     @GetMapping("/api/health")
     @Operation(summary = "Health check")
-    public String health() {
-        return "ok";
+    public HealthResponse health() {
+        return new HealthResponse("ok", "deskops-api", "2026.06-demo");
     }
+
+    public record HealthResponse(String status, String service, String version) {}
 }

--- a/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/health/HealthControllerTest.java
+++ b/ticketing-backend/src/test/java/com/aperdigon/ticketing_backend/unit/health/HealthControllerTest.java
@@ -1,0 +1,18 @@
+package com.aperdigon.ticketing_backend.unit.health;
+
+import com.aperdigon.ticketing_backend.api.controller.health.HealthController;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class HealthControllerTest {
+
+    @Test
+    void health_returns_basic_service_metadata() {
+        var response = new HealthController().health();
+
+        assertEquals("ok", response.status());
+        assertEquals("deskops-api", response.service());
+        assertEquals("2026.06-demo", response.version());
+    }
+}


### PR DESCRIPTION
Refs #124

## Resumen

Esta PR cambia `/api/health` para devolver metadatos basicos del servicio en JSON.

Respuesta esperada:

```json
{
  "status": "ok",
  "service": "deskops-api",
  "version": "2026.06-demo"
}
```

## Validacion

- Añade una prueba unitaria de `HealthController`.
- Es un cambio pequeño, util y preparado para merge.

## Valor DevOps que muestra

Cuando la PR pasa todos los checks, puede hacerse merge con confianza. Despues, la CI sobre `main` permite activar el workflow de CD.